### PR TITLE
fix: make current_apy time-weighted

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -392,6 +392,7 @@ impl SingleRWAVault {
             panic_with_error!(e, Error::FundingTargetNotMet);
         }
         put_vault_state(e, VaultState::Active);
+        put_activation_timestamp(e, e.ledger().timestamp());
         emit_vault_state_changed(e, VaultState::Funding, VaultState::Active);
         bump_instance(e);
     }
@@ -628,13 +629,37 @@ impl SingleRWAVault {
     pub fn asset(e: &Env) -> Address { get_asset(e) }
 
     pub fn current_apy(e: &Env) -> u32 {
-        let epoch = get_current_epoch(e);
         let ta = total_assets(e);
-        if epoch == 0 || ta == 0 {
+        let activation_ts = get_activation_timestamp(e);
+        if activation_ts == 0 || ta == 0 {
+            return get_expected_apy(e);
+        }
+        let now = e.ledger().timestamp();
+        let elapsed = now.saturating_sub(activation_ts);
+        if elapsed == 0 {
             return get_expected_apy(e);
         }
         let ytd = get_total_yield_distributed(e);
-        ((ytd * 10000) / ta) as u32
+        if ytd == 0 {
+            return get_expected_apy(e);
+        }
+        const SECONDS_PER_YEAR: u64 = 31_536_000;
+        let numerator = (ytd as i128)
+            .checked_mul(SECONDS_PER_YEAR as i128)
+            .and_then(|v| v.checked_mul(10000))
+            .unwrap_or(i128::MAX);
+        let denominator = (ta as i128)
+            .checked_mul(elapsed as i128)
+            .unwrap_or(i128::MAX);
+        if denominator == 0 || denominator == i128::MAX {
+            return get_expected_apy(e);
+        }
+        let apy = numerator / denominator;
+        if apy > u32::MAX as i128 {
+            u32::MAX
+        } else {
+            apy as u32
+        }
     }
 
     pub fn expected_apy(e: &Env) -> u32 { get_expected_apy(e) }

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -66,6 +66,7 @@ pub enum DataKey {
     // --- Vault state ---
     VaultState,
     Paused,
+    ActivationTimestamp,
 
     // --- Epoch / yield ---
     CurrentEpoch,
@@ -183,6 +184,18 @@ instance_get!(get_vault_state, VaultState, VaultState);
 instance_put!(put_vault_state, VaultState, VaultState);
 instance_get!(get_paused, Paused, bool);
 instance_put!(put_paused, Paused, bool);
+
+pub fn get_activation_timestamp(e: &Env) -> u64 {
+    e.storage()
+        .instance()
+        .get(&DataKey::ActivationTimestamp)
+        .unwrap_or(0)
+}
+pub fn put_activation_timestamp(e: &Env, val: u64) {
+    e.storage()
+        .instance()
+        .set(&DataKey::ActivationTimestamp, &val);
+}
 
 // Epoch / yield (global)
 instance_get!(get_current_epoch,           CurrentEpoch,           u32);


### PR DESCRIPTION
- Store activation_timestamp when transitioning vault to Active state
- Calculate APY using formula: (yield / assets) * (seconds_per_year / elapsed_seconds) * 10000
- Handle edge cases: zero elapsed time, zero assets, zero yield
- Use checked arithmetic to prevent overflow on intermediate values

Closes #28 