### PR TITLE
refactor(factory): remove dead VaultConstructorClient code (#25)

### DIFF
--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -19,37 +19,6 @@ use crate::events::*;
 use single_rwa_vault;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Cross-contract client for the SingleRWA_Vault constructor call
-// ─────────────────────────────────────────────────────────────────────────────
-
-use soroban_sdk::contractclient;
-
-#[contractclient(name = "VaultConstructorClient")]
-pub trait VaultConstructorInterface {
-    #[allow(clippy::too_many_arguments)]
-    fn __constructor(
-        env: Env,
-        asset: Address,
-        share_name: String,
-        share_symbol: String,
-        share_decimals: u32,
-        admin: Address,
-        zkme_verifier: Address,
-        cooperator: Address,
-        funding_target: i128,
-        maturity_date: u64,
-        min_deposit: i128,
-        max_deposit_per_user: i128,
-        early_redemption_fee_bps: u32,
-        rwa_name: String,
-        rwa_symbol: String,
-        rwa_document_uri: String,
-        rwa_category: String,
-        expected_apy: u32,
-    );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Contract
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Remove the unused VaultConstructorInterface trait and the VaultConstructorClient generated by #[contractclient]. Vault deployment uses deploy_v2 with InitParams directly — the cross-contract client stub was never called. The single_rwa_vault import is retained as it is needed for InitParams.

Closes #25