### PR TITLE
feat: #30 Add Vault Decommissioning / Removal from Factory Registry

### DIFF
--- a/soroban-contracts/contracts/vault_factory/src/errors.rs
+++ b/soroban-contracts/contracts/vault_factory/src/errors.rs
@@ -8,4 +8,6 @@ pub enum Error {
     VaultAlreadyExists = 1,
     VaultNotFound      = 2,
     NotAuthorized      = 3,
+    /// Vault must be set inactive before it can be removed.
+    VaultIsActive      = 4,
 }

--- a/soroban-contracts/contracts/vault_factory/src/events.rs
+++ b/soroban-contracts/contracts/vault_factory/src/events.rs
@@ -49,3 +49,11 @@ pub fn emit_defaults_updated(
         (asset, zkme_verifier, cooperator),
     );
 }
+
+/// Emitted when an inactive vault is removed from the factory registry.
+pub fn emit_vault_removed(e: &Env, vault: Address, removed_by: Address) {
+    e.events().publish(
+        (symbol_short!("v_remove"), vault),
+        removed_by,
+    );
+}

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -6,6 +6,9 @@ mod types;
 mod events;
 mod errors;
 
+#[cfg(test)]
+mod tests;
+
 pub use crate::types::*;
 
 use soroban_sdk::{
@@ -167,6 +170,42 @@ impl VaultFactory {
     // ─────────────────────────────────────────────────────────────────
     // Vault management
     // ─────────────────────────────────────────────────────────────────
+
+    /// Remove an inactive vault from the factory registry.
+    ///
+    /// - Caller must be the admin.
+    /// - Vault must be registered.
+    /// - Vault must be inactive (set via `set_vault_status`); active vaults
+    ///   cannot be removed to protect depositors.
+    ///
+    /// On success the vault is purged from both `AllVaults` and
+    /// `SingleRwaVaults` (if present) and its `VaultInfo` entry is deleted.
+    /// A `VaultRemoved` event is emitted.
+    pub fn remove_vault(e: &Env, caller: Address, vault: Address) {
+        caller.require_auth();
+        require_admin(e, &caller);
+
+        // Vault must exist
+        let info = get_vault_info(e, &vault)
+            .unwrap_or_else(|| panic_not_found(e));
+
+        // Guard: only inactive vaults may be removed
+        if info.active {
+            panic_with_error!(e, Error::VaultIsActive);
+        }
+
+        // Remove from both registry lists
+        remove_from_all_vaults(e, &vault);
+        if info.vault_type == VaultType::SingleRwa {
+            remove_from_single_rwa_vaults(e, &vault);
+        }
+
+        // Delete persistent VaultInfo entry
+        delete_vault_info(e, &vault);
+
+        emit_vault_removed(e, vault, caller);
+        bump_instance(e);
+    }
 
     pub fn set_vault_status(e: &Env, caller: Address, vault: Address, active: bool) {
         caller.require_auth();

--- a/soroban-contracts/contracts/vault_factory/src/storage.rs
+++ b/soroban-contracts/contracts/vault_factory/src/storage.rs
@@ -180,3 +180,40 @@ pub fn put_vault_info(e: &Env, vault: &Address, info: VaultInfo) {
     e.storage().persistent().set(&key, &info);
     bump_persist(e, &key);
 }
+
+/// Remove a vault address from the AllVaults list.
+pub fn remove_from_all_vaults(e: &Env, vault: &Address) {
+    let vaults = get_all_vaults(e);
+    let mut updated: Vec<Address> = Vec::new(e);
+    for i in 0..vaults.len() {
+        let addr = vaults.get(i).unwrap();
+        if addr != *vault {
+            updated.push_back(addr);
+        }
+    }
+    e.storage().persistent().set(&DataKey::AllVaults, &updated);
+    bump_persist(e, &DataKey::AllVaults);
+}
+
+/// Remove a vault address from the SingleRwaVaults list.
+pub fn remove_from_single_rwa_vaults(e: &Env, vault: &Address) {
+    let vaults = get_single_rwa_vaults(e);
+    let mut updated: Vec<Address> = Vec::new(e);
+    for i in 0..vaults.len() {
+        let addr = vaults.get(i).unwrap();
+        if addr != *vault {
+            updated.push_back(addr);
+        }
+    }
+    e.storage()
+        .persistent()
+        .set(&DataKey::SingleRwaVaults, &updated);
+    bump_persist(e, &DataKey::SingleRwaVaults);
+}
+
+/// Delete the persistent VaultInfo entry for the given vault address.
+pub fn delete_vault_info(e: &Env, vault: &Address) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultInfo(vault.clone()));
+}

--- a/soroban-contracts/contracts/vault_factory/src/tests.rs
+++ b/soroban-contracts/contracts/vault_factory/src/tests.rs
@@ -1,0 +1,196 @@
+extern crate std;
+
+use soroban_sdk::{
+    testutils::Address as _,
+    Address, BytesN, Env, String,
+};
+
+use crate::{
+    errors::Error,
+    storage::{delete_vault_info, get_all_vaults, get_single_rwa_vaults, get_vault_info,
+              push_all_vaults, push_single_rwa_vaults, put_vault_info},
+    types::{VaultInfo, VaultType},
+    VaultFactory, VaultFactoryClient,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Deploy and initialise a VaultFactory with a dummy WASM hash.
+fn setup_factory(e: &Env) -> (VaultFactoryClient, Address) {
+    let admin = Address::generate(e);
+    let asset = Address::generate(e);
+    let zkme = Address::generate(e);
+    let coop = Address::generate(e);
+    let wasm_hash = BytesN::<32>::from_array(e, &[0u8; 32]);
+
+    let factory_id = e.register(
+        VaultFactory,
+        (
+            admin.clone(),
+            asset.clone(),
+            zkme.clone(),
+            coop.clone(),
+            wasm_hash,
+        ),
+    );
+    (VaultFactoryClient::new(e, &factory_id), admin)
+}
+
+/// Inject a vault record directly into factory storage, bypassing deployment.
+/// Returns the generated vault address.
+fn inject_vault(e: &Env, factory_id: &Address, active: bool) -> Address {
+    let vault = Address::generate(e);
+    let info = VaultInfo {
+        vault: vault.clone(),
+        vault_type: VaultType::SingleRwa,
+        name: String::from_str(e, "Test Vault"),
+        symbol: String::from_str(e, "TV"),
+        active,
+        created_at: e.ledger().timestamp(),
+    };
+
+    // Write inside the factory contract context so storage keys resolve
+    // against the factory address.
+    e.as_contract(factory_id, || {
+        put_vault_info(e, &vault, info);
+        push_all_vaults(e, vault.clone());
+        push_single_rwa_vaults(e, vault.clone());
+    });
+
+    vault
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Admin successfully removes an inactive vault.
+#[test]
+fn test_remove_inactive_vault_success() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    let vault = inject_vault(&e, &factory_id, false /* inactive */);
+
+    // Pre-conditions
+    e.as_contract(&factory_id, || {
+        assert!(get_vault_info(&e, &vault).is_some());
+        assert!(get_all_vaults(&e).contains(vault.clone()));
+        assert!(get_single_rwa_vaults(&e).contains(vault.clone()));
+    });
+
+    client.remove_vault(&admin, &vault);
+
+    // Post-conditions: vault purged from all lists and VaultInfo deleted
+    e.as_contract(&factory_id, || {
+        assert!(get_vault_info(&e, &vault).is_none(), "VaultInfo must be deleted");
+        assert!(
+            !get_all_vaults(&e).contains(vault.clone()),
+            "vault must not appear in AllVaults"
+        );
+        assert!(
+            !get_single_rwa_vaults(&e).contains(vault.clone()),
+            "vault must not appear in SingleRwaVaults"
+        );
+    });
+}
+
+/// get_all_vaults no longer returns the removed vault.
+#[test]
+fn test_get_all_vaults_excludes_removed_vault() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    // Two vaults; one will be removed
+    let keep = inject_vault(&e, &factory_id, false);
+    let remove = inject_vault(&e, &factory_id, false);
+
+    client.remove_vault(&admin, &remove);
+
+    let all = client.get_all_vaults();
+    assert!(
+        !all.contains(remove.clone()),
+        "removed vault must not appear in get_all_vaults"
+    );
+    assert!(
+        all.contains(keep.clone()),
+        "remaining vault must still appear in get_all_vaults"
+    );
+}
+
+/// Non-admin caller must be rejected with NotAuthorized.
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_remove_vault_non_admin_fails() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+    let vault = inject_vault(&e, &factory_id, false);
+
+    let random = Address::generate(&e);
+    client.remove_vault(&random, &vault);
+}
+
+/// Attempting to remove an active vault must fail with VaultIsActive.
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_remove_active_vault_fails() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+    let vault = inject_vault(&e, &factory_id, true /* active */);
+
+    client.remove_vault(&admin, &vault);
+}
+
+/// Attempting to remove a vault that does not exist must fail with VaultNotFound.
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_remove_unknown_vault_fails() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let ghost = Address::generate(&e);
+
+    client.remove_vault(&admin, &ghost);
+}
+
+/// VaultRemoved event is emitted on a successful removal.
+#[test]
+fn test_remove_vault_emits_event() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+    let vault = inject_vault(&e, &factory_id, false);
+
+    client.remove_vault(&admin, &vault);
+
+    // The last published event must carry the "v_remove" topic and the
+    // vault address.
+    let events = e.events().all();
+    let last = events.last().expect("at least one event must be published");
+    // topics: (symbol_short!("v_remove"), vault_addr)
+    // data:   admin_addr
+    let (contract, topics, _data) = last;
+    assert_eq!(contract, factory_id);
+    // Verify the first topic is the "v_remove" symbol
+    let first_topic: soroban_sdk::Val = topics.get(0).unwrap();
+    let expected: soroban_sdk::Val =
+        soroban_sdk::symbol_short!("v_remove").into_val(&e);
+    assert_eq!(first_topic, expected);
+}


### PR DESCRIPTION
Closes #30

## Summary

- Add `remove_vault(caller, vault)` — admin-only function that decommissions a vault from the factory registry
- Guard: only vaults with `active = false` can be removed; active vaults revert with `VaultIsActive` (Error #4) to protect depositors
- Vault address is removed from both `AllVaults` and `SingleRwaVaults` Vec lists
- `VaultInfo` persistent entry is deleted on successful removal
- `VaultRemoved` event emitted on success (topic: `v_remove` + vault address; data: caller address)

## Definition of Done

- [x] Admin can remove an inactive vault from the registry
- [x] `get_all_vaults` no longer returns the removed vault
- [x] `VaultRemoved` event emitted on removal
- [x] Attempting to remove an active vault fails with `VaultIsActive` (Error #4)

## Files Changed

| File | Change |
|---|---|
| `vault_factory/src/errors.rs` | Added `VaultIsActive = 4` |
| `vault_factory/src/events.rs` | Added `emit_vault_removed` helper |
| `vault_factory/src/storage.rs` | Added `remove_from_all_vaults`, `remove_from_single_rwa_vaults`, `delete_vault_info` |
| `vault_factory/src/lib.rs` | Added `remove_vault` function |
| `vault_factory/src/tests.rs` | New — 5 test cases (success, list exclusion, non-admin rejection, active vault rejection, unknown vault rejection) |

## Test Cases

1. `test_remove_inactive_vault_success` — admin removes inactive vault; lists and VaultInfo cleared
2. `test_get_all_vaults_excludes_removed_vault` — removed vault absent from `get_all_vaults`, remaining vault still present
3. `test_remove_vault_non_admin_fails` — non-admin caller reverts with `NotAuthorized` (Error #3)
4. `test_remove_active_vault_fails` — active vault reverts with `VaultIsActive` (Error #4)
5. `test_remove_unknown_vault_fails` — unregistered address reverts with `VaultNotFound` (Error #2)

> **Note:** The `single_rwa_vault` dependency has pre-existing compile errors on `main` (`acquire_lock`, `release_lock`, `emit_address_blacklisted`, `DataKey::Locked` missing — introduced by a prior merged PR). These are unrelated to this issue and exist on the base branch before any changes from this PR.