### PR TITLE
feat: #31 Add funding_deadline with Auto-Refund Mechanism

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
@@ -21,4 +21,10 @@ pub enum Error {
     AddressBlacklisted      = 14,
     /// Reentrancy detected — a guarded function was called while already executing.
     Reentrant               = 15,
+    /// Funding deadline has already passed; cannot activate vault.
+    FundingDeadlinePassed   = 16,
+    /// Funding deadline has not yet passed; cannot cancel funding early.
+    FundingDeadlineNotPassed = 17,
+    /// Caller holds no shares to refund.
+    NoSharesToRefund        = 18,
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -6,13 +6,6 @@ use soroban_sdk::{symbol_short, Address, Env, String};
 
 use crate::types::VaultState;
 
-pub fn emit_address_blacklisted(e: &Env, address: Address, status: bool) {
-    e.events().publish(
-        (symbol_short!("blacklist"),),
-        (address, status),
-    );
-}
-
 pub fn emit_zkme_verifier_updated(e: &Env, old: Address, new: Address) {
     e.events().publish(
         (symbol_short!("zkme_upd"),),
@@ -207,5 +200,21 @@ pub fn emit_address_blacklisted(e: &Env, address: Address, status: bool) {
     e.events().publish(
         (symbol_short!("blacklist"), address),
         status,
+    );
+}
+
+/// Emitted by `cancel_funding` — vault moved to Cancelled state.
+pub fn emit_funding_cancelled(e: &Env) {
+    e.events().publish(
+        (symbol_short!("fund_cxl"),),
+        e.ledger().timestamp(),
+    );
+}
+
+/// Emitted by `refund` — user burned shares and received deposited assets back.
+pub fn emit_refunded(e: &Env, user: Address, amount: i128) {
+    e.events().publish(
+        (symbol_short!("refunded"), user),
+        amount,
     );
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -6,6 +6,9 @@ mod storage;
 mod token_interface;
 mod types;
 
+#[cfg(test)]
+mod test_funding_deadline;
+
 pub use crate::types::*;
 
 use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env, String};
@@ -59,6 +62,7 @@ impl SingleRWAVault {
         // Vault configuration
         put_funding_target(e, params.funding_target);
         put_maturity_date(e, params.maturity_date);
+        put_funding_deadline(e, params.funding_deadline);
         put_min_deposit(e, params.min_deposit);
         put_max_deposit_per_user(e, params.max_deposit_per_user);
         put_early_redemption_fee_bps(e, params.early_redemption_fee_bps);
@@ -488,11 +492,17 @@ impl SingleRWAVault {
         get_vault_state(e)
     }
 
-    /// Transition Funding → Active.  Requires funding target to be met.
+    /// Transition Funding → Active.  Requires funding target to be met and
+    /// the funding deadline must not have passed.
     pub fn activate_vault(e: &Env, caller: Address) {
         caller.require_auth();
         require_operator(e, &caller);
         require_state(e, VaultState::Funding);
+        // Cannot activate once the funding deadline has passed.
+        let deadline = get_funding_deadline(e);
+        if deadline > 0 && e.ledger().timestamp() > deadline {
+            panic_with_error!(e, Error::FundingDeadlinePassed);
+        }
         if !Self::is_funding_target_met(e) {
             panic_with_error!(e, Error::FundingTargetNotMet);
         }
@@ -500,6 +510,71 @@ impl SingleRWAVault {
         put_activation_timestamp(e, e.ledger().timestamp());
         emit_vault_state_changed(e, VaultState::Funding, VaultState::Active);
         bump_instance(e);
+    }
+
+    /// Cancel a failed funding round.
+    ///
+    /// Operator-only.  Callable only when the vault is in Funding state,
+    /// the funding deadline has passed, and the funding target has not been met.
+    /// Transitions the vault to Cancelled, enabling individual `refund` calls.
+    pub fn cancel_funding(e: &Env, caller: Address) {
+        caller.require_auth();
+        require_operator(e, &caller);
+        require_state(e, VaultState::Funding);
+        // Deadline must have passed.
+        let deadline = get_funding_deadline(e);
+        if deadline == 0 || e.ledger().timestamp() <= deadline {
+            panic_with_error!(e, Error::FundingDeadlineNotPassed);
+        }
+        // Funding target must still be unmet.
+        if Self::is_funding_target_met(e) {
+            panic_with_error!(e, Error::FundingTargetNotMet);
+        }
+        put_vault_state(e, VaultState::Cancelled);
+        emit_vault_state_changed(e, VaultState::Funding, VaultState::Cancelled);
+        emit_funding_cancelled(e);
+        bump_instance(e);
+    }
+
+    /// Refund a depositor after a cancelled funding round.
+    ///
+    /// Burns the caller's shares 1:1 and returns the corresponding deposited
+    /// assets.  Only callable when the vault is in Cancelled state.
+    ///
+    /// Security: follows CEI — shares are burned (Effect) before the asset
+    /// transfer (Interaction).  Reentrancy lock prevents double-refund.
+    pub fn refund(e: &Env, caller: Address) -> i128 {
+        caller.require_auth();
+        // --- Checks ---
+        acquire_lock(e);
+        require_not_paused(e);
+        require_state(e, VaultState::Cancelled);
+
+        let shares = get_share_balance(e, &caller);
+        if shares <= 0 {
+            panic_with_error!(e, Error::NoSharesToRefund);
+        }
+
+        // In Funding state no yield accrues, so the share price is always 1:1.
+        // preview_redeem handles this correctly (totalAssets == totalSupply).
+        let amount = preview_redeem(e, shares);
+
+        // --- Effects ---
+        put_user_deposited(e, &caller, 0);
+        _burn(e, &caller, shares);
+
+        // --- Interaction ---
+        transfer_asset_from_vault(e, &caller, amount);
+
+        emit_refunded(e, caller, amount);
+        bump_instance(e);
+        release_lock(e);
+        amount
+    }
+
+    /// Returns the funding deadline timestamp (0 = no deadline configured).
+    pub fn funding_deadline(e: &Env) -> u64 {
+        get_funding_deadline(e)
     }
 
     /// Transition Active → Matured.  Requires block timestamp ≥ maturityDate.
@@ -1201,6 +1276,7 @@ mod test {
             cooperator: admin.clone(),
             funding_target: 1000_0000000,
             maturity_date: 0,
+            funding_deadline: 0,
             min_deposit: 1_0000000,
             max_deposit_per_user: 0,
             early_redemption_fee_bps: 100,

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -66,10 +66,11 @@ pub enum DataKey {
     // --- Vault state ---
     VaultState,
     Paused,
-    Locked,
     ActivationTimestamp,
     /// Reentrancy lock — true while a guarded function is executing.
     Locked,
+    /// Unix timestamp deadline for funding; 0 means no deadline.
+    FundingDeadline,
 
     // --- Epoch / yield ---
     CurrentEpoch,
@@ -181,6 +182,17 @@ instance_get!(get_funding_target, FundingTarget, i128);
 instance_put!(put_funding_target, FundingTarget, i128);
 instance_get!(get_maturity_date, MaturityDate, u64);
 instance_put!(put_maturity_date, MaturityDate, u64);
+
+pub fn get_funding_deadline(e: &Env) -> u64 {
+    e.storage()
+        .instance()
+        .get(&DataKey::FundingDeadline)
+        .unwrap_or(0)
+}
+pub fn put_funding_deadline(e: &Env, val: u64) {
+    e.storage().instance().set(&DataKey::FundingDeadline, &val);
+}
+
 instance_get!(get_min_deposit, MinDeposit, i128);
 instance_put!(put_min_deposit, MinDeposit, i128);
 instance_get!(get_max_deposit_per_user, MaxDepositPerUser, i128);

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_funding_deadline.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_funding_deadline.rs
@@ -1,0 +1,311 @@
+//! Tests for funding_deadline, cancel_funding, and refund (issue #31).
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String,
+};
+
+use crate::{InitParams, SingleRWAVault, SingleRWAVaultClient, VaultState};
+
+use crate::test_helpers::{AlwaysApproveZkme, MockUsdc, MockUsdcClient};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test context with configurable funding_deadline and no deposit cap
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct Ctx {
+    env: Env,
+    vault_id: Address,
+    asset_id: Address,
+    admin: Address,
+    user: Address,
+}
+
+impl Ctx {
+    fn vault(&self) -> SingleRWAVaultClient<'_> {
+        SingleRWAVaultClient::new(&self.env, &self.vault_id)
+    }
+    fn asset(&self) -> MockUsdcClient<'_> {
+        MockUsdcClient::new(&self.env, &self.asset_id)
+    }
+}
+
+/// Deploy a fresh vault with the given `funding_deadline`.
+/// Funding target = 100 USDC; max_deposit_per_user = 0 (unlimited).
+fn deploy(funding_deadline: u64) -> Ctx {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let cooperator = Address::generate(&env);
+
+    let asset_id = env.register(MockUsdc, ());
+    let kyc_id = env.register(AlwaysApproveZkme, ());
+
+    let params = InitParams {
+        asset: asset_id.clone(),
+        share_name: String::from_str(&env, "StellarYield Bond Share"),
+        share_symbol: String::from_str(&env, "syBOND"),
+        share_decimals: 6u32,
+        admin: admin.clone(),
+        zkme_verifier: kyc_id.clone(),
+        cooperator: cooperator.clone(),
+        funding_target: 100_000_000i128,   // 100 USDC
+        maturity_date: 9_999_999_999u64,
+        funding_deadline,
+        min_deposit: 1_000_000i128,        // 1 USDC
+        max_deposit_per_user: 0i128,       // unlimited
+        early_redemption_fee_bps: 200u32,
+        rwa_name: String::from_str(&env, "US Treasury Bond 2026"),
+        rwa_symbol: String::from_str(&env, "USTB26"),
+        rwa_document_uri: String::from_str(&env, "https://example.com/ustb26"),
+        rwa_category: String::from_str(&env, "Government Bond"),
+        expected_apy: 500u32,
+    };
+
+    let vault_id = env.register(SingleRWAVault, (params,));
+    Ctx { env, vault_id, asset_id, admin, user }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: funding_deadline is stored and queryable at construction
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_funding_deadline_stored_at_construction() {
+    let deadline = 1_700_000_000u64;
+    let ctx = deploy(deadline);
+    assert_eq!(ctx.vault().funding_deadline(), deadline);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: zero deadline means "no deadline" — activate_vault is unaffected
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_zero_deadline_means_no_deadline() {
+    let ctx = deploy(0);
+    let vault = ctx.vault();
+
+    ctx.asset().mint(&ctx.user, &100_000_000i128);
+    vault.deposit(&ctx.user, &100_000_000i128, &ctx.user);
+
+    // Large timestamp advance — deadline = 0 should not block activation
+    ctx.env.ledger().with_mut(|li| li.timestamp = 9_999_999u64);
+    vault.activate_vault(&ctx.admin);
+    assert_eq!(vault.vault_state(), VaultState::Active);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: activate_vault succeeds before deadline when target is met
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_activate_vault_succeeds_before_deadline() {
+    let ctx = deploy(9_999_999_999u64);
+    let vault = ctx.vault();
+
+    ctx.asset().mint(&ctx.user, &100_000_000i128);
+    vault.deposit(&ctx.user, &100_000_000i128, &ctx.user);
+
+    vault.activate_vault(&ctx.admin);
+    assert_eq!(vault.vault_state(), VaultState::Active);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: activate_vault fails after deadline  (Error::FundingDeadlinePassed = 16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_activate_vault_fails_after_deadline() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    ctx.asset().mint(&ctx.user, &100_000_000i128);
+    vault.deposit(&ctx.user, &100_000_000i128, &ctx.user);
+
+    // Advance past deadline then attempt activation.
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.activate_vault(&ctx.admin); // must panic with Error #16
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: cancel_funding fails before deadline  (Error::FundingDeadlineNotPassed = 17)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_cancel_funding_fails_before_deadline() {
+    let ctx = deploy(9_999_999_999u64); // deadline far in the future
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    ctx.vault().deposit(&ctx.user, &10_000_000i128, &ctx.user);
+    ctx.vault().cancel_funding(&ctx.admin); // must panic with Error #17
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: cancel_funding with zero deadline also fails  (no deadline configured)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_cancel_funding_fails_when_no_deadline() {
+    let ctx = deploy(0); // deadline = 0 means "no deadline"
+    ctx.vault().cancel_funding(&ctx.admin);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: cancel_funding fails when funding target IS met after deadline
+// (Error::FundingTargetNotMet = 10 re-used to mean "target was met, can't cancel")
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_cancel_funding_fails_when_target_met() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    // Meet the funding target.
+    ctx.asset().mint(&ctx.user, &100_000_000i128);
+    vault.deposit(&ctx.user, &100_000_000i128, &ctx.user);
+
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.cancel_funding(&ctx.admin); // must panic — target met
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: cancel_funding transitions to Cancelled state
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_cancel_funding_sets_cancelled_state() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    // Deposit some (but not enough to meet target).
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.cancel_funding(&ctx.admin);
+
+    assert_eq!(vault.vault_state(), VaultState::Cancelled);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: full cancel-refund flow — two users each get their deposit back
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_full_cancel_and_refund_flow() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    let user2 = Address::generate(&ctx.env);
+
+    // Each user deposits 10 USDC (total = 20 USDC < 100 USDC target).
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    ctx.asset().mint(&user2, &10_000_000i128);
+    vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+    vault.deposit(&user2, &10_000_000i128, &user2);
+
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.cancel_funding(&ctx.admin);
+    assert_eq!(vault.vault_state(), VaultState::Cancelled);
+
+    // User 1 refunds.
+    let bal_before = ctx.asset().balance(&ctx.user);
+    let returned = vault.refund(&ctx.user);
+    let bal_after = ctx.asset().balance(&ctx.user);
+    assert_eq!(returned, 10_000_000i128);
+    assert_eq!(bal_after - bal_before, 10_000_000i128);
+    assert_eq!(vault.balance(&ctx.user), 0);
+
+    // User 2 refunds.
+    let bal2_before = ctx.asset().balance(&user2);
+    let returned2 = vault.refund(&user2);
+    let bal2_after = ctx.asset().balance(&user2);
+    assert_eq!(returned2, 10_000_000i128);
+    assert_eq!(bal2_after - bal2_before, 10_000_000i128);
+    assert_eq!(vault.balance(&user2), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: refund fails when vault is not Cancelled  (Error #5 = InvalidVaultState)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_refund_fails_when_vault_not_cancelled() {
+    let ctx = deploy(9_999_999_999u64);
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    ctx.vault().deposit(&ctx.user, &10_000_000i128, &ctx.user);
+    ctx.vault().refund(&ctx.user); // must panic — not Cancelled
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: refund fails when caller has no shares  (Error #18 = NoSharesToRefund)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_refund_fails_when_no_shares() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.cancel_funding(&ctx.admin);
+
+    let stranger = Address::generate(&ctx.env);
+    vault.refund(&stranger); // must panic — no shares
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: cannot double-refund  (Error #18 = NoSharesToRefund on second call)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_cannot_double_refund() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.cancel_funding(&ctx.admin);
+
+    vault.refund(&ctx.user); // first — ok
+    vault.refund(&ctx.user); // second — must panic
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test: only operator can cancel_funding  (Error #3 = NotOperator)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_cancel_funding_requires_operator() {
+    let deadline = 1_000u64;
+    let ctx = deploy(deadline);
+    let vault = ctx.vault();
+
+    ctx.asset().mint(&ctx.user, &10_000_000i128);
+    vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+    ctx.env.ledger().with_mut(|li| li.timestamp = deadline + 1);
+    vault.cancel_funding(&ctx.user); // non-operator — must panic
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
@@ -109,7 +109,7 @@ mod _bypass {
         }
     }
 }
-use _bypass::AlwaysApproveZkme;
+pub use _bypass::AlwaysApproveZkme;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TestContext — returned by setup() and setup_with_kyc_bypass()
@@ -239,6 +239,7 @@ fn default_params(
         cooperator,
         funding_target: 100_000_000i128,   // 100 USDC (6 decimals)
         maturity_date: 9_999_999_999u64,   // far future
+        funding_deadline: 9_999_999_999u64, // far future (no effective deadline by default)
         min_deposit: 1_000_000i128,        // 1 USDC
         max_deposit_per_user: 50_000_000i128, // 50 USDC
         early_redemption_fee_bps: 200u32,  // 2 %

--- a/soroban-contracts/contracts/single_rwa_vault/src/tests.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/tests.rs
@@ -83,6 +83,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             cooperator: cooperator.clone(),
             funding_target: 0i128,
             maturity_date: 9_999_999_999u64,
+            funding_deadline: 9_999_999_999u64,
             min_deposit: 0i128,
             max_deposit_per_user: 0i128,
             early_redemption_fee_bps: 200u32,

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -27,6 +27,8 @@ pub struct InitParams {
     pub min_deposit: i128,
     pub max_deposit_per_user: i128,
     pub early_redemption_fee_bps: u32,
+    /// Unix timestamp after which funding can be cancelled if target not met.
+    pub funding_deadline: u64,
     // RWA details
     pub rwa_name: String,
     pub rwa_symbol: String,
@@ -50,6 +52,8 @@ pub enum VaultState {
     Matured,
     /// Vault is closed.
     Closed,
+    /// Funding failed (deadline passed without meeting target); refunds available.
+    Cancelled,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -86,6 +86,7 @@ impl VaultFactory {
             zero_str,  // category
             0u32,      // expected_apy
             maturity_date,
+            0u64,      // funding_deadline (0 = no deadline)
             0i128,     // funding_target
             0i128,     // min_deposit
             0i128,     // max_deposit_per_user
@@ -116,6 +117,7 @@ impl VaultFactory {
             params.rwa_category,
             params.expected_apy,
             params.maturity_date,
+            params.funding_deadline,
             params.funding_target,
             params.min_deposit,
             params.max_deposit_per_user,
@@ -146,6 +148,7 @@ impl VaultFactory {
                 p.rwa_category,
                 p.expected_apy,
                 p.maturity_date,
+                p.funding_deadline,
                 p.funding_target,
                 p.min_deposit,
                 p.max_deposit_per_user,
@@ -327,6 +330,7 @@ impl VaultFactory {
         rwa_category: String,
         expected_apy: u32,
         maturity_date: u64,
+        funding_deadline: u64,
         funding_target: i128,
         min_deposit: i128,
         max_deposit_per_user: i128,
@@ -363,6 +367,7 @@ impl VaultFactory {
             cooperator: coop.clone(),
             funding_target,
             maturity_date,
+            funding_deadline,
             min_deposit,
             max_deposit_per_user,
             early_redemption_fee_bps,

--- a/soroban-contracts/contracts/vault_factory/src/types.rs
+++ b/soroban-contracts/contracts/vault_factory/src/types.rs
@@ -35,6 +35,7 @@ pub struct BatchVaultParams {
     pub rwa_category: String,
     pub expected_apy: u32,
     pub maturity_date: u64,
+    pub funding_deadline: u64,
     pub funding_target: i128,
     pub min_deposit: i128,
     pub max_deposit_per_user: i128,


### PR DESCRIPTION
## Summary

- Adds `funding_deadline: u64` to `InitParams` — configurable at vault construction, stored in instance storage
- Implements `cancel_funding(caller)` — operator-only, callable after deadline if funding target is not met; transitions vault to new `Cancelled` state
- Implements `refund(caller)` — any user can burn shares 1:1 and receive deposited assets back; only available in `Cancelled` state
- Updates `activate_vault` to reject activation after the funding deadline has passed
- Propagates `funding_deadline` through `VaultFactory`'s `BatchVaultParams` / `_create_single_rwa_vault`
- Fixes pre-existing compile errors (duplicate `Locked` DataKey variant, duplicate `emit_address_blacklisted`) that blocked the entire contract from building

## Definition of Done

- [x] Funding deadline is configurable at construction
- [x] Users can individually refund after funding failure
- [x] Cannot activate a vault past its funding deadline
- [x] Tests cover the full cancel-refund flow

## New Events

- `FundingCancelled` — emitted by `cancel_funding`
- `Refunded(user, amount)` — emitted by `refund`

## New Error Codes

| Code | Name | When |
|------|------|------|
| 16 | `FundingDeadlinePassed` | `activate_vault` called after deadline |
| 17 | `FundingDeadlineNotPassed` | `cancel_funding` called before deadline or with no deadline |
| 18 | `NoSharesToRefund` | `refund` called with zero share balance |

## Test Plan

- [x] `test_funding_deadline_stored_at_construction` — deadline is persisted
- [x] `test_zero_deadline_means_no_deadline` — `funding_deadline = 0` disables the check
- [x] `test_activate_vault_succeeds_before_deadline` — happy path
- [x] `test_activate_vault_fails_after_deadline` — deadline enforcement
- [x] `test_cancel_funding_fails_before_deadline` — cannot cancel early
- [x] `test_cancel_funding_fails_when_no_deadline` — no deadline = cannot cancel
- [x] `test_cancel_funding_fails_when_target_met` — cannot cancel if funded
- [x] `test_cancel_funding_sets_cancelled_state` — state transition
- [x] `test_full_cancel_and_refund_flow` — two-user end-to-end
- [x] `test_refund_fails_when_vault_not_cancelled` — state guard
- [x] `test_refund_fails_when_no_shares` — no shares guard
- [x] `test_cannot_double_refund` — idempotency guard
- [x] `test_cancel_funding_requires_operator` — access control

All 43 tests pass (`cargo test --package single_rwa_vault`).

Closes #31