### PR TITLE
feat: Implement ERC-4626 maxDeposit, maxMint, maxWithdraw, maxRedeem View Functions

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -350,6 +350,70 @@ impl SingleRWAVault {
         preview_redeem(e, shares)
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // ERC-4626 max helpers
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Maximum assets `receiver` can deposit right now.
+    /// Returns 0 when the vault is paused or not in Funding/Active state.
+    /// When `max_deposit_per_user` is 0 the vault is uncapped; returns i128::MAX.
+    pub fn max_deposit(e: &Env, receiver: Address) -> i128 {
+        if get_paused(e) {
+            return 0;
+        }
+        let state = get_vault_state(e);
+        if state != VaultState::Funding && state != VaultState::Active {
+            return 0;
+        }
+        let cap = get_max_deposit_per_user(e);
+        if cap == 0 {
+            return i128::MAX;
+        }
+        let already = get_user_deposited(e, &receiver);
+        (cap - already).max(0)
+    }
+
+    /// Maximum shares `receiver` can obtain via `mint` right now.
+    /// Converts `max_deposit` to shares using the current share price.
+    /// Returns 0 when the vault is paused or not in Funding/Active state.
+    pub fn max_mint(e: &Env, receiver: Address) -> i128 {
+        let max_assets = Self::max_deposit(e, receiver);
+        if max_assets == 0 {
+            return 0;
+        }
+        if max_assets == i128::MAX {
+            return i128::MAX;
+        }
+        preview_deposit(e, max_assets)
+    }
+
+    /// Maximum assets `owner` can withdraw right now.
+    /// Returns 0 when the vault is paused or not in Active/Matured state.
+    pub fn max_withdraw(e: &Env, owner: Address) -> i128 {
+        if get_paused(e) {
+            return 0;
+        }
+        let state = get_vault_state(e);
+        if state != VaultState::Active && state != VaultState::Matured {
+            return 0;
+        }
+        let shares = get_share_balance(e, &owner);
+        preview_redeem(e, shares)
+    }
+
+    /// Maximum shares `owner` can redeem right now (their full share balance).
+    /// Returns 0 when the vault is paused or not in Active/Matured state.
+    pub fn max_redeem(e: &Env, owner: Address) -> i128 {
+        if get_paused(e) {
+            return 0;
+        }
+        let state = get_vault_state(e);
+        if state != VaultState::Active && state != VaultState::Matured {
+            return 0;
+        }
+        get_share_balance(e, &owner)
+    }
+
     pub fn total_assets(e: &Env) -> i128 {
         total_assets(e)
     }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
@@ -81,6 +81,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             cooperator: cooperator.clone(),
             funding_target: 0i128,
             maturity_date: 9_999_999_999u64,
+            funding_deadline: 0u64,
             min_deposit: 0i128,
             max_deposit_per_user: 0i128,
             early_redemption_fee_bps: 200u32, // 2% fee

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_vault_state_guards.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_vault_state_guards.rs
@@ -80,6 +80,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             cooperator: cooperator.clone(),
             funding_target: 0i128,
             maturity_date: 9_999_999_999u64,
+            funding_deadline: 0u64,
             min_deposit: 0i128,
             max_deposit_per_user: 0i128,
             early_redemption_fee_bps: 200u32,

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_blacklisted_cannot_deposit.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_blacklisted_cannot_deposit.1.json
@@ -320,6 +320,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_blacklisted_cannot_transfer.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_blacklisted_cannot_transfer.1.json
@@ -547,6 +547,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_cannot_transfer_to_blacklisted.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_cannot_transfer_to_blacklisted.1.json
@@ -547,6 +547,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_set_blacklisted_by_admin.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_set_blacklisted_by_admin.1.json
@@ -345,6 +345,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_set_blacklisted_non_admin_fails.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test/test_set_blacklisted_non_admin_fails.1.json
@@ -182,6 +182,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_admin_is_set_and_is_operator.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_admin_is_set_and_is_operator.1.json
@@ -241,6 +241,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_asset_address_stored.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_asset_address_stored.1.json
@@ -240,6 +240,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_expected_apy_stored.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_expected_apy_stored.1.json
@@ -241,6 +241,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_initial_accounting_state_is_zero.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_initial_accounting_state_is_zero.1.json
@@ -242,6 +242,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_initial_vault_state.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_initial_vault_state.1.json
@@ -242,6 +242,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_rwa_metadata_stored_correctly.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_rwa_metadata_stored_correctly.1.json
@@ -244,6 +244,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_share_token_metadata.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_share_token_metadata.1.json
@@ -242,6 +242,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_time_to_maturity_nonzero_on_init.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_time_to_maturity_nonzero_on_init.1.json
@@ -240,6 +240,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_vault_config_matches_init_params.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_vault_config_matches_init_params.1.json
@@ -244,6 +244,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_zkme_verifier_and_cooperator_stored.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/test_constructor/test_zkme_verifier_and_cooperator_stored.1.json
@@ -241,6 +241,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_kyc_verified_succeeds.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_kyc_verified_succeeds.1.json
@@ -673,6 +673,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_non_kyc_rejected.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_non_kyc_rejected.1.json
@@ -539,6 +539,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_kyc_flag_disabled_allows_unverified_to.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_kyc_flag_disabled_allows_unverified_to.1.json
@@ -632,6 +632,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_to_kyc_verified_succeeds.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_to_kyc_verified_succeeds.1.json
@@ -585,6 +585,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_to_non_kyc_rejected.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_to_non_kyc_rejected.1.json
@@ -454,6 +454,18 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "FundingDeadline"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 9999999999
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "FundingTarget"
                             }
                           ]


### PR DESCRIPTION
This PR adds the four ERC-4626 "max" view functions to single_rwa_vault, giving integrators a standard way to query the upper bound of each operation for a given address before attempting it.

- max_deposit returns i128::MAX when max_deposit_per_user is 0 (uncapped vault), mirroring the ERC-4626 spec's unbounded sentinel
- max_mint propagates the i128::MAX sentinel directly rather than converting it (avoids overflow in preview_deposit)
- max_withdraw / max_redeem mirror the state guard used by withdraw and redeem (Active | Matured), so the return value is always 0 when those operations would revert

close #32 