### PR TITLE
feat: #4 Add typed errors for currently unhandled panic paths

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
@@ -5,26 +5,36 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
-    NotKYCVerified          = 1,
-    ZKMEVerifierNotSet      = 2,
-    NotOperator             = 3,
-    NotAdmin                = 4,
-    InvalidVaultState       = 5,
-    BelowMinimumDeposit     = 6,
-    ExceedsMaximumDeposit   = 7,
-    NotMatured              = 8,
-    NoYieldToClaim          = 9,
-    FundingTargetNotMet     = 10,
-    VaultPaused             = 11,
-    ZeroAddress             = 12,
-    ZeroAmount              = 13,
-    AddressBlacklisted      = 14,
+    NotKYCVerified = 1,
+    ZKMEVerifierNotSet = 2,
+    NotOperator = 3,
+    NotAdmin = 4,
+    InvalidVaultState = 5,
+    BelowMinimumDeposit = 6,
+    ExceedsMaximumDeposit = 7,
+    NotMatured = 8,
+    NoYieldToClaim = 9,
+    FundingTargetNotMet = 10,
+    VaultPaused = 11,
+    ZeroAddress = 12,
+    ZeroAmount = 13,
+    AddressBlacklisted = 14,
     /// Reentrancy detected — a guarded function was called while already executing.
-    Reentrant               = 15,
+    Reentrant = 15,
     /// Funding deadline has already passed; cannot activate vault.
-    FundingDeadlinePassed   = 16,
+    FundingDeadlinePassed = 16,
     /// Funding deadline has not yet passed; cannot cancel funding early.
     FundingDeadlineNotPassed = 17,
     /// Caller holds no shares to refund.
-    NoSharesToRefund        = 18,
+    NoSharesToRefund = 18,
+    /// Spender allowance is too low to cover the requested transfer.
+    InsufficientAllowance = 19,
+    /// Account balance is too low to cover the requested operation.
+    InsufficientBalance = 20,
+    /// Operation has already been processed and cannot be repeated.
+    AlreadyProcessed = 21,
+    /// Requested fee exceeds the permitted maximum.
+    FeeTooHigh = 22,
+    /// Price aggregator is not supported or not recognised.
+    AggregatorNotSupported = 23,
 }


### PR DESCRIPTION
## Summary

Adds the five missing error variants to `single_rwa_vault::errors::Error` as required by issue #4:

- `InsufficientAllowance = 19` — spender allowance too low
- `InsufficientBalance = 20` — account balance too low
- `AlreadyProcessed = 21` — operation already executed
- `FeeTooHigh = 22` — requested fee exceeds the permitted maximum
- `AggregatorNotSupported = 23` — price aggregator not recognised

## Changes

Only `soroban-contracts/contracts/single_rwa_vault/src/errors.rs` is modified. The new variants follow the same `#[contracterror]` / `#[derive(Copy, Clone, Debug, Eq, PartialEq)]` style as all existing variants and are assigned the next sequential discriminant values (19–23).

## Acceptance Criteria

- [x] All five error codes added to the `Error` enum
- [x] `cargo test --package single_rwa_vault` — 59 tests pass, 0 failures
- [x] `cargo fmt --package single_rwa_vault -- --check` — no formatting diff
- [x] Pre-existing clippy warnings in `lib.rs` are unchanged and unrelated to this PR

Closes #4