### PR TITLE
feat: #5 Enforce Allowance Expiration in SEP-41 Token Implementation

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -1042,6 +1042,13 @@ impl SingleRWAVault {
 
     pub fn approve(e: &Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
         from.require_auth();
+        // SEP-41 §3.4: expiration_ledger must be ≥ current ledger sequence.
+        // Allowing a zero amount with a past expiry is the canonical way to
+        // revoke an allowance, so we only reject future-expiry cases where
+        // amount > 0 and the ledger has already passed.
+        if amount > 0 && expiration_ledger < e.ledger().sequence() {
+            panic_with_error!(e, Error::InvalidVaultState);
+        }
         put_share_allowance_with_expiry(e, &from, &spender, amount, expiration_ledger);
         emit_approval(e, from, spender, amount, expiration_ledger);
         bump_instance(e);
@@ -1482,3 +1489,5 @@ mod test_redemption;
 
 #[cfg(test)]
 mod test_vault_state_guards;
+#[cfg(test)]
+mod test_token;

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -278,6 +278,19 @@ pub fn put_epoch_total_shares(e: &Env, epoch: u32, val: i128) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Allowance data type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Persistent allowance record that couples the approved amount with its
+/// expiration ledger, enabling on-chain expiry enforcement (SEP-41 §3.4).
+#[contracttype]
+#[derive(Clone)]
+pub struct AllowanceData {
+    pub amount: i128,
+    pub expiration_ledger: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Per-user persistent data
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -293,32 +306,74 @@ pub fn put_share_balance(e: &Env, addr: &Address, val: i128) {
         .set(&DataKey::Balance(addr.clone()), &val);
 }
 
-/// Allowance stored in persistent storage.
-/// A simple version without expiry tracking (expiry is tracked at application
-/// layer via `expiration_ledger` parameter in `approve`).
+/// Returns the current allowance for `(owner, spender)`.
+/// Returns 0 if no allowance is recorded **or** if it has expired
+/// (`expiration_ledger < current ledger sequence`).
 pub fn get_share_allowance(e: &Env, owner: &Address, spender: &Address) -> i128 {
+    let key = DataKey::Allowance(owner.clone(), spender.clone());
+    match e
+        .storage()
+        .persistent()
+        .get::<_, AllowanceData>(&key)
+    {
+        Some(data) => {
+            if e.ledger().sequence() > data.expiration_ledger {
+                0 // allowance has expired
+            } else {
+                data.amount
+            }
+        }
+        None => 0,
+    }
+}
+
+/// Decrements an existing allowance to `new_amount`, preserving the stored
+/// `expiration_ledger`.  Only call this after confirming the allowance is
+/// sufficient and non-expired via `get_share_allowance`.
+pub fn put_share_allowance(e: &Env, owner: &Address, spender: &Address, new_amount: i128) {
+    let key = DataKey::Allowance(owner.clone(), spender.clone());
+    // Read back the expiration that was set when the allowance was approved.
+    let expiration_ledger = e
+        .storage()
+        .persistent()
+        .get::<_, AllowanceData>(&key)
+        .map(|d| d.expiration_ledger)
+        .unwrap_or(0);
     e.storage()
         .persistent()
-        .get(&DataKey::Allowance(owner.clone(), spender.clone()))
-        .unwrap_or(0)
+        .set(&key, &AllowanceData { amount: new_amount, expiration_ledger });
+    // Keep the entry alive until it naturally expires.
+    let current = e.ledger().sequence();
+    if expiration_ledger > current {
+        let live_for = expiration_ledger - current + 1;
+        e.storage()
+            .persistent()
+            .extend_ttl(&key, live_for, live_for);
+    }
 }
-pub fn put_share_allowance(e: &Env, owner: &Address, spender: &Address, val: i128) {
-    e.storage()
-        .persistent()
-        .set(&DataKey::Allowance(owner.clone(), spender.clone()), &val);
-}
+
+/// Stores a fresh allowance with an on-chain `expiration_ledger` and sets the
+/// persistent entry TTL to match, enabling automatic ledger-level cleanup.
 pub fn put_share_allowance_with_expiry(
     e: &Env,
     owner: &Address,
     spender: &Address,
-    val: i128,
-    _expiration_ledger: u32,
+    amount: i128,
+    expiration_ledger: u32,
 ) {
-    // Store the amount; expiration logic can be enforced off-chain or via
-    // additional TTL machinery if needed.  For parity with the Solidity
-    // version (which has no on-chain allowance expiry either) we store
-    // only the amount.
-    put_share_allowance(e, owner, spender, val);
+    let key = DataKey::Allowance(owner.clone(), spender.clone());
+    e.storage()
+        .persistent()
+        .set(&key, &AllowanceData { amount, expiration_ledger });
+    // Align the persistent TTL with the expiration so Soroban's archival
+    // mechanism cleans up the entry automatically once it expires.
+    let current = e.ledger().sequence();
+    if expiration_ledger >= current {
+        let live_for = expiration_ledger - current + 1;
+        e.storage()
+            .persistent()
+            .extend_ttl(&key, live_for, live_for);
+    }
 }
 
 pub fn get_user_deposited(e: &Env, addr: &Address) -> i128 {

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_token.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_token.rs
@@ -1,7 +1,7 @@
 extern crate std;
 
 use soroban_sdk::{
-    testutils::Address as _,
+    testutils::{Address as _, Ledger},
     token::StellarAssetClient,
     Address, Env, String,
 };
@@ -28,6 +28,7 @@ fn default_params(env: &Env, admin: &Address, asset: &Address) -> InitParams {
         min_deposit: 1_000_i128,
         max_deposit_per_user: 0_i128,
         early_redemption_fee_bps: 100_u32,
+        funding_deadline: 0_u64,
         rwa_name: String::from_str(env, "Test RWA"),
         rwa_symbol: String::from_str(env, "TRWA"),
         rwa_document_uri: String::from_str(env, "https://test.com"),
@@ -290,4 +291,49 @@ fn test_burn_insufficient_balance_panics() {
 
     give_shares(&env, &vault_id, &alice, 100_i128);
     client.burn(&alice, &200_i128); // more than alice holds
+}
+
+// ─── Allowance expiration ──────────────────────────────────────────────────────
+
+/// allowance() returns 0 once the ledger sequence advances past expiration_ledger.
+#[test]
+fn test_allowance_returns_zero_after_expiration() {
+    let (env, vault_id, _, _) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let alice = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    // Approve with an expiry 10 ledgers from now.
+    let current = env.ledger().sequence();
+    let expiry = current + 10;
+    client.approve(&alice, &spender, &500_i128, &expiry);
+    assert_eq!(client.allowance(&alice, &spender), 500_i128);
+
+    // Advance the ledger past the expiration.
+    env.ledger().set_sequence_number(expiry + 1);
+    assert_eq!(client.allowance(&alice, &spender), 0_i128);
+}
+
+/// transfer_from panics when the allowance has expired, even if the raw
+/// storage amount is non-zero.
+#[test]
+#[should_panic]
+fn test_transfer_from_expired_allowance_panics() {
+    let (env, vault_id, _, _) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    give_shares(&env, &vault_id, &alice, 1_000_i128);
+
+    // Approve with an expiry 5 ledgers from now.
+    let expiry = env.ledger().sequence() + 5;
+    client.approve(&alice, &spender, &600_i128, &expiry);
+
+    // Advance the ledger past the expiration — allowance is effectively 0.
+    env.ledger().set_sequence_number(expiry + 1);
+
+    // This must panic because get_share_allowance returns 0 for expired allowances.
+    client.transfer_from(&spender, &alice, &bob, &100_i128);
 }


### PR DESCRIPTION
## Summary

Implements on-chain allowance expiration for the SEP-41 share-token interface as required by issue #5.

## Changes

### `storage.rs`
- Added `AllowanceData` struct (`amount: i128`, `expiration_ledger: u32`) decorated with `#[contracttype]`
- `get_share_allowance` now checks `e.ledger().sequence() > expiration_ledger` and returns `0` for expired entries
- `put_share_allowance_with_expiry` stores the full `AllowanceData` and sets the persistent entry TTL to `expiration_ledger - current + 1` ledgers, aligning Soroban's archival cleanup with the expiry
- `put_share_allowance` (spend path) reads back the stored expiration and preserves it when decrementing

### `lib.rs`
- `approve` gains a guard: rejects `amount > 0` with a past `expiration_ledger` (SEP-41 §3.4)
- No change to the public function signature
- `withdraw`, `redeem`, `transfer_from`, `burn_from` automatically benefit — all route through `get_share_allowance`

### `test_token.rs`
- Registered the module in `lib.rs`
- Fixed `default_params` helper to include `funding_deadline` field added by the prior feature
- Added `test_allowance_returns_zero_after_expiration`: approves with `+10` ledger expiry, advances past it, asserts `allowance() == 0`
- Added `test_transfer_from_expired_allowance_panics`: verifies `transfer_from` panics when allowance has expired

## Definition of Done

- [x] Allowance expiration is stored and enforced on read
- [x] `allowance()` returns 0 for expired allowances
- [x] Tests validate expiry behavior (2 new tests)
- [x] No change to the public function signature of `approve`
- [x] 74 tests pass, 0 failures (`cargo test --package single_rwa_vault`)

Closes #5