### PR TITLE
replace panic with panic with error

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
@@ -37,4 +37,8 @@ pub enum Error {
     FeeTooHigh = 22,
     /// Price aggregator is not supported or not recognised.
     AggregatorNotSupported = 23,
+    /// The specified redemption request ID is invalid or not found.
+    InvalidRedemptionRequest = 24,
+    /// Operation or component is not supported.
+    NotSupported = 25,
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -268,7 +268,7 @@ impl SingleRWAVault {
             let allowance = get_share_allowance(e, &owner, &caller);
             let shares_needed = preview_withdraw(e, assets);
             if allowance < shares_needed {
-                panic!("insufficient allowance");
+                panic_with_error!(e, Error::InsufficientAllowance);
             }
             // --- Effects ---
             put_share_allowance(e, &owner, &caller, allowance - shares_needed);
@@ -313,7 +313,7 @@ impl SingleRWAVault {
         if caller != owner {
             let allowance = get_share_allowance(e, &owner, &caller);
             if allowance < shares {
-                panic!("insufficient allowance");
+                panic_with_error!(e, Error::InsufficientAllowance);
             }
             // --- Effects ---
             put_share_allowance(e, &owner, &caller, allowance - shares);
@@ -749,7 +749,7 @@ impl SingleRWAVault {
         if caller != owner {
             let allowance = get_share_allowance(e, &owner, &caller);
             if allowance < shares {
-                panic!("insufficient allowance");
+                panic_with_error!(e, Error::InsufficientAllowance);
             }
             // --- Effects ---
             put_share_allowance(e, &owner, &caller, allowance - shares);
@@ -793,7 +793,7 @@ impl SingleRWAVault {
             panic_with_error!(e, Error::ZeroAmount);
         }
         if get_share_balance(e, &caller) < shares {
-            panic!("insufficient shares");
+            panic_with_error!(e, Error::InsufficientBalance);
         }
 
         let id = get_redemption_counter(e) + 1;
@@ -824,7 +824,7 @@ impl SingleRWAVault {
 
         let mut req = get_redemption_request(e, request_id);
         if req.processed {
-            panic!("already processed");
+            panic_with_error!(e, Error::AlreadyProcessed);
         }
 
         // --- Effects ---
@@ -855,7 +855,7 @@ impl SingleRWAVault {
         caller.require_auth();
         require_operator(e, &caller);
         if fee_bps > 1000 {
-            panic!("fee too high");
+            panic_with_error!(e, Error::FeeTooHigh);
         }
         put_early_redemption_fee_bps(e, fee_bps);
         emit_early_redemption_fee_set(e, fee_bps);
@@ -1085,7 +1085,7 @@ impl SingleRWAVault {
         update_user_snapshot(e, &to);
         let allowance = get_share_allowance(e, &from, &spender);
         if allowance < amount {
-            panic!("insufficient allowance");
+            panic_with_error!(e, Error::InsufficientAllowance);
         }
         put_share_allowance(e, &from, &spender, allowance - amount);
         spend_share_balance(e, &from, amount);
@@ -1105,7 +1105,7 @@ impl SingleRWAVault {
         spender.require_auth();
         let allowance = get_share_allowance(e, &from, &spender);
         if allowance < amount {
-            panic!("insufficient allowance");
+            panic_with_error!(e, Error::InsufficientAllowance);
         }
         put_share_allowance(e, &from, &spender, allowance - amount);
         _burn(e, &from, amount);
@@ -1203,7 +1203,7 @@ fn _mint(e: &Env, to: &Address, amount: i128) {
 fn _burn(e: &Env, from: &Address, amount: i128) {
     let bal = get_share_balance(e, from);
     if bal < amount {
-        panic!("insufficient balance");
+        panic_with_error!(e, Error::InsufficientBalance);
     }
     put_share_balance(e, from, bal - amount);
     put_total_supply(e, get_total_supply(e) - amount);
@@ -1213,7 +1213,7 @@ fn _burn(e: &Env, from: &Address, amount: i128) {
 fn spend_share_balance(e: &Env, from: &Address, amount: i128) {
     let bal = get_share_balance(e, from);
     if bal < amount {
-        panic!("insufficient balance");
+        panic_with_error!(e, Error::InsufficientBalance);
     }
     put_share_balance(e, from, bal - amount);
     bump_balance(e, from);

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -12,8 +12,9 @@
 //! INSTANCE_BUMP_AMOUNT  ≈ 30 days
 //! BALANCE_BUMP_AMOUNT   ≈ 60 days
 
-use soroban_sdk::{contracttype, Address, Env, String};
+use soroban_sdk::{contracttype, panic_with_error, Address, Env, String};
 
+use crate::errors::Error;
 use crate::types::{RedemptionRequest, VaultState};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -508,7 +509,7 @@ pub fn get_redemption_request(e: &Env, id: u32) -> RedemptionRequest {
     e.storage()
         .persistent()
         .get(&DataKey::RedemptionRequest(id))
-        .unwrap_or_else(|| panic!("invalid request"))
+        .unwrap_or_else(|| panic_with_error!(e, Error::InvalidRedemptionRequest))
 }
 pub fn put_redemption_request(e: &Env, id: u32, req: RedemptionRequest) {
     e.storage()

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
@@ -278,9 +278,9 @@ fn test_set_early_redemption_fee() {
     assert_eq!(vault.early_redemption_fee_bps(), 0u32);
 }
 
-/// Setting early redemption fee above 1000 bps (10%) must panic.
+/// Setting early redemption fee above 1000 bps (10%) must panic with Error::FeeTooHigh (22).
 #[test]
-#[should_panic(expected = "fee too high")]
+#[should_panic(expected = "Error(Contract, #22)")]
 fn test_set_early_redemption_fee_too_high_panics() {
     let env = Env::default();
     env.mock_all_auths();

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_kyc_verified_succeeds.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_kyc_verified_succeeds.1.json
@@ -328,16 +328,33 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiration_ledger"
+                      },
+                      "val": {
+                        "u32": 999999
+                      }
+                    }
+                  ]
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          1000000
         ]
       ],
       [

--- a/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_non_kyc_rejected.1.json
+++ b/soroban-contracts/contracts/single_rwa_vault/test_snapshots/tests/test_transfer_from_to_non_kyc_rejected.1.json
@@ -287,16 +287,33 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000000
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiration_ledger"
+                      },
+                      "val": {
+                        "u32": 999999
+                      }
+                    }
+                  ]
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          1000000
         ]
       ],
       [

--- a/soroban-contracts/contracts/vault_factory/src/errors.rs
+++ b/soroban-contracts/contracts/vault_factory/src/errors.rs
@@ -10,4 +10,6 @@ pub enum Error {
     NotAuthorized      = 3,
     /// Vault must be set inactive before it can be removed.
     VaultIsActive      = 4,
+    /// Requested operation is not supported.
+    NotSupported       = 5,
 }

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -161,13 +161,13 @@ impl VaultFactory {
 
     /// Aggregator vault is not supported (mirrors the Solidity version).
     pub fn create_aggregator_vault(
-        _e: &Env,
+        e: &Env,
         _caller: Address,
         _asset: Address,
         _name: String,
         _symbol: String,
     ) -> Address {
-        panic!("Aggregator vault not supported");
+        panic_with_error!(e, Error::NotSupported);
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/vault_factory/src/tests.rs
+++ b/soroban-contracts/contracts/vault_factory/src/tests.rs
@@ -1,13 +1,12 @@
 extern crate std;
 
 use soroban_sdk::{
-    testutils::Address as _,
-    Address, BytesN, Env, String,
+    testutils::{Address as _, Events as _},
+    Address, BytesN, Env, IntoVal, String,
 };
 
 use crate::{
-    errors::Error,
-    storage::{delete_vault_info, get_all_vaults, get_single_rwa_vaults, get_vault_info,
+    storage::{get_all_vaults, get_single_rwa_vaults, get_vault_info,
               push_all_vaults, push_single_rwa_vaults, put_vault_info},
     types::{VaultInfo, VaultType},
     VaultFactory, VaultFactoryClient,
@@ -189,8 +188,7 @@ fn test_remove_vault_emits_event() {
     let (contract, topics, _data) = last;
     assert_eq!(contract, factory_id);
     // Verify the first topic is the "v_remove" symbol
-    let first_topic: soroban_sdk::Val = topics.get(0).unwrap();
-    let expected: soroban_sdk::Val =
-        soroban_sdk::symbol_short!("v_remove").into_val(&e);
+    let first_topic: soroban_sdk::Symbol = topics.get(0).unwrap().into_val(&e);
+    let expected = soroban_sdk::symbol_short!("v_remove");
     assert_eq!(first_topic, expected);
 }


### PR DESCRIPTION
I have refactored the 
single_rwa_vault
 and vault_factory contracts to replace raw panic! calls with proper panic_with_error! macros and specific error variants.

Changes Made
1. New Error Variants
Added InvalidRedemptionRequest and NotSupported to 
single_rwa_vault/src/errors.rs
.
Added NotSupported to 
vault_factory/src/errors.rs
.
2. Implementation Refactoring
single_rwa_vault/src/lib.rs
: Replaced all 10 panic! calls with panic_with_error!.
single_rwa_vault/src/storage.rs
: Replaced panic!("invalid request") with panic_with_error!.
vault_factory/src/lib.rs
: Replaced panic!("Aggregator vault not supported") with panic_with_error!.
3. Test Suite Updates
vault_factory/src/tests.rs
:
Imported missing Events and IntoVal traits.
Fixed Val comparison by converting it to Symbol before assert_eq!.
Cleaned up unused imports.
single_rwa_vault/src/test_redemption.rs
:
Updated 
test_set_early_redemption_fee_too_high_panics
 to expect Error(Contract, #22) instead of a string message.


Closes #17 