### PR TITLE
feat: add unit tests for vault lifecycle transitions

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -8,6 +8,8 @@ mod types;
 
 #[cfg(test)]
 mod test_funding_deadline;
+#[cfg(test)]
+mod test_lifecycle;
 
 pub use crate::types::*;
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_lifecycle.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_lifecycle.rs
@@ -1,0 +1,185 @@
+//! Unit tests for SingleRWAVault lifecycle transitions.
+//!
+//! Verifies the state machine: Funding -> Active -> Matured.
+//! Transitions require preconditions (funding target, maturity date) and guards (operator-only).
+
+use crate::test_helpers::{setup_with_kyc_bypass, mint_usdc, advance_time};
+use crate::{VaultState, Error};
+use soroban_sdk::{testutils::{Events, Ledger}, symbol_short, vec, IntoVal};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy Paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_activate_vault_transitions_to_active() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    // 1. Initial state is Funding
+    assert_eq!(v.vault_state(), VaultState::Funding);
+
+    // 2. Meet funding target (100 USDC in default_params)
+    let amount = 100_000_000i128;
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, amount);
+    v.deposit(&ctx.user, &amount, &ctx.user);
+
+    assert!(v.is_funding_target_met());
+
+    // 3. Activate by operator
+    v.activate_vault(&ctx.operator);
+
+    // 4. Verify state and event
+    assert_eq!(v.vault_state(), VaultState::Active);
+
+    let last_event = ctx.env.events().all().last().unwrap();
+    assert_eq!(
+        last_event,
+        (
+            ctx.vault_id.clone(),
+            (symbol_short!("st_chg"),).into_val(&ctx.env),
+            (VaultState::Funding, VaultState::Active).into_val(&ctx.env)
+        )
+    );
+}
+
+#[test]
+fn test_mature_vault_transitions_to_matured() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    // 1. Activate vault
+    let amount = 100_000_000i128;
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, amount);
+    v.deposit(&ctx.user, &amount, &ctx.user);
+    v.activate_vault(&ctx.operator);
+
+    // 2. Advance time past maturity date
+    let maturity = v.maturity_date();
+    ctx.env.ledger().with_mut(|li| li.timestamp = maturity + 1);
+
+    // 3. Mature by operator
+    v.mature_vault(&ctx.operator);
+
+    // 4. Verify state and event
+    assert_eq!(v.vault_state(), VaultState::Matured);
+
+    let last_event = ctx.env.events().all().last().unwrap();
+    assert_eq!(
+        last_event,
+        (
+            ctx.vault_id.clone(),
+            (symbol_short!("st_chg"),).into_val(&ctx.env),
+            (VaultState::Active, VaultState::Matured).into_val(&ctx.env)
+        )
+    );
+}
+
+#[test]
+fn test_set_maturity_date() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    let new_maturity = 2_000_000_000u64;
+    v.set_maturity_date(&ctx.operator, &new_maturity);
+
+    assert_eq!(v.maturity_date(), new_maturity);
+
+    let last_event = ctx.env.events().all().last().unwrap();
+    assert_eq!(
+        last_event,
+        (
+            ctx.vault_id.clone(),
+            (symbol_short!("mat_set"),).into_val(&ctx.env),
+            new_maturity.into_val(&ctx.env)
+        )
+    );
+}
+
+#[test]
+fn test_is_funding_target_met() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    let target = v.funding_target();
+    
+    // Not met initially
+    assert!(!v.is_funding_target_met());
+
+    // Deposit exactly the target
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, target);
+    v.deposit(&ctx.user, &target, &ctx.user);
+
+    assert!(v.is_funding_target_met());
+}
+
+#[test]
+fn test_time_to_maturity() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    let maturity = 10_000u64;
+    v.set_maturity_date(&ctx.operator, &maturity);
+    
+    ctx.env.ledger().with_mut(|li| li.timestamp = 1000);
+    assert_eq!(v.time_to_maturity(), 9000);
+
+    advance_time(&ctx.env, 5000);
+    assert_eq!(v.time_to_maturity(), 4000);
+
+    advance_time(&ctx.env, 4000);
+    assert_eq!(v.time_to_maturity(), 0);
+
+    advance_time(&ctx.env, 1000);
+    assert_eq!(v.time_to_maturity(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #10)")] // FundingTargetNotMet
+fn test_activate_insufficient_funding() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    // Deposit less than target (100 USDC)
+    let amount = 50_000_000i128;
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, amount);
+    v.deposit(&ctx.user, &amount, &ctx.user);
+
+    assert!(!v.is_funding_target_met());
+
+    // Attempt activation should panic
+    v.activate_vault(&ctx.operator);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #11)")] // NotMatured
+fn test_mature_premature() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    // Activate vault
+    let amount = 100_000_000i128;
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, amount);
+    v.deposit(&ctx.user, &amount, &ctx.user);
+    v.activate_vault(&ctx.operator);
+
+    // Try to mature before maturity date
+    let maturity = v.maturity_date();
+    ctx.env.ledger().with_mut(|li| li.timestamp = maturity - 1);
+
+    v.mature_vault(&ctx.operator);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #3)")] // NotAuthorized
+fn test_operator_only_guards() {
+    let ctx = setup_with_kyc_bypass();
+    let v = ctx.vault();
+
+    // Non-operator (user) tries to set maturity date
+    v.set_maturity_date(&ctx.user, &2_000_000_000u64);
+}


### PR DESCRIPTION
- Changes :
  - Implemented test_lifecycle.rs with 8 test cases covering all lifecycle transitions and guards.
  - Registered the test module in lib.rs .
- Closes : #11
- Closes : #20 
- Closes : #18 
- Closes: #10 