### PR TITLE
chore: Add Pagination to Factory Vault Query Functions

### DIFF
--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -197,7 +197,7 @@ impl VaultFactory {
             panic_with_error!(e, Error::VaultIsActive);
         }
 
-        // Remove from both registry lists
+        // Remove from all registry lists (vault is already inactive — not in ActiveVaults)
         remove_from_all_vaults(e, &vault);
         if info.vault_type == VaultType::SingleRwa {
             remove_from_single_rwa_vaults(e, &vault);
@@ -216,6 +216,14 @@ impl VaultFactory {
 
         let mut info = get_vault_info(e, &vault)
             .unwrap_or_else(|| panic_not_found(e));
+
+        // Keep ActiveVaults in sync when the flag changes.
+        if active && !info.active {
+            push_active_vaults(e, vault.clone());
+        } else if !active && info.active {
+            remove_from_active_vaults(e, &vault);
+        }
+
         info.active = active;
         put_vault_info(e, &vault, info);
         emit_vault_status_changed(e, vault, active);
@@ -226,10 +234,17 @@ impl VaultFactory {
     // View functions
     // ─────────────────────────────────────────────────────────────────
 
+    /// Returns every registered vault address.
+    ///
+    /// **Note:** loads the full vault list from persistent storage.
+    /// For large registries prefer `get_vaults_paginated`.
     pub fn get_all_vaults(e: &Env) -> Vec<Address> {
         get_all_vaults(e)
     }
 
+    /// Returns every registered SingleRWA vault address.
+    ///
+    /// **Note:** loads the full list from persistent storage.
     pub fn get_single_rwa_vaults(e: &Env) -> Vec<Address> {
         get_single_rwa_vaults(e)
     }
@@ -242,22 +257,53 @@ impl VaultFactory {
         get_vault_info(e, &vault).is_some()
     }
 
+    /// Returns the current number of registered vaults.
+    ///
+    /// Reads a dedicated counter from instance storage — does not load the
+    /// full vault list.
     pub fn get_vault_count(e: &Env) -> u32 {
-        get_all_vaults(e).len()
+        get_vault_count(e)
     }
 
+    /// Returns all vaults whose `active` flag is set.
     pub fn get_active_vaults(e: &Env) -> Vec<Address> {
+        get_active_vaults(e)
+    }
+
+    /// Returns a page of vault addresses from the full registry.
+    ///
+    /// `offset` is zero-based. Returns an empty vec when `offset >= total`.
+    /// Returns fewer than `limit` entries when the end of the list is reached.
+    pub fn get_vaults_paginated(e: &Env, offset: u32, limit: u32) -> Vec<Address> {
         let all = get_all_vaults(e);
-        let mut active: Vec<Address> = Vec::new(e);
-        for i in 0..all.len() {
-            let addr = all.get(i).unwrap();
-            if let Some(info) = get_vault_info(e, &addr) {
-                if info.active {
-                    active.push_back(addr);
-                }
-            }
+        let total = all.len();
+        let mut result: Vec<Address> = Vec::new(e);
+        if offset >= total || limit == 0 {
+            return result;
         }
-        active
+        let end = (offset + limit).min(total);
+        for i in offset..end {
+            result.push_back(all.get(i).unwrap());
+        }
+        result
+    }
+
+    /// Returns a page of *active* vault addresses.
+    ///
+    /// `offset` is zero-based within the active-vault list. Returns an empty
+    /// vec when `offset >= active count` or `limit == 0`.
+    pub fn get_active_vaults_paginated(e: &Env, offset: u32, limit: u32) -> Vec<Address> {
+        let active = get_active_vaults(e);
+        let total = active.len();
+        let mut result: Vec<Address> = Vec::new(e);
+        if offset >= total || limit == 0 {
+            return result;
+        }
+        let end = (offset + limit).min(total);
+        for i in offset..end {
+            result.push_back(active.get(i).unwrap());
+        }
+        result
     }
 
     pub fn aggregator_vault(e: &Env) -> Option<Address> {
@@ -395,6 +441,7 @@ impl VaultFactory {
         put_vault_info(e, &vault_addr, info);
         push_all_vaults(e, vault_addr.clone());
         push_single_rwa_vaults(e, vault_addr.clone());
+        push_active_vaults(e, vault_addr.clone()); // new vaults start active
 
         emit_vault_created(e, vault_addr.clone(), VaultType::SingleRwa, name, e.current_contract_address());
 

--- a/soroban-contracts/contracts/vault_factory/src/storage.rs
+++ b/soroban-contracts/contracts/vault_factory/src/storage.rs
@@ -33,7 +33,9 @@ pub enum DataKey {
     AggregatorVault,
     AllVaults,
     SingleRwaVaults,
+    ActiveVaults,
     VaultInfo(Address),
+    VaultCount,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -132,6 +134,21 @@ pub fn put_aggregator_vault(e: &Env, val: Address) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Vault count counter (Instance — same lifetime as other global config)
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub fn get_vault_count(e: &Env) -> u32 {
+    e.storage()
+        .instance()
+        .get(&DataKey::VaultCount)
+        .unwrap_or(0)
+}
+
+fn put_vault_count(e: &Env, val: u32) {
+    e.storage().instance().set(&DataKey::VaultCount, &val);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Vault lists (Persistent)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -147,6 +164,7 @@ pub fn push_all_vaults(e: &Env, addr: Address) {
     vaults.push_back(addr);
     e.storage().persistent().set(&DataKey::AllVaults, &vaults);
     bump_persist(e, &DataKey::AllVaults);
+    put_vault_count(e, get_vault_count(e) + 1);
 }
 
 pub fn get_single_rwa_vaults(e: &Env) -> Vec<Address> {
@@ -165,6 +183,33 @@ pub fn push_single_rwa_vaults(e: &Env, addr: Address) {
     bump_persist(e, &DataKey::SingleRwaVaults);
 }
 
+pub fn get_active_vaults(e: &Env) -> Vec<Address> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::ActiveVaults)
+        .unwrap_or_else(|| vec![e])
+}
+
+pub fn push_active_vaults(e: &Env, addr: Address) {
+    let mut vaults = get_active_vaults(e);
+    vaults.push_back(addr);
+    e.storage().persistent().set(&DataKey::ActiveVaults, &vaults);
+    bump_persist(e, &DataKey::ActiveVaults);
+}
+
+pub fn remove_from_active_vaults(e: &Env, vault: &Address) {
+    let vaults = get_active_vaults(e);
+    let mut updated: Vec<Address> = Vec::new(e);
+    for i in 0..vaults.len() {
+        let addr = vaults.get(i).unwrap();
+        if addr != *vault {
+            updated.push_back(addr);
+        }
+    }
+    e.storage().persistent().set(&DataKey::ActiveVaults, &updated);
+    bump_persist(e, &DataKey::ActiveVaults);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // VaultInfo (Persistent, keyed by vault address)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -181,7 +226,7 @@ pub fn put_vault_info(e: &Env, vault: &Address, info: VaultInfo) {
     bump_persist(e, &key);
 }
 
-/// Remove a vault address from the AllVaults list.
+/// Remove a vault address from the AllVaults list and decrement the counter.
 pub fn remove_from_all_vaults(e: &Env, vault: &Address) {
     let vaults = get_all_vaults(e);
     let mut updated: Vec<Address> = Vec::new(e);
@@ -193,6 +238,10 @@ pub fn remove_from_all_vaults(e: &Env, vault: &Address) {
     }
     e.storage().persistent().set(&DataKey::AllVaults, &updated);
     bump_persist(e, &DataKey::AllVaults);
+    let count = get_vault_count(e);
+    if count > 0 {
+        put_vault_count(e, count - 1);
+    }
 }
 
 /// Remove a vault address from the SingleRwaVaults list.

--- a/soroban-contracts/contracts/vault_factory/src/tests.rs
+++ b/soroban-contracts/contracts/vault_factory/src/tests.rs
@@ -6,8 +6,9 @@ use soroban_sdk::{
 };
 
 use crate::{
-    storage::{get_all_vaults, get_single_rwa_vaults, get_vault_info,
-              push_all_vaults, push_single_rwa_vaults, put_vault_info},
+    storage::{get_active_vaults, get_all_vaults, get_single_rwa_vaults, get_vault_count,
+              get_vault_info, push_active_vaults, push_all_vaults, push_single_rwa_vaults,
+              put_vault_info},
     types::{VaultInfo, VaultType},
     VaultFactory, VaultFactoryClient,
 };
@@ -56,6 +57,9 @@ fn inject_vault(e: &Env, factory_id: &Address, active: bool) -> Address {
         put_vault_info(e, &vault, info);
         push_all_vaults(e, vault.clone());
         push_single_rwa_vaults(e, vault.clone());
+        if active {
+            push_active_vaults(e, vault.clone());
+        }
     });
 
     vault
@@ -64,6 +68,215 @@ fn inject_vault(e: &Env, factory_id: &Address, active: bool) -> Address {
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ─── ActiveVaults list ────────────────────────────────────────────────────────
+
+/// set_vault_status keeps ActiveVaults in sync: deactivating removes,
+/// reactivating re-adds.
+#[test]
+fn test_set_vault_status_updates_active_list() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    let vault = inject_vault(&e, &factory_id, true);
+
+    // Initially active — should appear in ActiveVaults.
+    e.as_contract(&factory_id, || {
+        assert!(get_active_vaults(&e).contains(vault.clone()));
+    });
+
+    // Deactivate — must be removed from ActiveVaults.
+    client.set_vault_status(&admin, &vault, &false);
+    e.as_contract(&factory_id, || {
+        assert!(!get_active_vaults(&e).contains(vault.clone()));
+    });
+
+    // Reactivate — must be re-added.
+    client.set_vault_status(&admin, &vault, &true);
+    e.as_contract(&factory_id, || {
+        assert!(get_active_vaults(&e).contains(vault.clone()));
+    });
+}
+
+/// get_active_vaults returns only the active list directly (O(1) read).
+#[test]
+fn test_get_active_vaults_uses_dedicated_list() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    let a = inject_vault(&e, &factory_id, true);
+    inject_vault(&e, &factory_id, false); // inactive
+
+    let active = client.get_active_vaults();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active.get(0).unwrap(), a);
+}
+
+// ─── get_vault_count ──────────────────────────────────────────────────────────
+
+/// get_vault_count reflects the live counter without loading the full list.
+#[test]
+fn test_get_vault_count_tracks_adds_and_removes() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    assert_eq!(client.get_vault_count(), 0);
+
+    let v1 = inject_vault(&e, &factory_id, false);
+    assert_eq!(client.get_vault_count(), 1);
+
+    let v2 = inject_vault(&e, &factory_id, false);
+    assert_eq!(client.get_vault_count(), 2);
+
+    client.remove_vault(&admin, &v1);
+    assert_eq!(client.get_vault_count(), 1);
+
+    client.remove_vault(&admin, &v2);
+    assert_eq!(client.get_vault_count(), 0);
+}
+
+/// Counter in instance storage matches the list length at all times.
+#[test]
+fn test_vault_count_matches_list_length() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    for _ in 0..5 {
+        inject_vault(&e, &factory_id, true);
+    }
+
+    e.as_contract(&factory_id, || {
+        assert_eq!(get_vault_count(&e) as usize, get_all_vaults(&e).len() as usize);
+    });
+}
+
+// ─── get_vaults_paginated ─────────────────────────────────────────────────────
+
+/// First page returns up to `limit` items starting at offset 0.
+#[test]
+fn test_get_vaults_paginated_first_page() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    let mut all_vaults = soroban_sdk::Vec::new(&e);
+    for _ in 0..5 {
+        all_vaults.push_back(inject_vault(&e, &factory_id, true));
+    }
+
+    let page = client.get_vaults_paginated(&0, &3);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap(), all_vaults.get(0).unwrap());
+    assert_eq!(page.get(2).unwrap(), all_vaults.get(2).unwrap());
+}
+
+/// Second page returns the remaining items.
+#[test]
+fn test_get_vaults_paginated_second_page() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    let mut all_vaults = soroban_sdk::Vec::new(&e);
+    for _ in 0..5 {
+        all_vaults.push_back(inject_vault(&e, &factory_id, true));
+    }
+
+    let page = client.get_vaults_paginated(&3, &3);
+    assert_eq!(page.len(), 2); // only 2 items remain after offset 3
+    assert_eq!(page.get(0).unwrap(), all_vaults.get(3).unwrap());
+    assert_eq!(page.get(1).unwrap(), all_vaults.get(4).unwrap());
+}
+
+/// Offset past the end of the list returns an empty vec.
+#[test]
+fn test_get_vaults_paginated_offset_past_end() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    inject_vault(&e, &factory_id, true);
+    inject_vault(&e, &factory_id, true);
+
+    let page = client.get_vaults_paginated(&10, &5);
+    assert_eq!(page.len(), 0);
+}
+
+/// limit = 0 always returns an empty vec.
+#[test]
+fn test_get_vaults_paginated_zero_limit() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    inject_vault(&e, &factory_id, true);
+
+    let page = client.get_vaults_paginated(&0, &0);
+    assert_eq!(page.len(), 0);
+}
+
+// ─── get_active_vaults_paginated ──────────────────────────────────────────────
+
+/// Only active vaults are included; offset/limit apply to the filtered set.
+#[test]
+fn test_get_active_vaults_paginated_filters_inactive() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    let a1 = inject_vault(&e, &factory_id, true);
+    inject_vault(&e, &factory_id, false); // inactive
+    let a2 = inject_vault(&e, &factory_id, true);
+    inject_vault(&e, &factory_id, false); // inactive
+    let a3 = inject_vault(&e, &factory_id, true);
+
+    // All 3 active vaults with a generous limit.
+    let page = client.get_active_vaults_paginated(&0, &10);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap(), a1);
+    assert_eq!(page.get(1).unwrap(), a2);
+    assert_eq!(page.get(2).unwrap(), a3);
+}
+
+/// Offset skips active vaults only (inactive ones are invisible to pagination).
+#[test]
+fn test_get_active_vaults_paginated_offset_skips_active() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, _) = setup_factory(&e);
+    let factory_id = client.address.clone();
+
+    inject_vault(&e, &factory_id, true);  // active[0] — skipped by offset=1
+    let a2 = inject_vault(&e, &factory_id, true);  // active[1]
+    inject_vault(&e, &factory_id, false); // inactive — not counted
+
+    let page = client.get_active_vaults_paginated(&1, &5);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0).unwrap(), a2);
+}
 
 /// Admin successfully removes an inactive vault.
 #[test]


### PR DESCRIPTION
Add ActiveVaults list and fix O(n) active vault pagination

Previously, get_active_vaults and get_active_vaults_paginated worked by loading the entire AllVaults list from persistent storage and then doing a separate get_vault_info read for every entry to check the active flag — O(n) storage reads regardless of how many results were actually needed. This made pagination pointless from a cost perspective: a request for page 2 of 10 still paid the full scan cost of all registered vaults. The fix introduces a dedicated ActiveVaults persistent list maintained in parallel with AllVaults. _create_single_rwa_vault pushes to it on creation, and set_vault_status adds or removes from it whenever the flag changes, keeping the list always consistent with VaultInfo.

With the dedicated list in place, both get_active_vaults and get_active_vaults_paginated now read only from ActiveVaults — no VaultInfo lookups, no full-list scan. get_active_vaults_paginated is now structurally identical to get_vaults_paginated: a simple O(limit) slice. Two new tests cover the core invariant — that set_vault_status keeps ActiveVaults in sync through deactivation and reactivation cycles — and confirm that get_active_vaults excludes inactive vaults without scanning AllVaults.

closes #26 