### PR TITLE
Restrict claim_yield to Active and Matured vault states

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -494,7 +494,7 @@ impl SingleRWAVault {
         // --- Checks ---
         acquire_lock(e);
         require_not_paused(e);
-        require_not_closed(e);
+        require_active_or_matured(e);
         require_not_blacklisted(e, &caller);
 
         let amount = Self::pending_yield(e, caller.clone());
@@ -531,7 +531,7 @@ impl SingleRWAVault {
         // --- Checks ---
         acquire_lock(e);
         require_not_paused(e);
-        require_not_closed(e);
+        require_active_or_matured(e);
         require_not_blacklisted(e, &caller);
 
         if get_has_claimed_epoch(e, &caller, epoch) {

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_vault_state_guards.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_vault_state_guards.rs
@@ -260,3 +260,68 @@ fn test_redeem_during_matured_succeeds() {
     assert!(user_balance_after > user_balance_before);
     assert_eq!(vault.balance(&user), 0);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// claim_yield — state guard tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// claim_yield during Funding state must panic with Error::InvalidVaultState.
+#[test]
+#[should_panic]
+fn test_claim_yield_during_funding_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, token_id, zkme_id, _admin) = make_vault(&env);
+    let user = Address::generate(&env);
+
+    // Deposit during Funding so user has shares.
+    fund_user(&env, &vault_id, &token_id, &zkme_id, &user, 1_000_000);
+
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    // Vault is still in Funding -- must panic.
+    vault.claim_yield(&user);
+}
+
+/// claim_yield during Active state succeeds (when yield has been distributed).
+#[test]
+fn test_claim_yield_during_active_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, token_id, zkme_id, admin) = make_vault(&env);
+    let user = Address::generate(&env);
+
+    fund_user(&env, &vault_id, &token_id, &zkme_id, &user, 1_000_000);
+    activate(&env, &vault_id, &admin);
+
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let token = MockTokenClient::new(&env, &token_id);
+
+    // Distribute yield so there is something to claim.
+    token.mint(&admin, &500_000);
+    vault.distribute_yield(&admin, &500_000);
+
+    let pending = vault.pending_yield(&user);
+    assert!(pending > 0);
+
+    let claimed = vault.claim_yield(&user);
+    assert_eq!(claimed, pending);
+}
+
+/// claim_yield_for_epoch during Funding state must panic.
+#[test]
+#[should_panic]
+fn test_claim_yield_for_epoch_during_funding_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, token_id, zkme_id, _admin) = make_vault(&env);
+    let user = Address::generate(&env);
+
+    fund_user(&env, &vault_id, &token_id, &zkme_id, &user, 1_000_000);
+
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    // Vault is still in Funding -- must panic.
+    vault.claim_yield_for_epoch(&user, &1);
+}


### PR DESCRIPTION
## Summary

- Replace `require_not_closed` with `require_active_or_matured` in `claim_yield` and `claim_yield_for_epoch` so claiming is only allowed when the vault is Active or Matured
- Reuses the existing `require_active_or_matured` guard helper (no new code needed for the guard itself)
- View functions (`pending_yield`, `pending_yield_for_epoch`) remain callable in any state for frontend transparency
- Add three tests: claiming panics during Funding, claiming succeeds during Active, and per-epoch claiming panics during Funding

## Test plan

- [x] Contract compiles cleanly
- [x] `test_claim_yield_during_funding_panics` verifies rejection during Funding
- [x] `test_claim_yield_during_active_succeeds` verifies claiming works in Active state with distributed yield
- [x] `test_claim_yield_for_epoch_during_funding_panics` verifies per-epoch rejection during Funding

Closes #73