### PR TITLE
Add batch size limit to batch_create_vaults

### DIFF
--- a/soroban-contracts/contracts/vault_factory/src/errors.rs
+++ b/soroban-contracts/contracts/vault_factory/src/errors.rs
@@ -14,4 +14,6 @@ pub enum Error {
     NotSupported       = 5,
     /// Invalid initialization parameters provided.
     InvalidInitParams  = 6,
+    /// Batch size exceeds the maximum allowed limit.
+    BatchTooLarge      = 7,
 }

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -23,6 +23,11 @@ use crate::errors::Error;
 use crate::events::*;
 use single_rwa_vault;
 
+/// Maximum number of vaults that can be created in a single batch call.
+/// Contract deployment is one of the most expensive Soroban operations;
+/// exceeding this limit risks exhausting the transaction's CPU budget.
+const MAX_BATCH_SIZE: u32 = 10;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Contract
 // ─────────────────────────────────────────────────────────────────────────────
@@ -128,6 +133,9 @@ impl VaultFactory {
     }
 
     /// Batch-create multiple vaults in one transaction.
+    ///
+    /// The batch size is capped at `MAX_BATCH_SIZE` (10) to prevent gas
+    /// exhaustion from unbounded contract deployments.
     pub fn batch_create_vaults(
         e: &Env,
         caller: Address,
@@ -135,6 +143,10 @@ impl VaultFactory {
     ) -> Vec<Address> {
         caller.require_auth();
         require_operator_or_admin(e, &caller);
+
+        if params.len() > MAX_BATCH_SIZE {
+            panic_with_error!(e, Error::BatchTooLarge);
+        }
 
         let mut vaults: Vec<Address> = Vec::new(e);
         for i in 0..params.len() {

--- a/soroban-contracts/contracts/vault_factory/src/tests.rs
+++ b/soroban-contracts/contracts/vault_factory/src/tests.rs
@@ -406,3 +406,94 @@ fn test_remove_vault_emits_event() {
     let expected = soroban_sdk::symbol_short!("v_remove");
     assert_eq!(first_symbol, expected);
 }
+
+// ─── batch_create_vaults size limit ──────────────────────────────────────────
+
+/// batch_create_vaults with more than MAX_BATCH_SIZE (10) entries must panic
+/// with Error::BatchTooLarge (#7).
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_batch_create_vaults_exceeds_limit() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let asset = Address::generate(&e);
+
+    // Build a batch of 11 entries (one over the limit).
+    let mut params: soroban_sdk::Vec<crate::types::BatchVaultParams> = soroban_sdk::Vec::new(&e);
+    for i in 0..11u32 {
+        params.push_back(crate::types::BatchVaultParams {
+            asset: asset.clone(),
+            name: String::from_str(&e, "V"),
+            symbol: String::from_str(&e, "V"),
+            rwa_name: String::from_str(&e, "RWA"),
+            rwa_symbol: String::from_str(&e, "R"),
+            rwa_document_uri: String::from_str(&e, "https://example.com"),
+            rwa_category: String::from_str(&e, "Bond"),
+            expected_apy: 500,
+            maturity_date: 9_999_999_999u64 + i as u64,
+            funding_deadline: 0,
+            funding_target: 0,
+            min_deposit: 0,
+            max_deposit_per_user: 0,
+            early_redemption_fee_bps: 200,
+        });
+    }
+
+    // Must panic with BatchTooLarge.
+    client.batch_create_vaults(&admin, &params);
+}
+
+/// batch_create_vaults at exactly MAX_BATCH_SIZE (10) should not panic
+/// (the limit is inclusive).
+#[test]
+fn test_batch_create_vaults_at_limit_ok() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (client, admin) = setup_factory(&e);
+    let asset = Address::generate(&e);
+
+    let mut params: soroban_sdk::Vec<crate::types::BatchVaultParams> = soroban_sdk::Vec::new(&e);
+    for i in 0..10u32 {
+        params.push_back(crate::types::BatchVaultParams {
+            asset: asset.clone(),
+            name: String::from_str(&e, "V"),
+            symbol: String::from_str(&e, "V"),
+            rwa_name: String::from_str(&e, "RWA"),
+            rwa_symbol: String::from_str(&e, "R"),
+            rwa_document_uri: String::from_str(&e, "https://example.com"),
+            rwa_category: String::from_str(&e, "Bond"),
+            expected_apy: 500,
+            maturity_date: 9_999_999_999u64 + i as u64,
+            funding_deadline: 0,
+            funding_target: 0,
+            min_deposit: 0,
+            max_deposit_per_user: 0,
+            early_redemption_fee_bps: 200,
+        });
+    }
+
+    // Should not panic -- exactly at the limit.
+    // Note: actual deployment will fail because we use a dummy WASM hash,
+    // but the size check passes before deployment starts.
+    // We test only the guard here, not full deployment.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.batch_create_vaults(&admin, &params);
+    }));
+    // The call may still panic due to dummy WASM hash, but NOT with BatchTooLarge (#7).
+    if let Err(e) = result {
+        let msg = if let Some(s) = e.downcast_ref::<std::string::String>() {
+            s.clone()
+        } else if let Some(s) = e.downcast_ref::<&str>() {
+            std::string::String::from(*s)
+        } else {
+            std::string::String::from("")
+        };
+        assert!(
+            !msg.contains("#7"),
+            "batch of 10 should not trigger BatchTooLarge"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MAX_BATCH_SIZE` constant (10) and enforce it at the start of `batch_create_vaults`, panicking with `Error::BatchTooLarge` if exceeded
- Add `BatchTooLarge = 7` variant to the factory error enum
- Add tests verifying the limit is enforced (11 entries panics) and that exactly 10 entries passes the guard

## Test plan

- [x] Contract compiles cleanly (`cargo build`)
- [x] `test_batch_create_vaults_exceeds_limit` verifies panic on 11 entries
- [x] `test_batch_create_vaults_at_limit_ok` verifies 10 entries passes the size check
- [ ] Existing factory tests remain unaffected

Closes #68