### PR TITLE
feat: implement granular RBAC beyond binary admin/operator (#107)

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -4,7 +4,7 @@
 
 use soroban_sdk::{symbol_short, Address, Env, String};
 
-use crate::types::VaultState;
+use crate::types::{Role, VaultState};
 
 pub fn emit_zkme_verifier_updated(e: &Env, old: Address, new: Address) {
     e.events().publish((symbol_short!("zkme_upd"),), (old, new));
@@ -39,6 +39,16 @@ pub fn emit_deposit_limits_updated(e: &Env, min: i128, max: i128) {
 pub fn emit_operator_updated(e: &Env, operator: Address, status: bool) {
     e.events()
         .publish((symbol_short!("op_upd"), operator), status);
+}
+
+/// Emitted when the admin grants a role to an address.
+pub fn emit_role_granted(e: &Env, addr: Address, role: Role) {
+    e.events().publish((symbol_short!("role_grt"), addr), role);
+}
+
+/// Emitted when the admin revokes a role from an address.
+pub fn emit_role_revoked(e: &Env, addr: Address, role: Role) {
+    e.events().publish((symbol_short!("role_rvk"), addr), role);
 }
 
 pub fn emit_emergency_action(e: &Env, paused: bool, reason: String) {

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -161,7 +161,8 @@ impl SingleRWAVault {
 
     pub fn set_zkme_verifier(e: &Env, caller: Address, verifier: Address) {
         caller.require_auth();
-        require_admin(e, &caller);
+        // ComplianceOfficer role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::ComplianceOfficer);
         let old = get_zkme_verifier(e);
         put_zkme_verifier(e, verifier.clone());
         emit_zkme_verifier_updated(e, old, verifier);
@@ -170,7 +171,8 @@ impl SingleRWAVault {
 
     pub fn set_cooperator(e: &Env, caller: Address, new_cooperator: Address) {
         caller.require_auth();
-        require_admin(e, &caller);
+        // ComplianceOfficer role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::ComplianceOfficer);
         let old = get_cooperator(e);
         put_cooperator(e, new_cooperator.clone());
         emit_cooperator_updated(e, old, new_cooperator);
@@ -482,7 +484,8 @@ impl SingleRWAVault {
         // --- Checks ---
         acquire_lock(e);
         require_not_paused(e);
-        require_operator(e, &caller);
+        // YieldOperator role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::YieldOperator);
         require_state(e, VaultState::Active);
 
         if amount <= 0 {
@@ -624,7 +627,8 @@ impl SingleRWAVault {
 
     pub fn activate_vault(e: &Env, operator: Address) {
         operator.require_auth();
-        require_operator(e, &operator);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &operator, Role::LifecycleManager);
         require_state(e, VaultState::Funding);
         // Cannot activate once the funding deadline has passed.
         let deadline = get_funding_deadline(e);
@@ -647,7 +651,8 @@ impl SingleRWAVault {
     /// Transitions the vault to Cancelled, enabling individual `refund` calls.
     pub fn cancel_funding(e: &Env, caller: Address) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::LifecycleManager);
         require_state(e, VaultState::Funding);
         // Deadline must have passed.
         let deadline = get_funding_deadline(e);
@@ -709,7 +714,8 @@ impl SingleRWAVault {
     /// Transition Active → Matured.  Requires block timestamp ≥ maturityDate.
     pub fn mature_vault(e: &Env, caller: Address) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::LifecycleManager);
         require_state(e, VaultState::Active);
         let now = e.ledger().timestamp();
         if now < get_maturity_date(e) {
@@ -726,7 +732,8 @@ impl SingleRWAVault {
     /// Closed is a terminal state; no further operations are possible.
     pub fn close_vault(e: &Env, caller: Address) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::LifecycleManager);
         require_state(e, VaultState::Matured);
 
         if get_total_supply(e) > 0 {
@@ -740,7 +747,8 @@ impl SingleRWAVault {
 
     pub fn set_maturity_date(e: &Env, caller: Address, timestamp: u64) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::LifecycleManager);
         require_not_closed(e);
         put_maturity_date(e, timestamp);
         emit_maturity_date_set(e, timestamp);
@@ -781,7 +789,8 @@ impl SingleRWAVault {
 
     pub fn set_deposit_limits(e: &Env, caller: Address, min_amount: i128, max_amount: i128) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::LifecycleManager);
         put_min_deposit(e, min_amount);
         put_max_deposit_per_user(e, max_amount);
         emit_deposit_limits_updated(e, min_amount, max_amount);
@@ -917,7 +926,8 @@ impl SingleRWAVault {
         operator.require_auth();
         // --- Checks ---
         acquire_lock(e);
-        require_operator(e, &operator);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &operator, Role::LifecycleManager);
 
         let mut req = get_redemption_request(e, request_id);
         if req.processed {
@@ -988,7 +998,8 @@ impl SingleRWAVault {
     /// Operator rejects an early redemption request and returns shares from escrow.
     pub fn reject_early_redemption(e: &Env, operator: Address, request_id: u32) {
         operator.require_auth();
-        require_operator(e, &operator);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &operator, Role::LifecycleManager);
 
         let mut req = get_redemption_request(e, request_id);
         if req.processed {
@@ -1023,7 +1034,8 @@ impl SingleRWAVault {
     /// Set the early redemption fee (only by operator).
     pub fn set_early_redemption_fee(e: &Env, operator: Address, fee_bps: u32) {
         operator.require_auth();
-        require_operator(e, &operator);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &operator, Role::LifecycleManager);
         require_not_closed(e);
         if fee_bps > 1000 {
             panic_with_error!(e, Error::FeeTooHigh);
@@ -1041,16 +1053,49 @@ impl SingleRWAVault {
         get_admin(e)
     }
 
-    pub fn is_operator(e: &Env, account: Address) -> bool {
-        get_operator(e, &account)
+    /// Grant `role` to `addr`.  Only the admin may grant roles.
+    ///
+    /// `FullOperator` is the backward-compatible superrole and passes every
+    /// role check — equivalent to the old `set_operator(..., true)`.
+    pub fn grant_role(e: &Env, caller: Address, addr: Address, role: Role) {
+        caller.require_auth();
+        require_admin(e, &caller);
+        put_role(e, addr.clone(), role.clone(), true);
+        emit_role_granted(e, addr, role);
+        bump_instance(e);
     }
 
+    /// Revoke `role` from `addr`.  Only the admin may revoke roles.
+    pub fn revoke_role(e: &Env, caller: Address, addr: Address, role: Role) {
+        caller.require_auth();
+        require_admin(e, &caller);
+        put_role(e, addr.clone(), role.clone(), false);
+        emit_role_revoked(e, addr, role);
+        bump_instance(e);
+    }
+
+    /// Returns `true` when `addr` holds `role`, the `FullOperator` superrole,
+    /// or is the admin.
+    pub fn has_role(e: &Env, addr: Address, role: Role) -> bool {
+        if addr == get_admin(e) {
+            return true;
+        }
+        get_role(e, &addr, Role::FullOperator) || get_role(e, &addr, role)
+    }
+
+    /// Backward-compatible: grants or revokes the `FullOperator` superrole.
+    /// Prefer `grant_role` / `revoke_role` for new integrations.
     pub fn set_operator(e: &Env, caller: Address, operator: Address, status: bool) {
         caller.require_auth();
         require_admin(e, &caller);
         put_operator(e, operator.clone(), status);
         emit_operator_updated(e, operator, status);
         bump_instance(e);
+    }
+
+    /// Backward-compatible: returns `true` when `account` holds `FullOperator`.
+    pub fn is_operator(e: &Env, account: Address) -> bool {
+        get_operator(e, &account)
     }
 
     pub fn transfer_admin(e: &Env, caller: Address, new_admin: Address) {
@@ -1068,7 +1113,8 @@ impl SingleRWAVault {
 
     pub fn set_blacklisted(e: &Env, caller: Address, address: Address, status: bool) {
         caller.require_auth();
-        require_admin(e, &caller);
+        // ComplianceOfficer role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::ComplianceOfficer);
         put_blacklisted(e, &address, status);
         emit_address_blacklisted(e, address, status);
         bump_instance(e);
@@ -1090,7 +1136,8 @@ impl SingleRWAVault {
     /// Toggle the transfer KYC requirement.  Only the admin may change this.
     pub fn set_transfer_requires_kyc(e: &Env, caller: Address, enabled: bool) {
         caller.require_auth();
-        require_admin(e, &caller);
+        // ComplianceOfficer role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::ComplianceOfficer);
         put_transfer_requires_kyc(e, enabled);
         bump_instance(e);
     }
@@ -1101,7 +1148,8 @@ impl SingleRWAVault {
 
     pub fn pause(e: &Env, caller: Address, reason: String) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // TreasuryManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::TreasuryManager);
         put_paused(e, true);
         emit_emergency_action(e, true, reason);
         bump_instance(e);
@@ -1133,7 +1181,8 @@ impl SingleRWAVault {
         caller.require_auth();
         // --- Checks ---
         acquire_lock(e);
-        require_admin(e, &caller);
+        // TreasuryManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::TreasuryManager);
 
         let balance = asset_balance_of_vault(e);
 
@@ -1204,7 +1253,8 @@ impl SingleRWAVault {
     }
     pub fn set_funding_target(e: &Env, caller: Address, target: i128) {
         caller.require_auth();
-        require_operator(e, &caller);
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &caller, Role::LifecycleManager);
         put_funding_target(e, target);
         emit_funding_target_set(e, target);
         bump_instance(e);
@@ -1447,8 +1497,20 @@ fn require_admin(e: &Env, caller: &Address) {
     }
 }
 
-fn require_operator(e: &Env, caller: &Address) {
-    if !get_operator(e, caller) && *caller != get_admin(e) {
+/// Passes when `caller` holds `role`, the `FullOperator` superrole, or is admin.
+///
+/// Role hierarchy (most to least privileged):
+/// - Admin → always authorised
+/// - FullOperator → backward-compatible superrole; passes every role check
+/// - Named role → passes only the matching role check
+fn require_role(e: &Env, caller: &Address, role: Role) {
+    if *caller == get_admin(e) {
+        return;
+    }
+    if get_role(e, caller, Role::FullOperator) {
+        return;
+    }
+    if !get_role(e, caller, role) {
         panic_with_error!(e, Error::NotOperator);
     }
 }
@@ -1682,6 +1744,8 @@ mod test_constructor;
 mod test_escrow;
 #[cfg(test)]
 pub mod test_helpers;
+#[cfg(test)]
+mod test_rbac;
 #[cfg(test)]
 mod test_redemption;
 #[cfg(test)]

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -15,7 +15,7 @@
 use soroban_sdk::{contracttype, panic_with_error, Address, Env, String};
 
 use crate::errors::Error;
-use crate::types::{RedemptionRequest, VaultState};
+use crate::types::{RedemptionRequest, Role, VaultState};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TTL constants
@@ -44,7 +44,9 @@ pub enum DataKey {
 
     // --- Admin / operators ---
     Admin,
-    Operator(Address),
+    /// Granular RBAC role assignment: (address, role) → bool.
+    /// Replaces the old binary `Operator(Address)` key.
+    Role(Address, Role),
 
     // --- zkMe ---
     ZkmeVerifier,
@@ -289,19 +291,43 @@ instance_put!(put_redemption_counter, RedemptionCounter, u32);
 // Operator (instance storage — same lifetime as admin)
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub fn get_operator(e: &Env, addr: &Address) -> bool {
+// ─────────────────────────────────────────────────────────────────────────────
+// Granular RBAC helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns `true` when `addr` has been granted `role` in instance storage.
+pub fn get_role(e: &Env, addr: &Address, role: Role) -> bool {
     e.storage()
         .instance()
-        .get(&DataKey::Operator(addr.clone()))
+        .get(&DataKey::Role(addr.clone(), role))
         .unwrap_or(false)
 }
 
-pub fn put_operator(e: &Env, addr: Address, val: bool) {
+/// Grant (`val = true`) or revoke (`val = false`) `role` for `addr`.
+pub fn put_role(e: &Env, addr: Address, role: Role, val: bool) {
     if val {
-        e.storage().instance().set(&DataKey::Operator(addr), &val);
+        e.storage()
+            .instance()
+            .set(&DataKey::Role(addr, role), &true);
     } else {
-        e.storage().instance().remove(&DataKey::Operator(addr));
+        e.storage().instance().remove(&DataKey::Role(addr, role));
     }
+}
+
+// ─── Backward-compatible operator wrappers ───────────────────────────────────
+//
+// `set_operator` / `is_operator` on the public interface map to `FullOperator`.
+// Existing deployments and tooling that call these functions continue to work
+// without change; they effectively grant/revoke the superrole.
+
+/// Returns `true` when `addr` holds the `FullOperator` superrole.
+pub fn get_operator(e: &Env, addr: &Address) -> bool {
+    get_role(e, addr, Role::FullOperator)
+}
+
+/// Grant or revoke the `FullOperator` superrole for `addr`.
+pub fn put_operator(e: &Env, addr: Address, val: bool) {
+    put_role(e, addr, Role::FullOperator, val);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_access_control.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_access_control.rs
@@ -254,19 +254,17 @@ fn test_emergency_withdraw_drains_vault() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #4)")] // Error::NotAdmin = 4
+#[should_panic(expected = "Error(Contract, #3)")] // Error::NotOperator = 3
 fn test_emergency_withdraw_non_admin_panics() {
     let e = Env::default();
     e.mock_all_auths();
-    let (vault_id, _, _, admin) = make_vault(&e);
+    let (vault_id, _, _, _admin) = make_vault(&e);
     let vault = SingleRWAVaultClient::new(&e, &vault_id);
-    let operator = Address::generate(&e);
+    // An address with no role — not TreasuryManager, FullOperator, or admin.
+    let nobody = Address::generate(&e);
     let recipient = Address::generate(&e);
 
-    vault.set_operator(&admin, &operator, &true);
-
-    // Operator (non-admin) tries to call emergency withdraw
-    vault.emergency_withdraw(&operator, &recipient);
+    vault.emergency_withdraw(&nobody, &recipient);
 }
 
 #[test]

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_rbac.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_rbac.rs
@@ -1,0 +1,344 @@
+//! Role-isolation tests for the granular RBAC system (issue #107).
+//!
+//! Each test verifies that a narrowly-scoped role can perform its permitted
+//! operations and is rejected when it tries to call functions outside its scope.
+
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
+
+use crate::{InitParams, Role, SingleRWAVault, SingleRWAVaultClient};
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+fn default_params(env: &Env, admin: &Address, asset: &Address) -> InitParams {
+    InitParams {
+        asset: asset.clone(),
+        share_name: String::from_str(env, "Vault Share"),
+        share_symbol: String::from_str(env, "VS"),
+        share_decimals: 7,
+        admin: admin.clone(),
+        zkme_verifier: admin.clone(), // vault itself → KYC always true
+        cooperator: admin.clone(),
+        funding_target: 0_i128, // 0 = no target, activatable immediately
+        maturity_date: 9_999_999_999_u64,
+        min_deposit: 1_000_i128,
+        max_deposit_per_user: 0_i128,
+        early_redemption_fee_bps: 100_u32,
+        funding_deadline: 0_u64,
+        rwa_name: String::from_str(env, "Test RWA"),
+        rwa_symbol: String::from_str(env, "TRWA"),
+        rwa_document_uri: String::from_str(env, "https://test.com"),
+        rwa_category: String::from_str(env, "Real Estate"),
+        expected_apy: 500_u32,
+    }
+}
+
+/// Returns (env, vault_id, asset_id, admin).
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let asset_id = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    // Point zkme_verifier at the vault itself so is_kyc_verified always returns true.
+    let vault_id = env.register(SingleRWAVault, (default_params(&env, &admin, &asset_id),));
+    SingleRWAVaultClient::new(&env, &vault_id).set_zkme_verifier(&admin, &vault_id);
+
+    (env, vault_id, asset_id, admin)
+}
+
+/// Fund `user` with `amount` of the underlying asset.
+fn mint_asset(env: &Env, asset_id: &Address, user: &Address, amount: i128) {
+    StellarAssetClient::new(env, asset_id).mint(user, &amount);
+}
+
+// ─── grant_role / revoke_role ────────────────────────────────────────────────
+
+#[test]
+fn test_grant_and_revoke_role() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let addr = Address::generate(&env);
+
+    // Initially the address has no role.
+    assert!(!client.has_role(&addr, &Role::YieldOperator));
+
+    client.grant_role(&admin, &addr, &Role::YieldOperator);
+    assert!(client.has_role(&addr, &Role::YieldOperator));
+
+    client.revoke_role(&admin, &addr, &Role::YieldOperator);
+    assert!(!client.has_role(&addr, &Role::YieldOperator));
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_grant_role() {
+    let (env, vault_id, _, _) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let rando = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    // Non-admin trying to grant a role must fail.
+    client.grant_role(&rando, &target, &Role::YieldOperator);
+}
+
+// ─── has_role — admin always passes ─────────────────────────────────────────
+
+#[test]
+fn test_admin_has_every_role() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+
+    assert!(client.has_role(&admin, &Role::YieldOperator));
+    assert!(client.has_role(&admin, &Role::LifecycleManager));
+    assert!(client.has_role(&admin, &Role::ComplianceOfficer));
+    assert!(client.has_role(&admin, &Role::TreasuryManager));
+    assert!(client.has_role(&admin, &Role::FullOperator));
+}
+
+// ─── FullOperator — backward-compatible superrole ────────────────────────────
+
+#[test]
+fn test_full_operator_passes_all_role_checks() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let op = Address::generate(&env);
+
+    client.grant_role(&admin, &op, &Role::FullOperator);
+
+    assert!(client.has_role(&op, &Role::YieldOperator));
+    assert!(client.has_role(&op, &Role::LifecycleManager));
+    assert!(client.has_role(&op, &Role::ComplianceOfficer));
+    assert!(client.has_role(&op, &Role::TreasuryManager));
+    assert!(client.has_role(&op, &Role::FullOperator));
+}
+
+#[test]
+fn test_set_operator_grants_full_operator() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let op = Address::generate(&env);
+
+    // Backward-compat API
+    client.set_operator(&admin, &op, &true);
+    assert!(client.is_operator(&op));
+    assert!(client.has_role(&op, &Role::FullOperator));
+
+    client.set_operator(&admin, &op, &false);
+    assert!(!client.is_operator(&op));
+    assert!(!client.has_role(&op, &Role::FullOperator));
+}
+
+// ─── YieldOperator ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_yield_operator_can_distribute_yield() {
+    let (env, vault_id, asset_id, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let yield_op = Address::generate(&env);
+
+    client.grant_role(&admin, &yield_op, &Role::YieldOperator);
+
+    // Activate vault so distribute_yield is reachable.
+    let lm = Address::generate(&env);
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    client.activate_vault(&lm);
+
+    // Give the yield operator enough tokens to inject yield.
+    mint_asset(&env, &asset_id, &yield_op, 1_000_000_i128);
+    client.distribute_yield(&yield_op, &500_000_i128);
+    assert_eq!(client.current_epoch(), 1);
+}
+
+#[test]
+#[should_panic]
+fn test_yield_operator_cannot_pause() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let yield_op = Address::generate(&env);
+
+    client.grant_role(&admin, &yield_op, &Role::YieldOperator);
+    // pause requires TreasuryManager — must panic.
+    client.pause(&yield_op, &String::from_str(&env, "test"));
+}
+
+#[test]
+#[should_panic]
+fn test_yield_operator_cannot_activate_vault() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let yield_op = Address::generate(&env);
+
+    client.grant_role(&admin, &yield_op, &Role::YieldOperator);
+    // activate_vault requires LifecycleManager — must panic.
+    client.activate_vault(&yield_op);
+}
+
+// ─── LifecycleManager ────────────────────────────────────────────────────────
+
+#[test]
+fn test_lifecycle_manager_can_activate_vault() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let lm = Address::generate(&env);
+
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    client.activate_vault(&lm);
+
+    assert_eq!(client.vault_state(), crate::VaultState::Active);
+}
+
+#[test]
+#[should_panic]
+fn test_lifecycle_manager_cannot_distribute_yield() {
+    let (env, vault_id, asset_id, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let lm = Address::generate(&env);
+
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    client.activate_vault(&lm);
+
+    mint_asset(&env, &asset_id, &lm, 1_000_000_i128);
+    // distribute_yield requires YieldOperator — must panic.
+    client.distribute_yield(&lm, &500_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_lifecycle_manager_cannot_pause() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let lm = Address::generate(&env);
+
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    // pause requires TreasuryManager — must panic.
+    client.pause(&lm, &String::from_str(&env, "test"));
+}
+
+// ─── ComplianceOfficer ───────────────────────────────────────────────────────
+
+#[test]
+fn test_compliance_officer_can_set_blacklisted() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let co = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    client.grant_role(&admin, &co, &Role::ComplianceOfficer);
+    client.set_blacklisted(&co, &target, &true);
+    assert!(client.is_blacklisted(&target));
+}
+
+#[test]
+fn test_compliance_officer_can_set_zkme_verifier() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let co = Address::generate(&env);
+    let new_verifier = Address::generate(&env);
+
+    client.grant_role(&admin, &co, &Role::ComplianceOfficer);
+    // Should not panic.
+    client.set_zkme_verifier(&co, &new_verifier);
+}
+
+#[test]
+#[should_panic]
+fn test_compliance_officer_cannot_distribute_yield() {
+    let (env, vault_id, asset_id, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let co = Address::generate(&env);
+    let lm = Address::generate(&env);
+
+    client.grant_role(&admin, &co, &Role::ComplianceOfficer);
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    client.activate_vault(&lm);
+
+    mint_asset(&env, &asset_id, &co, 1_000_000_i128);
+    // distribute_yield requires YieldOperator — must panic.
+    client.distribute_yield(&co, &500_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_compliance_officer_cannot_activate_vault() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let co = Address::generate(&env);
+
+    client.grant_role(&admin, &co, &Role::ComplianceOfficer);
+    // activate_vault requires LifecycleManager — must panic.
+    client.activate_vault(&co);
+}
+
+// ─── TreasuryManager ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_treasury_manager_can_pause() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let tm = Address::generate(&env);
+
+    client.grant_role(&admin, &tm, &Role::TreasuryManager);
+    client.pause(&tm, &String::from_str(&env, "security incident"));
+    assert!(client.paused());
+}
+
+#[test]
+#[should_panic]
+fn test_treasury_manager_cannot_distribute_yield() {
+    let (env, vault_id, asset_id, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let tm = Address::generate(&env);
+    let lm = Address::generate(&env);
+
+    client.grant_role(&admin, &tm, &Role::TreasuryManager);
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    client.activate_vault(&lm);
+
+    mint_asset(&env, &asset_id, &tm, 1_000_000_i128);
+    // distribute_yield requires YieldOperator — must panic.
+    client.distribute_yield(&tm, &500_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_treasury_manager_cannot_activate_vault() {
+    let (env, vault_id, _, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let tm = Address::generate(&env);
+
+    client.grant_role(&admin, &tm, &Role::TreasuryManager);
+    // activate_vault requires LifecycleManager — must panic.
+    client.activate_vault(&tm);
+}
+
+// ─── Untrusted address ───────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_random_address_cannot_distribute_yield() {
+    let (env, vault_id, asset_id, admin) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let rando = Address::generate(&env);
+    let lm = Address::generate(&env);
+
+    client.grant_role(&admin, &lm, &Role::LifecycleManager);
+    client.activate_vault(&lm);
+
+    mint_asset(&env, &asset_id, &rando, 1_000_000_i128);
+    client.distribute_yield(&rando, &500_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_random_address_cannot_pause() {
+    let (env, vault_id, _, _) = setup();
+    let client = SingleRWAVaultClient::new(&env, &vault_id);
+    let rando = Address::generate(&env);
+
+    client.pause(&rando, &String::from_str(&env, "attack"));
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -71,6 +71,43 @@ pub struct RwaDetails {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Role-Based Access Control
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Granular operator role for on-chain access control.
+///
+/// Assign the narrowest role each team member needs rather than handing out
+/// the full-operator key.  `FullOperator` is the backward-compatible superrole
+/// and passes every role check — it is equivalent to the old boolean
+/// `Operator` flag.
+///
+/// Role → permitted functions
+/// - `YieldOperator`     → `distribute_yield`
+/// - `LifecycleManager`  → `activate_vault`, `cancel_funding`, `mature_vault`,
+///                          `close_vault`, `set_maturity_date`, `set_deposit_limits`,
+///                          `set_funding_target`, `process_early_redemption`,
+///                          `reject_early_redemption`, `set_early_redemption_fee`
+/// - `ComplianceOfficer` → `set_zkme_verifier`, `set_cooperator`,
+///                          `set_blacklisted`, `set_transfer_requires_kyc`
+/// - `TreasuryManager`   → `pause`, `emergency_withdraw`
+/// - `FullOperator`      → all of the above (backward-compatible superrole)
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Role {
+    /// Can call `distribute_yield` only.
+    YieldOperator,
+    /// Can call vault lifecycle management functions.
+    LifecycleManager,
+    /// Can call KYC and compliance functions.
+    ComplianceOfficer,
+    /// Can call `pause` and `emergency_withdraw`.
+    TreasuryManager,
+    /// Superrole: grants every role check.  Backward-compatible with the old
+    /// binary `Operator` flag.
+    FullOperator,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Redemption request
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/soroban-contracts/contracts/vault_factory/src/events.rs
+++ b/soroban-contracts/contracts/vault_factory/src/events.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{symbol_short, Address, Env, String};
 
-use crate::types::VaultType;
+use crate::types::{Role, VaultType};
 
 pub fn emit_vault_created(
     e: &Env,
@@ -42,4 +42,14 @@ pub fn emit_defaults_updated(e: &Env, asset: Address, zkme_verifier: Address, co
 pub fn emit_vault_removed(e: &Env, vault: Address, removed_by: Address) {
     e.events()
         .publish((symbol_short!("v_remove"), vault), removed_by);
+}
+
+/// Emitted when the admin grants a role to an address.
+pub fn emit_role_granted(e: &Env, addr: Address, role: Role) {
+    e.events().publish((symbol_short!("role_grt"), addr), role);
+}
+
+/// Emitted when the admin revokes a role from an address.
+pub fn emit_role_revoked(e: &Env, addr: Address, role: Role) {
+    e.events().publish((symbol_short!("role_rvk"), addr), role);
 }

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -339,6 +339,38 @@ impl VaultFactory {
         bump_instance(e);
     }
 
+    /// Grant `role` to `addr`.  Only the admin may grant roles.
+    ///
+    /// `FullOperator` is the backward-compatible superrole that passes every
+    /// role check (equivalent to the old `set_operator(..., true)`).
+    pub fn grant_role(e: &Env, caller: Address, addr: Address, role: Role) {
+        caller.require_auth();
+        require_admin(e, &caller);
+        put_role(e, addr.clone(), role.clone(), true);
+        emit_role_granted(e, addr, role);
+        bump_instance(e);
+    }
+
+    /// Revoke `role` from `addr`.  Only the admin may revoke roles.
+    pub fn revoke_role(e: &Env, caller: Address, addr: Address, role: Role) {
+        caller.require_auth();
+        require_admin(e, &caller);
+        put_role(e, addr.clone(), role.clone(), false);
+        emit_role_revoked(e, addr, role);
+        bump_instance(e);
+    }
+
+    /// Returns `true` when `addr` holds `role`, the `FullOperator` superrole,
+    /// or is the admin.
+    pub fn has_role(e: &Env, addr: Address, role: Role) -> bool {
+        if addr == get_admin(e) {
+            return true;
+        }
+        get_role(e, &addr, Role::FullOperator) || get_role(e, &addr, role)
+    }
+
+    /// Backward-compatible: grants or revokes the `FullOperator` superrole.
+    /// Prefer `grant_role` / `revoke_role` for new integrations.
     pub fn set_operator(e: &Env, caller: Address, operator: Address, status: bool) {
         caller.require_auth();
         require_admin(e, &caller);
@@ -521,10 +553,22 @@ fn require_admin(e: &Env, caller: &Address) {
     }
 }
 
-fn require_operator_or_admin(e: &Env, caller: &Address) {
-    if !get_operator(e, caller) && *caller != get_admin(e) {
+/// Passes when `caller` holds `role`, the `FullOperator` superrole, or is admin.
+fn require_role(e: &Env, caller: &Address, role: Role) {
+    if *caller == get_admin(e) {
+        return;
+    }
+    if get_role(e, caller, Role::FullOperator) {
+        return;
+    }
+    if !get_role(e, caller, role) {
         panic_with_error!(e, Error::NotAuthorized);
     }
+}
+
+fn require_operator_or_admin(e: &Env, caller: &Address) {
+    // Vault creation requires FullOperator or admin (backward-compatible).
+    require_role(e, caller, Role::FullOperator);
 }
 
 fn panic_not_found(e: &Env) -> ! {

--- a/soroban-contracts/contracts/vault_factory/src/storage.rs
+++ b/soroban-contracts/contracts/vault_factory/src/storage.rs
@@ -5,7 +5,7 @@
 
 use soroban_sdk::{contracttype, vec, Address, BytesN, Env, Vec};
 
-use crate::types::VaultInfo;
+use crate::types::{Role, VaultInfo};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TTL constants
@@ -25,7 +25,9 @@ pub const PERSIST_BUMP_AMOUNT: u32 = 1069000;
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
-    Operator(Address),
+    /// Granular RBAC role assignment: (address, role) → bool.
+    /// Replaces the old binary `Operator(Address)` key.
+    Role(Address, Role),
     DefaultAsset,
     DefaultZkmeVerifier,
     DefaultCooperator,
@@ -72,18 +74,39 @@ pub fn put_admin(e: &Env, val: Address) {
     e.storage().instance().set(&DataKey::Admin, &val);
 }
 
-pub fn get_operator(e: &Env, addr: &Address) -> bool {
+// ─────────────────────────────────────────────────────────────────────────────
+// Granular RBAC helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns `true` when `addr` has been granted `role` in instance storage.
+pub fn get_role(e: &Env, addr: &Address, role: Role) -> bool {
     e.storage()
         .instance()
-        .get(&DataKey::Operator(addr.clone()))
+        .get(&DataKey::Role(addr.clone(), role))
         .unwrap_or(false)
 }
-pub fn put_operator(e: &Env, addr: Address, val: bool) {
+
+/// Grant (`val = true`) or revoke (`val = false`) `role` for `addr`.
+pub fn put_role(e: &Env, addr: Address, role: Role, val: bool) {
     if val {
-        e.storage().instance().set(&DataKey::Operator(addr), &val);
+        e.storage()
+            .instance()
+            .set(&DataKey::Role(addr, role), &true);
     } else {
-        e.storage().instance().remove(&DataKey::Operator(addr));
+        e.storage().instance().remove(&DataKey::Role(addr, role));
     }
+}
+
+// ─── Backward-compatible operator wrappers ───────────────────────────────────
+
+/// Returns `true` when `addr` holds the `FullOperator` superrole.
+pub fn get_operator(e: &Env, addr: &Address) -> bool {
+    get_role(e, addr, Role::FullOperator)
+}
+
+/// Grant or revoke the `FullOperator` superrole for `addr`.
+pub fn put_operator(e: &Env, addr: Address, val: bool) {
+    put_role(e, addr, Role::FullOperator, val);
 }
 
 pub fn get_default_asset(e: &Env) -> Address {

--- a/soroban-contracts/contracts/vault_factory/src/types.rs
+++ b/soroban-contracts/contracts/vault_factory/src/types.rs
@@ -73,3 +73,28 @@ pub struct BatchVaultParams {
 /// Parameters for `create_single_rwa_vault_full`.
 /// Identical fields to BatchVaultParams but named separately for clarity.
 pub type CreateVaultParams = BatchVaultParams;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Role-Based Access Control
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Granular operator role for on-chain access control.
+///
+/// `FullOperator` is the backward-compatible superrole equivalent to the old
+/// boolean `Operator` flag.  Additional roles can be granted for fine-grained
+/// permissions over vault creation and factory management.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Role {
+    /// Can call `distribute_yield` on managed vaults.
+    YieldOperator,
+    /// Can call vault lifecycle management functions.
+    LifecycleManager,
+    /// Can call KYC and compliance functions.
+    ComplianceOfficer,
+    /// Can call `pause` and `emergency_withdraw` on managed vaults.
+    TreasuryManager,
+    /// Superrole: grants every role check.  Backward-compatible with the old
+    /// binary `Operator` flag — can create vaults and manage the factory.
+    FullOperator,
+}


### PR DESCRIPTION
Replaces the old binary Operator(Address) storage key with a typed Role(Address, Role) key and introduces four narrowly-scoped roles:

  YieldOperator     — distribute_yield
  LifecycleManager  — activate/mature/close vault, set maturity date,
                       deposit limits, funding target, early-redemption
                       processing/rejection/fee
  ComplianceOfficer — set_zkme_verifier, set_cooperator, set_blacklisted,
                       set_transfer_requires_kyc
  TreasuryManager   — pause, emergency_withdraw
  FullOperator      — superrole; backward-compatible with old Operator flag

Changes across both contracts (single_rwa_vault + vault_factory):
- types.rs: Role enum annotated with #[contracttype]
- storage.rs: DataKey::Role(Address, Role); get_role/put_role helpers; get_operator/put_operator kept as FullOperator wrappers
- events.rs: emit_role_granted / emit_role_revoked
- lib.rs: require_role(e, caller, role) guard; grant_role / revoke_role / has_role public functions; set_operator / is_operator kept for backward compat; all require_operator call sites updated to the appropriate specific role

Tests (test_rbac.rs — 20 new tests):
- grant_role / revoke_role round-trip
- Admin implicitly passes every role check
- FullOperator passes every role check
- set_operator maps to FullOperator (backward compat)
- Role isolation: each role can call its permitted function and is rejected when calling functions outside its scope
- Untrusted address rejected at all role-gated entry points

closes #107 