### PR TITLE
Feature yield vesting

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -215,6 +215,10 @@ pub fn emit_early_redemption_fee_set(e: &Env, fee_bps: u32) {
     e.events().publish((symbol_short!("fee_set"),), fee_bps);
 }
 
+pub fn emit_yield_vesting_period_set(e: &Env, vesting_period: u64) {
+    e.events().publish((symbol_short!("vest_set"),), vesting_period);
+}
+
 /// Emitted by `set_funding_target`.
 pub fn emit_funding_target_set(e: &Env, target: i128) {
     e.events().publish((symbol_short!("fund_set"),), target);

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -61,6 +61,8 @@ mod test_vault_state_guards;
 #[cfg(test)]
 mod test_withdraw;
 #[cfg(test)]
+mod test_yield_vesting;
+#[cfg(test)]
 mod tests;
 
 pub use crate::storage::Key;
@@ -158,6 +160,7 @@ impl SingleRWAVault {
         put_min_deposit(e, params.min_deposit);
         put_max_deposit_per_user(e, params.max_deposit_per_user);
         put_early_redemption_fee_bps(e, params.early_redemption_fee_bps);
+        put_yield_vesting_period(e, params.yield_vesting_period);
 
         // Initial state
         put_vault_state(e, VaultState::Funding);
@@ -770,25 +773,41 @@ impl SingleRWAVault {
         require_active_or_matured(e);
         require_not_blacklisted(e, &caller);
 
-        if get_has_claimed_epoch(e, &caller, epoch) {
-            panic_with_error!(e, Error::NoYieldToClaim);
-        }
-
         let amount = Self::pending_yield_for_epoch(e, caller.clone(), epoch);
         if amount <= 0 {
             panic_with_error!(e, Error::NoYieldToClaim);
         }
 
         // --- Effects ---
-        put_has_claimed_epoch(e, &caller, epoch, true);
-        // Advance the cursor: if this epoch is the next sequential one after
-        // the cursor, walk forward over any already-claimed epochs too.
-        let mut cursor = get_last_claimed_epoch(e, &caller);
-        let current = get_current_epoch(e);
-        while cursor < current && get_has_claimed_epoch(e, &caller, cursor + 1) {
-            cursor += 1;
+        // Update the amount claimed for this specific epoch
+        let already_claimed = get_user_epoch_yield_claimed(e, &caller, epoch);
+        put_user_epoch_yield_claimed(e, &caller, epoch, already_claimed + amount);
+        
+        // Check if this epoch is now fully claimed
+        let total_yield_for_user = {
+            let user_shares = _get_user_shares_for_epoch(e, &caller, epoch);
+            let total_shares = get_epoch_total_shares(e, epoch);
+            if total_shares == 0 || user_shares == 0 {
+                0
+            } else {
+                math::mul_div(e, get_epoch_yield(e, epoch), user_shares, total_shares)
+            }
+        };
+        
+        let new_total_claimed = already_claimed + amount;
+        if new_total_claimed >= total_yield_for_user {
+            // Epoch is fully claimed - mark as claimed for cursor optimization
+            put_has_claimed_epoch(e, &caller, epoch, true);
+            
+            // Advance the cursor: if this epoch is the next sequential one after
+            // the cursor, walk forward over any already-claimed epochs too.
+            let mut cursor = get_last_claimed_epoch(e, &caller);
+            let current = get_current_epoch(e);
+            while cursor < current && get_has_claimed_epoch(e, &caller, cursor + 1) {
+                cursor += 1;
+            }
+            put_last_claimed_epoch(e, &caller, cursor);
         }
-        put_last_claimed_epoch(e, &caller, cursor);
 
         put_total_yield_claimed(e, &caller, get_total_yield_claimed(e, &caller) + amount);
         transfer_asset_from_vault(e, &caller, amount);
@@ -822,7 +841,50 @@ impl SingleRWAVault {
         if total_shares == 0 || user_shares == 0 {
             return 0;
         }
-        math::mul_div(e, get_epoch_yield(e, epoch), user_shares, total_shares)
+        
+        // Calculate total yield for user in this epoch
+        let total_yield_for_user = math::mul_div(e, get_epoch_yield(e, epoch), user_shares, total_shares);
+        
+        // Get vesting period (0 = instant claiming for backward compatibility)
+        let vesting_period = get_yield_vesting_period(e);
+        if vesting_period == 0 {
+            // No vesting - return full amount
+            return total_yield_for_user;
+        }
+        
+        // Get when this epoch was distributed
+        let epoch_timestamp = get_epoch_timestamp(e, epoch);
+        if epoch_timestamp == 0 {
+            // Epoch timestamp not set (shouldn't happen with proper initialization)
+            return total_yield_for_user;
+        }
+        
+        // Calculate vested portion
+        let now = e.ledger().timestamp();
+        if now <= epoch_timestamp {
+            // Distribution just happened - nothing vested yet
+            return 0;
+        }
+        
+        let elapsed = now - epoch_timestamp;
+        let vested_fraction = if elapsed >= vesting_period {
+            // Fully vested
+            1_000_000_000 // Use 1e9 for precision
+        } else {
+            // Partially vested - use integer math: (elapsed * 1e9) / vesting_period
+            (elapsed * 1_000_000_000) / vesting_period
+        };
+        
+        // Calculate vested amount: (total_yield * vested_fraction) / 1e9
+        let vested_amount = (total_yield_for_user * vested_fraction as i128) / 1_000_000_000i128;
+        
+        // Subtract already claimed amount for this epoch
+        let already_claimed = get_user_epoch_yield_claimed(e, &user, epoch);
+        if vested_amount <= already_claimed {
+            return 0;
+        }
+        
+        vested_amount - already_claimed
     }
 
     pub fn current_epoch(e: &Env) -> u32 {
@@ -1453,6 +1515,16 @@ impl SingleRWAVault {
         }
         put_early_redemption_fee_bps(e, fee_bps);
         emit_early_redemption_fee_set(e, fee_bps);
+        bump_instance(e);
+    }
+
+    pub fn set_yield_vesting_period(e: &Env, operator: Address, vesting_period: u64) {
+        operator.require_auth();
+        // LifecycleManager role required — also passes for FullOperator and admin.
+        require_role(e, &operator, Role::LifecycleManager);
+        require_not_closed(e);
+        put_yield_vesting_period(e, vesting_period);
+        emit_yield_vesting_period_set(e, vesting_period);
         bump_instance(e);
     }
 
@@ -2516,6 +2588,7 @@ mod test {
             rwa_category: String::from_str(e, "Bonds"),
             expected_apy: 500,
             timelock_delay: 172800u64, // 48 hours
+            yield_vesting_period: 0u64, // Default to 0 for instant claiming
         };
 
         let vault_addr = e.register(SingleRWAVault, (params,));

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -64,6 +64,8 @@ pub enum Key {
     MinDep,
     MaxDepUsr,
     ERedFee,
+    /// Yield vesting period in seconds (0 = instant claiming for backward compatibility)
+    YldVstPer,
 
     // --- Vault state ---
     VaultSt,
@@ -90,6 +92,8 @@ pub enum Key {
     /// Cursor: the highest epoch at which all epochs ≤ cursor have been claimed.
     /// Allows pending_yield / claim_yield to scan only new epochs.
     LstClmEp(Address),
+    /// Track how much yield a user has claimed for a specific epoch (for vesting)
+    UsrEpYldClm(Address, u32),
 
     // --- User share snapshots ---
     UsrShrEp(Address, u32),
@@ -186,6 +190,8 @@ impl soroban_sdk::IntoVal<Env, soroban_sdk::Val> for Key {
             Key::TlkDelay => 50,
             Key::TlkCount => 51,
             Key::TlkAct(n) => 52 + *n,
+            Key::YldVstPer => 100, // Unique ID for yield vesting period
+            Key::UsrEpYldClm(_, _) => 101, // Unique ID for user epoch yield claimed
         };
         n.into_val(env)
     }
@@ -232,6 +238,7 @@ impl soroban_sdk::TryFromVal<Env, soroban_sdk::Val> for Key {
             49 => Ok(Key::EmgTotSup),
             50 => Ok(Key::TlkDelay),
             51 => Ok(Key::TlkCount),
+            100 => Ok(Key::YldVstPer),
             _ => Err(soroban_sdk::Error::from_contract_error(1)),
         }
     }
@@ -318,6 +325,7 @@ pub fn bump_user_data(e: &Env, addr: &Address, epoch: u32) {
         Key::TotYldClm(addr.clone()),
         Key::LstIntEp(addr.clone()),
         Key::LstClmEp(addr.clone()),
+        Key::UsrEpYldClm(addr.clone(), epoch), // Include the specific epoch key
     ];
     for key in &addr_keys {
         if e.storage().persistent().has(key) {
@@ -406,6 +414,16 @@ instance_get!(get_max_deposit_per_user, MaxDepUsr, i128);
 instance_put!(put_max_deposit_per_user, MaxDepUsr, i128);
 instance_get!(get_early_redemption_fee_bps, ERedFee, u32);
 instance_put!(put_early_redemption_fee_bps, ERedFee, u32);
+
+pub fn get_yield_vesting_period(e: &Env) -> u64 {
+    e.storage()
+        .instance()
+        .get(&Key::YldVstPer)
+        .unwrap_or(0) // Default to 0 for backward compatibility (instant claiming)
+}
+pub fn put_yield_vesting_period(e: &Env, val: u64) {
+    e.storage().instance().set(&Key::YldVstPer, &val);
+}
 
 // State
 instance_get!(get_vault_state, VaultSt, VaultState);
@@ -668,6 +686,20 @@ pub fn get_total_yield_claimed(e: &Env, addr: &Address) -> i128 {
 }
 pub fn put_total_yield_claimed(e: &Env, addr: &Address, val: i128) {
     let key = Key::TotYldClm(addr.clone());
+    e.storage().persistent().set(&key, &val);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, BALANCE_LIFETIME_THRESHOLD, BALANCE_BUMP_AMOUNT);
+}
+
+pub fn get_user_epoch_yield_claimed(e: &Env, addr: &Address, epoch: u32) -> i128 {
+    e.storage()
+        .persistent()
+        .get(&Key::UsrEpYldClm(addr.clone(), epoch))
+        .unwrap_or(0)
+}
+pub fn put_user_epoch_yield_claimed(e: &Env, addr: &Address, epoch: u32, val: i128) {
+    let key = Key::UsrEpYldClm(addr.clone(), epoch);
     e.storage().persistent().set(&key, &val);
     e.storage()
         .persistent()

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
@@ -271,5 +271,6 @@ fn default_params(
         rwa_category: String::from_str(env, "Government Bond"),
         expected_apy: 500u32, // 5 %
         timelock_delay: 172800u64, // 48 hours
+        yield_vesting_period: 0u64, // Default to 0 for instant claiming (backward compatibility)
     }
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_yield_vesting.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_yield_vesting.rs
@@ -1,0 +1,124 @@
+//! Tests for yield vesting schedule functionality.
+
+extern crate std;
+
+use crate::test_helpers::*;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env};
+
+#[test]
+fn test_yield_vesting_zero_period_instant_claiming() {
+    // Test backward compatibility: vesting period = 0 should maintain instant claiming
+    let ctx = setup_with_vesting(0); // 0 seconds = instant claiming
+    
+    // Setup: deposit and distribute yield
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 1_000_000_000);
+    ctx.vault().deposit(&ctx.user, &1_000_000_000i128, &ctx.user);
+    
+    // Activate vault
+    ctx.vault().activate_vault(&ctx.operator);
+    
+    // Distribute yield
+    let yield_amount = 100_000_000i128;
+    let epoch = ctx.vault().distribute_yield(&ctx.operator, &yield_amount);
+    
+    // Should be able to claim full amount immediately (no vesting)
+    let pending = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(pending, yield_amount, "Full yield should be available instantly");
+    
+    // Claim should work
+    let claimed = ctx.vault().claim_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(claimed, yield_amount, "Should claim full amount");
+    
+    // No more yield pending
+    let pending_after = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(pending_after, 0, "No yield should remain after claiming");
+}
+
+#[test]
+fn test_yield_vesting_partial_vesting_50_percent() {
+    // Test 50% vesting - half of yield should be available after half the period
+    let vesting_period = 1000u64; // 1000 seconds
+    let ctx = setup_with_vesting(vesting_period);
+    
+    // Setup: deposit and distribute yield
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 1_000_000_000);
+    ctx.vault().deposit(&ctx.user, &1_000_000_000i128, &ctx.user);
+    
+    // Activate vault
+    ctx.vault().activate_vault(&ctx.operator);
+    
+    // Distribute yield
+    let yield_amount = 100_000_000i128;
+    let epoch = ctx.vault().distribute_yield(&ctx.operator, &yield_amount);
+    
+    // Immediately after distribution - nothing should be vested
+    let pending_immediate = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(pending_immediate, 0, "No yield should be vested immediately");
+    
+    // Advance time by 50% of vesting period
+    advance_time(&ctx.env, (vesting_period / 2) as u64);
+    
+    // Should have 50% vested
+    let pending_50_percent = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    let expected_50_percent = yield_amount / 2; // Should be exactly 50%
+    assert_eq!(pending_50_percent, expected_50_percent, "50% of yield should be vested");
+    
+    // Claim the vested portion
+    let claimed = ctx.vault().claim_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(claimed, expected_50_percent, "Should claim vested portion");
+    
+    // Advance time to full vesting
+    advance_time(&ctx.env, (vesting_period / 2) as u64);
+    
+    // Should have remaining 50% available
+    let pending_remaining = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(pending_remaining, expected_50_percent, "Remaining 50% should be vested");
+    
+    // Claim the rest
+    let claimed_final = ctx.vault().claim_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(claimed_final, expected_50_percent, "Should claim remaining portion");
+    
+    // Nothing should remain
+    let pending_final = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(pending_final, 0, "No yield should remain after full claiming");
+}
+
+#[test]
+fn test_yield_vesting_full_vesting_after_period() {
+    // Test that 100% of yield is available after full vesting period
+    let vesting_period = 500u64;
+    let ctx = setup_with_vesting(vesting_period);
+    
+    // Setup: deposit and distribute yield
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 1_000_000_000);
+    ctx.vault().deposit(&ctx.user, &1_000_000_000i128, &ctx.user);
+    
+    // Activate vault
+    ctx.vault().activate_vault(&ctx.operator);
+    
+    // Distribute yield
+    let yield_amount = 200_000_000i128;
+    let epoch = ctx.vault().distribute_yield(&ctx.operator, &yield_amount);
+    
+    // Advance time past vesting period
+    advance_time(&ctx.env, vesting_period + 100);
+    
+    // Should have full amount vested
+    let pending = ctx.vault().pending_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(pending, yield_amount, "Full yield should be vested after period");
+    
+    // Claim full amount
+    let claimed = ctx.vault().claim_yield_for_epoch(&ctx.user, &epoch);
+    assert_eq!(claimed, yield_amount, "Should claim full amount");
+}
+
+// Helper function to set up vault with custom vesting period
+fn setup_with_vesting(vesting_period: u64) -> TestContext {
+    let ctx = setup_with_kyc_bypass();
+    
+    // Update the vesting period by modifying the stored value
+    ctx.vault().set_yield_vesting_period(&ctx.operator, &vesting_period);
+    
+    ctx
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -38,6 +38,8 @@ pub struct InitParams {
     // Timelock configuration
     /// Delay in seconds for critical admin operations (default: 48 hours)
     pub timelock_delay: u64,
+    /// Yield vesting period in seconds (0 = instant claiming for backward compatibility)
+    pub yield_vesting_period: u64,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Summary

Currently, yield is fully claimable the instant distribute_yield is called. In traditional finance, RWA yields often have vesting schedules — the yield becomes claimable over time (e.g., linear vesting over 30 days). Instant yield claiming enables yield-sniping: a user deposits just before a yield distribution, claims immediately, and redeems — capturing yield without bearing the investment risk.

Closes #118 