### PR TITLE
feat: add is_matured, list_operators, get_defaults_snapshot, list_vaults_by_status

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -93,6 +93,7 @@ pub struct SingleRWAVault;
 
 /// Fixed-point precision for yield_per_share calculations (10^6).
 const PRECISION: i128 = 1_000_000;
+const MAX_OPERATOR_PAGE_SIZE: u32 = 50;
 
 /// Virtual offset for share price inflation attack mitigation (OpenZeppelin approach).
 /// Set to 10^6 to provide robust protection for 6-decimal assets like USDC.
@@ -1209,6 +1210,24 @@ impl SingleRWAVault {
         mat.saturating_sub(now)
     }
 
+    /// Returns `true` when maturity conditions are met.
+    ///
+    /// Evaluates to `true` in two cases:
+    /// - The vault has already been transitioned to `VaultState::Matured` (or `Closed`).
+    /// - The vault is still `Active` but the current ledger timestamp has reached
+    ///   or passed the configured maturity date.
+    ///
+    /// This lets client code check "is the RWA past its term?" in a single call
+    /// without separately reading vault_state + maturity_date and comparing them.
+    pub fn is_matured(e: &Env) -> bool {
+        let state = get_vault_state(e);
+        match state {
+            VaultState::Matured | VaultState::Closed => true,
+            VaultState::Active => e.ledger().timestamp() >= get_maturity_date(e),
+            _ => false,
+        }
+    }
+
     // ─────────────────────────────────────────────────────────────────
     // Deposit limits
     // ─────────────────────────────────────────────────────────────────
@@ -1630,6 +1649,26 @@ impl SingleRWAVault {
     /// Backward-compatible: returns `true` when `account` holds `FullOperator`.
     pub fn is_operator(e: &Env, account: Address) -> bool {
         get_operator(e, &account)
+    }
+
+    /// Returns a bounded page of addresses that currently hold the `FullOperator` superrole.
+    ///
+    /// `offset` is zero-based within the full operator list.
+    /// `limit` is capped at `MAX_OPERATOR_PAGE_SIZE` (50) to prevent expensive queries.
+    /// Returns an empty vec when `offset >= total` or `limit == 0`.
+    pub fn list_operators(e: &Env, offset: u32, limit: u32) -> Vec<Address> {
+        let capped = limit.min(MAX_OPERATOR_PAGE_SIZE);
+        let operators = get_operator_list(e);
+        let total = operators.len();
+        let mut result = Vec::new(e);
+        if offset >= total || capped == 0 {
+            return result;
+        }
+        let end = (offset + capped).min(total);
+        for i in offset..end {
+            result.push_back(operators.get(i).unwrap());
+        }
+        result
     }
 
     pub fn transfer_admin(e: &Env, caller: Address, _new_admin: Address) {

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -127,6 +127,9 @@ pub enum Key {
     // --- Transfer KYC gate ---
     XferKyc,
 
+    // --- Operator list (FullOperator addresses) ---
+    OperatorList,
+
     // --- Emergency pro-rata distribution ---
     EmgBal,
     HasClmEmg(Address),
@@ -220,6 +223,7 @@ impl soroban_sdk::IntoVal<Env, soroban_sdk::Val> for Key {
             Key::RedCnt => 42u32.into_val(env),
             Key::TransferExemptList => 45u32.into_val(env),
             Key::XferKyc => 46u32.into_val(env),
+            Key::OperatorList => 52u32.into_val(env),
             Key::EmgBal => 47u32.into_val(env),
             Key::EmgTotSup => 49u32.into_val(env),
             Key::TlkDelay => 50u32.into_val(env),
@@ -308,6 +312,7 @@ impl soroban_sdk::TryFromVal<Env, soroban_sdk::Val> for Key {
             42 => Ok(Key::RedCnt),
             45 => Ok(Key::TransferExemptList),
             46 => Ok(Key::XferKyc),
+            52 => Ok(Key::OperatorList),
             47 => Ok(Key::EmgBal),
             49 => Ok(Key::EmgTotSup),
             50 => Ok(Key::TlkDelay),
@@ -570,9 +575,43 @@ pub fn get_operator(e: &Env, addr: &Address) -> bool {
     get_role(e, addr, Role::FullOperator)
 }
 
+/// Returns the list of all addresses currently holding the FullOperator superrole.
+pub fn get_operator_list(e: &Env) -> Vec<Address> {
+    e.storage()
+        .instance()
+        .get(&Key::OperatorList)
+        .unwrap_or_else(|| Vec::new(e))
+}
+
+fn put_operator_list(e: &Env, list: &Vec<Address>) {
+    if list.is_empty() {
+        e.storage().instance().remove(&Key::OperatorList);
+    } else {
+        e.storage().instance().set(&Key::OperatorList, list);
+    }
+}
+
 /// Grant or revoke the `FullOperator` superrole for `addr`.
+/// Maintains the operator list so `list_operators` can paginate without scanning all keys.
 pub fn put_operator(e: &Env, addr: Address, val: bool) {
-    put_role(e, addr, Role::FullOperator, val);
+    put_role(e, addr.clone(), Role::FullOperator, val);
+
+    let mut list = get_operator_list(e);
+    let already_listed = (0..list.len()).any(|i| list.get(i).unwrap() == addr);
+
+    if val && !already_listed {
+        list.push_back(addr);
+        put_operator_list(e, &list);
+    } else if !val && already_listed {
+        let mut updated = Vec::new(e);
+        for i in 0..list.len() {
+            let entry = list.get(i).unwrap();
+            if entry != addr {
+                updated.push_back(entry);
+            }
+        }
+        put_operator_list(e, &updated);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -28,6 +28,9 @@ use crate::storage::*;
 /// exceeding this limit risks exhausting the transaction's CPU budget.
 const MAX_BATCH_SIZE: u32 = 10;
 
+/// Maximum page size for status-filtered vault list queries.
+const MAX_STATUS_PAGE_SIZE: u32 = 50;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Contract
 // ─────────────────────────────────────────────────────────────────────────────
@@ -58,6 +61,7 @@ impl VaultFactory {
         put_default_zkme_verifier(e, zkme_verifier);
         put_default_cooperator(e, cooperator);
         put_vault_wasm_hash(e, vault_wasm_hash);
+        put_default_fee_bps(e, 200u32);
         put_operator(e, admin, true);
         // Versioning
         put_contract_version(e, 1u32);
@@ -429,6 +433,60 @@ impl VaultFactory {
 
     pub fn aggregator_vault(e: &Env) -> Option<Address> {
         get_aggregator_vault(e)
+    }
+
+    /// Returns all factory-level defaults in a single call.
+    ///
+    /// Useful for vault creation forms and deployment scripts that need the
+    /// current default asset, verifier, cooperator, fee bps, and wasm hash
+    /// without making five separate contract calls.
+    pub fn get_defaults_snapshot(e: &Env) -> FactoryDefaultsSnapshot {
+        bump_instance(e);
+        FactoryDefaultsSnapshot {
+            default_asset: get_default_asset(e),
+            zkme_verifier: get_default_zkme_verifier(e),
+            cooperator: get_default_cooperator(e),
+            fee_bps: get_default_fee_bps(e),
+            vault_wasm_hash: get_vault_wasm_hash(e),
+        }
+    }
+
+    /// Returns a status-filtered page of vault addresses.
+    ///
+    /// `status` must be `VaultStatus::Active` or `VaultStatus::Inactive`.
+    /// `offset` is zero-based within the filtered set.
+    /// `limit` is capped at `MAX_STATUS_PAGE_SIZE` (50) to prevent expensive queries.
+    /// Returns an empty vec when the filtered set is empty or `offset` is out of range.
+    pub fn list_vaults_by_status(
+        e: &Env,
+        status: VaultStatus,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Address> {
+        let capped = limit.min(MAX_STATUS_PAGE_SIZE);
+        let total = get_vault_count(e);
+        let mut result: Vec<Address> = Vec::new(e);
+        if capped == 0 {
+            return result;
+        }
+        let want_active = status == VaultStatus::Active;
+        let mut cursor: u32 = 0;
+        for i in 0..total {
+            if let Some(vault) = get_vault_at_index(e, i) {
+                if let Some(info) = get_vault_info(e, &vault) {
+                    if info.active == want_active {
+                        if cursor >= offset {
+                            result.push_back(vault);
+                            if result.len() >= capped {
+                                break;
+                            }
+                        }
+                        cursor += 1;
+                    }
+                }
+            }
+        }
+        result
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/vault_factory/src/storage.rs
+++ b/soroban-contracts/contracts/vault_factory/src/storage.rs
@@ -41,6 +41,7 @@ pub enum DataKey {
     VaultCount,
     VaultDeployCounter,
     VaultsByAsset(Address),
+    DefaultFeeBps,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -178,6 +179,16 @@ pub fn get_aggregator_vault(e: &Env) -> Option<Address> {
 #[allow(dead_code)]
 pub fn put_aggregator_vault(e: &Env, val: Address) {
     e.storage().instance().set(&DataKey::AggregatorVault, &val);
+}
+
+pub fn get_default_fee_bps(e: &Env) -> u32 {
+    e.storage()
+        .instance()
+        .get(&DataKey::DefaultFeeBps)
+        .unwrap_or(200)
+}
+pub fn put_default_fee_bps(e: &Env, val: u32) {
+    e.storage().instance().set(&DataKey::DefaultFeeBps, &val);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/vault_factory/src/types.rs
+++ b/soroban-contracts/contracts/vault_factory/src/types.rs
@@ -1,6 +1,6 @@
 //! Shared types for VaultFactory.
 
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contracttype, Address, BytesN, String};
 
 /// Vault type — mirrors the Solidity VaultType enum.
 #[contracttype]
@@ -77,6 +77,29 @@ pub type CreateVaultParams = BatchVaultParams;
 // ─────────────────────────────────────────────────────────────────────────────
 // Role-Based Access Control
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// Snapshot of factory-level defaults returned by `get_defaults_snapshot()`.
+///
+/// Useful for vault creation forms and deployment scripts that need all
+/// factory defaults in a single contract call.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FactoryDefaultsSnapshot {
+    pub default_asset: Address,
+    pub zkme_verifier: Address,
+    pub cooperator: Address,
+    /// Default early-redemption fee in basis points (e.g. 200 = 2 %).
+    pub fee_bps: u32,
+    pub vault_wasm_hash: BytesN<32>,
+}
+
+/// Status filter used by `list_vaults_by_status`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum VaultStatus {
+    Active,
+    Inactive,
+}
 
 /// Granular operator role for on-chain access control.
 ///


### PR DESCRIPTION
Closes #269
Closes #275
Closes #277
Closes #286

## What changed

### #286 — `is_matured()` convenience view (single_rwa_vault)
- Returns `true` when the vault state is `Matured` or `Closed`
- Also returns `true` when state is `Active` and ledger timestamp >= maturity_date
- Eliminates repeated state+timestamp checks in client code

### #269 — `list_operators(offset, limit)` with bounded pagination (single_rwa_vault)
- Adds `OperatorList` instance-storage key (ID 52) to track FullOperator addresses
- `put_operator()` now maintains the list on grant/revoke
- `list_operators(offset, limit)` returns a page of FullOperator addresses with max page size 50

### #275 — `get_defaults_snapshot()` factory view (vault_factory)
- Adds `FactoryDefaultsSnapshot` struct with `default_asset`, `zkme_verifier`, `cooperator`, `fee_bps`, `vault_wasm_hash`
- Adds `DefaultFeeBps` storage key, initialised to 200 bps in the constructor
- Returns all factory defaults in a single contract call

### #277 — `list_vaults_by_status(status, offset, limit)` (vault_factory)
- Adds `VaultStatus` enum (`Active` / `Inactive`) to types
- Filters the vault registry by `VaultInfo.active` flag with zero-based pagination
- Max page size 50 to prevent exhausting CPU budget on large registries

## How to test
- **#286** — Set vault to Active state with maturity_date in the past; `is_matured()` returns true. Set to Matured state; returns true. In Funding state; returns false.
- **#269** — Call `set_operator(addr, true)`; then `list_operators(0, 10)` returns the address. Revoke; address disappears from the list.
- **#275** — Call `get_defaults_snapshot()` after construction; verify all five fields match the constructor args and `fee_bps == 200`.
- **#277** — Register active and inactive vaults; `list_vaults_by_status(Active, 0, 50)` returns only active ones; `Inactive` returns the rest.