### PR TITLE
feat: vault improvements (closes #119, #121, #124, #167)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,88 @@
+# SingleRWAVault — Resource Cost Benchmarks
+
+This document tracks CPU instruction and memory cost for the `single_rwa_vault`
+contract's hot-path entry points so regressions are visible in PRs.
+
+The benchmarks are implemented as `#[ignore]` tests in
+`contracts/single_rwa_vault/src/bench.rs` and emit `cpu=…` / `mem=…` lines via
+`println!`. Numbers below are produced by running them in native Rust mode —
+WASM execution will be **strictly more expensive** (per the soroban-sdk
+docs: *"CPU instructions are likely to be underestimated when running Rust
+code compared to running the WASM equivalent"*). Treat the numbers as
+**relative** indicators, not absolute on-chain costs.
+
+## Running
+
+```bash
+# Just the benchmarks, with output captured
+cargo test --package single_rwa_vault --lib bench:: -- --ignored --nocapture
+
+# The always-on regression check (runs in normal CI):
+cargo test --package single_rwa_vault --lib bench::bench_deposit_within_cpu_budget
+```
+
+## Cost table (native Rust, soroban-sdk 22.0.11)
+
+| Function                  | CPU instructions | Memory bytes |
+| ------------------------- | ---------------: | -----------: |
+| `deposit`                 |          362,082 |       87,149 |
+| `withdraw`                |          520,917 |       95,888 |
+| `transfer`                |          421,237 |       80,755 |
+| `distribute_yield`        |          178,089 |       56,944 |
+| `claim_yield` (1 epoch)   |          496,099 |      110,592 |
+| `claim_yield` (10 epochs) |        2,267,007 |      405,432 |
+| `claim_yield` (50 epochs) |       15,523,415 |    3,244,632 |
+| `redeem_at_maturity`      |          530,046 |      100,617 |
+
+Stellar Soroban's per-transaction CPU instruction budget is **100,000,000**.
+Even at 50 epochs, native `claim_yield` consumes ~15.5% of that — the WASM
+multiplier and per-user state growth are the real risk.
+
+## Scaling observations
+
+- **`claim_yield` is linear in epoch count.** From 1 → 10 → 50 epochs the cost
+  grows ~4.6× → ~31×. The slope is **~310k CPU instructions per additional
+  epoch**, dominated by the `update_user_snapshot` walk plus per-epoch
+  `HasClaimedEpoch` writes. A single user accumulating ~250 unclaimed epochs
+  natively would already approach the 80M-instruction alarm threshold; in
+  WASM that ceiling will be hit much sooner.
+- **`deposit`, `withdraw`, `transfer`, `redeem_at_maturity`** all sit in the
+  300k–530k native CPU range and do not scale with epoch count for the
+  caller. They scale weakly with the *number of unclaimed epochs* on the
+  user's snapshot the first time the user touches the vault after a long
+  break, via `update_user_snapshot`.
+- **`distribute_yield`** is the cheapest entry point (~178k native CPU). It
+  records a fixed set of instance-storage entries per epoch
+  (`EpYield`, `EpTotShr`, `EpTimest`, and now `EpochTotalAssets` from #119)
+  and does not iterate users.
+
+## Identified bottlenecks and recommendations
+
+1. **`update_user_snapshot` walks every unclaimed epoch.** The 50-epoch
+   `claim_yield` shows the linear blow-up. Recommendations:
+   - Batch the snapshot write — store a single "last interacted at epoch N
+     with shares S" row instead of per-epoch `UsrShrEp` entries.
+   - Cap `claim_yield` to a bounded epoch window (e.g. 64) and require users
+     to call it again to drain the rest. Predictable per-call cost beats
+     unpredictable big claims.
+2. **`pending_yield` performs the same linear scan as `claim_yield`.** It is
+   called as a *view* but is no cheaper than the write path. Either share
+   the cursor logic so view and write produce the same bound, or document
+   that view calls past ~128 epochs may exceed the simulator budget.
+3. **`vault_factory::get_active_vaults` is O(n) with cross-contract calls.**
+   Not measured here (different package), but flagged for parity: switching
+   to an indexed list of active vaults would remove the per-vault probe.
+4. **`bump_instance` on view functions:** verified — currently only invoked
+   from state-mutating functions in this contract, so there is nothing to
+   strip on the view side. Keep it that way; reviewers should reject any new
+   `bump_instance` call on a `pub fn` that does not write storage.
+
+## Regression guard
+
+`bench::bench_deposit_within_cpu_budget` runs on every CI invocation
+(it is *not* `#[ignore]`) and asserts that native `deposit` consumes fewer
+than 80% of the Soroban per-transaction CPU budget (80,000,000 instructions).
+Native execution is much cheaper than WASM, so this only catches dramatic
+regressions — it is a smoke alarm, not a precise meter. Real budget-fit
+verification should be done on testnet with `soroban contract invoke`
+diagnostics or a soroban-cli simulation against a deployed WASM build.

--- a/soroban-contracts/contracts/single_rwa_vault/src/bench.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/bench.rs
@@ -1,0 +1,201 @@
+//! Resource-cost benchmarks for `SingleRWAVault` (#124).
+//!
+//! Run with:
+//!
+//!   `cargo test --package single_rwa_vault --lib bench:: -- --ignored --nocapture`
+//!
+//! The benchmarks reset the Soroban budget before each call, exercise one
+//! contract entry point, and print `cpu_instruction_cost` and
+//! `memory_bytes_cost`. The output is intended to be copied into
+//! `BENCHMARKS.md` so cost regressions over time are visible in PRs.
+//!
+//! `bench_deposit_within_cpu_budget` is *not* `#[ignore]` — it runs in
+//! every CI invocation as a coarse regression check that the hot deposit
+//! path stays well under the Soroban per-transaction CPU budget. The
+//! threshold is intentionally generous: native execution underestimates
+//! WASM CPU cost (per the SDK docs), so we only catch dramatic regressions.
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address,
+};
+use std::println;
+
+use crate::test_helpers::{mint_usdc, setup_with_kyc_bypass, TestContext};
+
+// Minimum funding to clear the default `funding_target` (100 USDC) so the
+// vault can be `activate_vault`'d in benches that need an Active state.
+const FUNDING: i128 = 100_000_000;
+
+// Soroban mainnet per-transaction CPU instruction budget.
+const SOROBAN_CPU_BUDGET: u64 = 100_000_000;
+// Regression alarm bound: 80% of the per-tx budget.
+const REGRESSION_BUDGET: u64 = SOROBAN_CPU_BUDGET * 80 / 100;
+
+fn measure<F: FnOnce()>(ctx: &TestContext, label: &str, f: F) -> (u64, u64) {
+    // Reset unlimited so the call always completes; we read what it actually
+    // consumed afterward. The regression test compares against
+    // REGRESSION_BUDGET independently.
+    ctx.env.budget().reset_unlimited();
+    f();
+    let cpu = ctx.env.budget().cpu_instruction_cost();
+    let mem = ctx.env.budget().memory_bytes_cost();
+    println!("[bench] {label}: cpu={cpu} mem={mem}");
+    (cpu, mem)
+}
+
+fn fund(ctx: &TestContext, who: &Address, amount: i128) {
+    mint_usdc(&ctx.env, &ctx.asset_id, who, amount);
+    ctx.vault().deposit(who, &amount, who);
+}
+
+fn distribute(ctx: &TestContext, amount: i128) {
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.admin, amount);
+    ctx.vault().distribute_yield(&ctx.admin, &amount);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-function CPU/memory snapshots
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore]
+fn bench_deposit() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    mint_usdc(&ctx.env, &ctx.asset_id, &user, FUNDING);
+    measure(&ctx, "deposit", || {
+        ctx.vault().deposit(&user, &FUNDING, &user);
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_withdraw() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    fund(&ctx, &user, FUNDING);
+    ctx.vault().activate_vault(&ctx.admin);
+    measure(&ctx, "withdraw", || {
+        ctx.vault().withdraw(&user, &(FUNDING / 2), &user, &user);
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_transfer() {
+    let ctx = setup_with_kyc_bypass();
+    let alice = Address::generate(&ctx.env);
+    let bob = Address::generate(&ctx.env);
+    // Split funding so the combined deposit does not exceed the funding target.
+    fund(&ctx, &alice, FUNDING / 2);
+    fund(&ctx, &bob, FUNDING / 2);
+    measure(&ctx, "transfer", || {
+        ctx.vault().transfer(&alice, &bob, &(FUNDING / 10));
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_distribute_yield() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    fund(&ctx, &user, FUNDING);
+    ctx.vault().activate_vault(&ctx.admin);
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.admin, FUNDING / 10);
+    measure(&ctx, "distribute_yield", || {
+        ctx.vault().distribute_yield(&ctx.admin, &(FUNDING / 10));
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_claim_yield_1_epoch() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    fund(&ctx, &user, FUNDING);
+    ctx.vault().activate_vault(&ctx.admin);
+    distribute(&ctx, FUNDING / 10);
+    measure(&ctx, "claim_yield/1_epoch", || {
+        ctx.vault().claim_yield(&user);
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_claim_yield_10_epochs() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    fund(&ctx, &user, FUNDING);
+    ctx.vault().activate_vault(&ctx.admin);
+    for _ in 0..10 {
+        distribute(&ctx, FUNDING / 10);
+    }
+    measure(&ctx, "claim_yield/10_epochs", || {
+        ctx.vault().claim_yield(&user);
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_claim_yield_50_epochs() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    fund(&ctx, &user, FUNDING);
+    ctx.vault().activate_vault(&ctx.admin);
+    for _ in 0..50 {
+        distribute(&ctx, FUNDING / 10);
+    }
+    measure(&ctx, "claim_yield/50_epochs", || {
+        ctx.vault().claim_yield(&user);
+    });
+}
+
+#[test]
+#[ignore]
+fn bench_redeem_at_maturity() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    fund(&ctx, &user, FUNDING);
+    ctx.vault().activate_vault(&ctx.admin);
+
+    // Advance past maturity and mature the vault. (No yield distributions
+    // here — redeem_at_maturity also pays out pending yield, so distributing
+    // before maturity skews the bench toward the claim_yield code path.)
+    let maturity = ctx.vault().maturity_date();
+    ctx.env.ledger().with_mut(|li| {
+        li.timestamp = maturity + 1;
+    });
+    ctx.vault().mature_vault(&ctx.admin);
+
+    let shares = ctx.vault().balance(&user);
+    measure(&ctx, "redeem_at_maturity", || {
+        ctx.vault().redeem_at_maturity(&user, &shares, &user, &user);
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CPU regression alarm (always-on; not #[ignore])
+//
+// Native execution underestimates WASM cost, so we only flag obvious blow-ups.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bench_deposit_within_cpu_budget() {
+    let ctx = setup_with_kyc_bypass();
+    let user = Address::generate(&ctx.env);
+    mint_usdc(&ctx.env, &ctx.asset_id, &user, FUNDING);
+
+    let (cpu, _mem) = measure(&ctx, "deposit/regression", || {
+        ctx.vault().deposit(&user, &FUNDING, &user);
+    });
+
+    assert!(
+        cpu < REGRESSION_BUDGET,
+        "deposit consumed {cpu} CPU instructions natively, which exceeds 80% of the \
+         Soroban per-transaction budget ({REGRESSION_BUDGET}). WASM execution will be \
+         strictly more expensive — investigate the regression."
+    );
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/fuzz_tests.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/fuzz_tests.rs
@@ -193,6 +193,11 @@ proptest! {
             "share conservation violated: {} + {} + {} != {}",
             bal_a, bal_b, bal_c, total
         );
+
+        // Sanity: no balance is negative and none exceeds total supply.
+        prop_assert!(bal_a >= 0 && bal_b >= 0 && bal_c >= 0, "balance went negative");
+        prop_assert!(total >= 0, "total supply went negative");
+        prop_assert!(bal_a <= total && bal_b <= total && bal_c <= total, "balance exceeds total supply");
     }
 }
 
@@ -372,5 +377,58 @@ proptest! {
             "yield conservation violated after transfer: {} + {} > {}",
             pending_a, pending_b, distributed
         );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Property 7: Balance sanity invariants
+// Balances never go negative, never exceed total supply, and sum matches total.
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    #[test]
+    #[ignore]
+    fn fuzz_balance_sanity_invariants(
+        deposit_a in 1_000i128..10_000_000i128,
+        deposit_b in 1_000i128..10_000_000i128,
+        transfer_pct in 0u32..=100u32,
+    ) {
+        let ctx = setup();
+        let vault = SingleRWAVaultClient::new(&ctx.env, &ctx.vault_id);
+
+        let user_a = Address::generate(&ctx.env);
+        let user_b = Address::generate(&ctx.env);
+
+        mint_and_deposit(&ctx, &user_a, deposit_a);
+        mint_and_deposit(&ctx, &user_b, deposit_b);
+
+        let bal_a_before = vault.balance(&user_a);
+        let transfer_amount = bal_a_before.saturating_mul(transfer_pct as i128) / 100;
+        if transfer_amount > 0 {
+            vault.transfer(&user_a, &user_b, &transfer_amount);
+        }
+
+        let bal_a = vault.balance(&user_a);
+        let bal_b = vault.balance(&user_b);
+        let total = vault.total_supply();
+
+        prop_assert!(bal_a >= 0, "user_a balance negative: {}", bal_a);
+        prop_assert!(bal_b >= 0, "user_b balance negative: {}", bal_b);
+        prop_assert!(total >= 0, "total_supply negative: {}", total);
+
+        prop_assert!(bal_a <= total, "user_a balance ({}) exceeds total_supply ({})", bal_a, total);
+        prop_assert!(bal_b <= total, "user_b balance ({}) exceeds total_supply ({})", bal_b, total);
+
+        prop_assert_eq!(
+            bal_a + bal_b,
+            total,
+            "sum of balances ({} + {}) != total_supply ({})",
+            bal_a, bal_b, total
+        );
+
+        // Overflow sanity: adding the two balances must not wrap.
+        prop_assert!(bal_a.checked_add(bal_b).is_some(), "balance sum overflowed");
     }
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -9,6 +9,8 @@ mod token_interface;
 mod types;
 
 #[cfg(test)]
+mod bench;
+#[cfg(test)]
 mod fuzz_tests;
 #[cfg(test)]
 mod test_access_control;

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -1407,6 +1407,10 @@ impl SingleRWAVault {
             panic_with_error!(e, Error::InsufficientBalance);
         }
 
+        // Lock the asset value at request time so that yield distributed
+        // (or removed) between now and processing cannot move the payout.
+        let locked_asset_value = preview_redeem(e, shares);
+
         // --- Effects (Escrow shares) ---
         put_share_balance(e, &caller, bal - shares);
         let escrowed = get_escrowed_shares(e, &caller) + shares;
@@ -1424,6 +1428,7 @@ impl SingleRWAVault {
                 shares,
                 request_time: e.ledger().timestamp(),
                 processed: false,
+                locked_asset_value,
             },
         );
 
@@ -1457,12 +1462,20 @@ impl SingleRWAVault {
             panic_with_error!(e, Error::InsufficientBalance);
         }
 
-        // Payout math before irreversible updates — `preview_redeem` may panic on dust
-        // (ERC-4626 zero-asset guard) and must not run after escrow/supply are changed.
-        let assets = preview_redeem(e, req.shares);
+        // Use the asset value snapshotted at request time, not the current
+        // share price. This protects the user from share-price moves between
+        // request and processing.
+        let assets = req.locked_asset_value;
         let fee_bps = get_early_redemption_fee_bps(e) as i128;
         let fee = math::mul_div(e, assets, fee_bps, 10000);
         let net_assets = assets - fee;
+
+        // Vault liquidity guard: refuse to process if the locked payout exceeds
+        // the vault's current asset balance. The operator can wait for more
+        // assets, or the user can cancel the request.
+        if asset_balance_of_vault(e) < net_assets {
+            panic_with_error!(e, Error::InsufficientBalance);
+        }
 
         // --- Effects ---
         req.processed = true;

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -63,6 +63,8 @@ mod test_redemption;
 #[cfg(test)]
 mod test_rwa_setters;
 #[cfg(test)]
+mod test_share_price_oracle;
+#[cfg(test)]
 mod test_token;
 #[cfg(test)]
 mod test_vault_state_guards;
@@ -700,6 +702,59 @@ impl SingleRWAVault {
     }
 
     // ─────────────────────────────────────────────────────────────────
+    // Share-price oracle views (#119)
+    //
+    // External integrators (lending markets, DEXs, NAV reporters) can read
+    // the live share price without computing the ratio off-chain.  Historical
+    // price is available per epoch via `price_per_share_history`.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Live share price scaled by `10^share_decimals`.
+    /// Returns `10^share_decimals` (par) when `total_supply == 0`.
+    pub fn share_price(e: &Env) -> i128 {
+        let decimals = get_share_decimals(e);
+        Self::share_price_with_precision(e, decimals)
+    }
+
+    /// Live share price scaled by `10^precision`. Returns `10^precision` (par)
+    /// when `total_supply == 0`. Caps `precision` at 18 to keep `pow` bounded
+    /// and the result within `i128`.
+    pub fn share_price_with_precision(e: &Env, precision: u32) -> i128 {
+        let p = if precision > 18 { 18 } else { precision };
+        let scale: i128 = 10i128.pow(p);
+        let supply = get_total_supply(e);
+        if supply == 0 {
+            return scale;
+        }
+        math::mul_div(e, total_assets(e), scale, supply)
+    }
+
+    /// Returns `(total_assets, total_supply)` for callers that prefer to
+    /// compute the ratio themselves (e.g. with their own scaling or rounding).
+    pub fn exchange_rate(e: &Env) -> (i128, i128) {
+        (total_assets(e), get_total_supply(e))
+    }
+
+    /// Net Asset Value per share. Alias for `share_price` named for traditional
+    /// finance integrators.
+    pub fn nav_per_share(e: &Env) -> i128 {
+        Self::share_price(e)
+    }
+
+    /// Share price at a specific epoch, scaled by `10^share_decimals`.
+    /// Reads the `(total_assets, total_supply)` pair snapshotted by
+    /// `distribute_yield`. Returns `0` for epochs with no recorded supply.
+    pub fn price_per_share_history(e: &Env, epoch: u32) -> i128 {
+        let supply = get_epoch_total_shares(e, epoch);
+        if supply == 0 {
+            return 0;
+        }
+        let assets = get_epoch_total_assets(e, epoch);
+        let scale: i128 = 10i128.pow(get_share_decimals(e));
+        math::mul_div(e, assets, scale, supply)
+    }
+
+    // ─────────────────────────────────────────────────────────────────
     // Yield distribution
     // ─────────────────────────────────────────────────────────────────
 
@@ -736,7 +791,10 @@ impl SingleRWAVault {
         put_epoch_total_shares(e, epoch, total_supply);
         put_epoch_timestamp(e, epoch, e.ledger().timestamp());
         put_total_yield_distributed(e, get_total_yield_distributed(e) + amount);
-        put_total_deposited(e, get_total_deposited(e) + amount);
+        let new_total_deposited = get_total_deposited(e) + amount;
+        put_total_deposited(e, new_total_deposited);
+        // Snapshot total_assets at this epoch for the share-price oracle (#119).
+        put_epoch_total_assets(e, epoch, new_total_deposited);
 
         emit_yield_distributed(e, epoch, amount, e.ledger().timestamp());
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -1039,6 +1039,31 @@ pub fn has_timelock_action(e: &Env, action_id: u32) -> bool {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Per-epoch share-price oracle snapshot (instance storage, keyed by epoch).
+// Captured at distribute_yield so historical share price is computable from
+// the recorded (total_assets, total_shares) pair without iterating users.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum OracleDataKey {
+    EpochTotalAssets(u32),
+}
+
+pub fn get_epoch_total_assets(e: &Env, epoch: u32) -> i128 {
+    e.storage()
+        .instance()
+        .get(&OracleDataKey::EpochTotalAssets(epoch))
+        .unwrap_or(0)
+}
+
+pub fn put_epoch_total_assets(e: &Env, epoch: u32, val: i128) {
+    e.storage()
+        .instance()
+        .set(&OracleDataKey::EpochTotalAssets(epoch), &val);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Per-epoch activity tracking (persistent, keyed by epoch or lifetime)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
@@ -1130,3 +1130,114 @@ fn test_partial_early_redemption_then_full_redemption_at_maturity() {
         "total received must be at least the deposited principal"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — Early redemption: share-price lock at request time (#121)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The asset value used at processing time is the value snapshotted at
+/// request time, not the value after a yield distribution moved the price.
+#[test]
+fn test_process_early_redemption_uses_locked_price_after_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, token_id, zkme_id, admin) = make_vault(&env);
+    let user = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    let user_deposit = 1_000_000i128;
+    let other_deposit = 1_000_000i128;
+    let shares = fund_user(&env, &vault_id, &token_id, &zkme_id, &user, user_deposit);
+    fund_user(&env, &vault_id, &token_id, &zkme_id, &other, other_deposit);
+
+    activate(&env, &vault_id, &admin);
+
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let token = MockTokenClient::new(&env, &token_id);
+
+    // Locked at 1:1 — locked_asset_value should equal the user's deposit.
+    let request_id = vault.request_early_redemption(&user, &shares);
+    let req = vault.redemption_request(&request_id);
+    assert_eq!(req.locked_asset_value, user_deposit);
+
+    // Distribute a large yield. preview_redeem(shares) would now exceed
+    // user_deposit, but the locked value is what must be paid out.
+    let yield_amt = 500_000i128;
+    distribute_yield(&env, &vault_id, &token_id, &admin, yield_amt);
+
+    let vault_balance_before = token.balance(&vault_id);
+    vault.process_early_redemption(&admin, &request_id);
+
+    // Fee is computed on the locked value (default fee_bps = 200).
+    let fee = (user_deposit * 200) / 10000;
+    let net_assets = user_deposit - fee;
+
+    assert_eq!(token.balance(&user), net_assets);
+    assert_eq!(token.balance(&vault_id), vault_balance_before - net_assets);
+}
+
+/// Symmetric guarantee: if the share price drops between request and process
+/// (e.g. distributing yield to escrowed/non-requested shares while supply
+/// shifts), the user still receives the locked value, not a reduced one.
+#[test]
+fn test_process_early_redemption_locked_price_unchanged_by_subsequent_request() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, token_id, zkme_id, admin) = make_vault(&env);
+    let user = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    let deposit_amount = 1_000_000i128;
+    let user_shares = fund_user(&env, &vault_id, &token_id, &zkme_id, &user, deposit_amount);
+    let other_shares = fund_user(&env, &vault_id, &token_id, &zkme_id, &other, deposit_amount);
+
+    activate(&env, &vault_id, &admin);
+
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let token = MockTokenClient::new(&env, &token_id);
+
+    let req_id = vault.request_early_redemption(&user, &user_shares);
+    let locked = vault.redemption_request(&req_id).locked_asset_value;
+    assert_eq!(locked, deposit_amount);
+
+    // Another user's request and a yield distribution happen in the meantime.
+    let _ = vault.request_early_redemption(&other, &other_shares);
+    distribute_yield(&env, &vault_id, &token_id, &admin, 250_000i128);
+
+    let user_balance_before = token.balance(&user);
+    vault.process_early_redemption(&admin, &req_id);
+
+    let fee = (locked * 200) / 10000;
+    let net_assets = locked - fee;
+    assert_eq!(token.balance(&user) - user_balance_before, net_assets);
+}
+
+/// If the vault's asset balance is too low to satisfy the locked payout,
+/// processing must revert with `InsufficientVaultBalance` rather than pay
+/// out a different amount.
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")]
+fn test_process_early_redemption_reverts_when_vault_underfunded() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, token_id, zkme_id, admin) = make_vault(&env);
+    let user = Address::generate(&env);
+
+    let deposit_amount = 1_000_000i128;
+    let shares = fund_user(&env, &vault_id, &token_id, &zkme_id, &user, deposit_amount);
+    activate(&env, &vault_id, &admin);
+
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let token = MockTokenClient::new(&env, &token_id);
+
+    let request_id = vault.request_early_redemption(&user, &shares);
+
+    // Drain the vault's asset balance so the locked payout is unfunded.
+    let drain = token.balance(&vault_id);
+    token.transfer(&vault_id, &admin, &drain);
+
+    vault.process_early_redemption(&admin, &request_id);
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_share_price_oracle.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_share_price_oracle.rs
@@ -1,0 +1,241 @@
+extern crate std;
+
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env, String};
+
+use crate::{InitParams, SingleRWAVault, SingleRWAVaultClient};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock SEP-41 token + zkMe verifier (auto-approve)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct MockToken;
+
+#[contractimpl]
+impl MockToken {
+    pub fn balance(e: Env, id: Address) -> i128 {
+        e.storage().persistent().get(&id).unwrap_or(0i128)
+    }
+    pub fn transfer(e: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let from_bal: i128 = e.storage().persistent().get(&from).unwrap_or(0);
+        if from_bal < amount {
+            panic!("insufficient balance");
+        }
+        e.storage().persistent().set(&from, &(from_bal - amount));
+        let to_bal: i128 = e.storage().persistent().get(&to).unwrap_or(0);
+        e.storage().persistent().set(&to, &(to_bal + amount));
+    }
+    pub fn mint(e: Env, to: Address, amount: i128) {
+        let bal: i128 = e.storage().persistent().get(&to).unwrap_or(0);
+        e.storage().persistent().set(&to, &(bal + amount));
+    }
+}
+
+#[contract]
+pub struct MockZkme;
+
+#[contractimpl]
+impl MockZkme {
+    pub fn has_approved(_e: Env, _cooperator: Address, _user: Address) -> bool {
+        true
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers (share_decimals = 6, so par price = 1_000_000)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PAR: i128 = 1_000_000; // 10^6
+
+fn make_vault(env: &Env) -> (Address, Address, Address) {
+    let admin = Address::generate(env);
+    let cooperator = Address::generate(env);
+    let token_id = env.register(MockToken, ());
+    let zkme_id = env.register(MockZkme, ());
+    let vault_id = env.register(
+        SingleRWAVault,
+        (InitParams {
+            asset: token_id.clone(),
+            share_name: String::from_str(env, "Oracle Share"),
+            share_symbol: String::from_str(env, "OS"),
+            share_decimals: 6u32,
+            admin: admin.clone(),
+            zkme_verifier: zkme_id.clone(),
+            cooperator: cooperator.clone(),
+            funding_target: 0i128,
+            maturity_date: 9_999_999_999u64,
+            funding_deadline: 0u64,
+            min_deposit: 0i128,
+            max_deposit_per_user: 0i128,
+            early_redemption_fee_bps: 0u32,
+            rwa_name: String::from_str(env, "Bond"),
+            rwa_symbol: String::from_str(env, "BOND"),
+            rwa_document_uri: String::from_str(env, "https://example.com"),
+            rwa_category: String::from_str(env, "Bond"),
+            expected_apy: 500u32,
+            timelock_delay: 172800u64,
+            yield_vesting_period: 0u64,
+        },),
+    );
+    (vault_id, token_id, admin)
+}
+
+fn fund(env: &Env, vault_id: &Address, token_id: &Address, who: &Address, amount: i128) {
+    MockTokenClient::new(env, token_id).mint(who, &amount);
+    SingleRWAVaultClient::new(env, vault_id).deposit(who, &amount, who);
+}
+
+fn distribute(env: &Env, vault_id: &Address, token_id: &Address, admin: &Address, amount: i128) {
+    MockTokenClient::new(env, token_id).mint(admin, &amount);
+    SingleRWAVaultClient::new(env, vault_id).distribute_yield(admin, &amount);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live views — share_price / nav_per_share / exchange_rate
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_share_price_returns_par_when_supply_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, _t, _a) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+
+    assert_eq!(vault.share_price(), PAR);
+    assert_eq!(vault.nav_per_share(), PAR);
+    assert_eq!(vault.exchange_rate(), (0, 0));
+}
+
+#[test]
+fn test_share_price_par_after_first_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, token_id, _admin) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let user = Address::generate(&env);
+
+    fund(&env, &vault_id, &token_id, &user, 1_000_000);
+
+    // Initial 1:1 deposit → price stays at par (10^decimals).
+    assert_eq!(vault.share_price(), PAR);
+    assert_eq!(vault.exchange_rate(), (1_000_000, 1_000_000));
+}
+
+#[test]
+fn test_share_price_increases_after_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, token_id, admin) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let user = Address::generate(&env);
+
+    fund(&env, &vault_id, &token_id, &user, 1_000_000);
+    vault.activate_vault(&admin);
+
+    let before = vault.share_price();
+    distribute(&env, &vault_id, &token_id, &admin, 500_000);
+    let after = vault.share_price();
+
+    // total_assets = 1_500_000; total_supply = 1_000_000.
+    // price = 1_500_000 * 10^6 / 1_000_000 = 1_500_000.
+    assert!(after > before);
+    assert_eq!(after, 1_500_000);
+
+    // exchange_rate exposes the raw pair.
+    assert_eq!(vault.exchange_rate(), (1_500_000, 1_000_000));
+}
+
+#[test]
+fn test_share_price_with_precision_scales() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, token_id, admin) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let user = Address::generate(&env);
+
+    fund(&env, &vault_id, &token_id, &user, 1_000_000);
+    vault.activate_vault(&admin);
+    distribute(&env, &vault_id, &token_id, &admin, 500_000);
+
+    // Same 1.5x ratio at different precisions.
+    assert_eq!(vault.share_price_with_precision(&0u32), 1);
+    assert_eq!(vault.share_price_with_precision(&2u32), 150);
+    assert_eq!(vault.share_price_with_precision(&6u32), 1_500_000);
+    assert_eq!(vault.share_price_with_precision(&8u32), 150_000_000);
+
+    // precision is capped at 18 — 100 should be clamped to 18.
+    let cap = vault.share_price_with_precision(&100u32);
+    let p18 = vault.share_price_with_precision(&18u32);
+    assert_eq!(cap, p18);
+}
+
+#[test]
+fn test_share_price_with_precision_par_when_supply_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, _t, _a) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+
+    assert_eq!(vault.share_price_with_precision(&0u32), 1);
+    assert_eq!(vault.share_price_with_precision(&6u32), 1_000_000);
+    assert_eq!(vault.share_price_with_precision(&18u32), 10i128.pow(18));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// price_per_share_history — uses the snapshotted (assets, supply) pair
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_price_per_share_history_records_each_epoch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, token_id, admin) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let user = Address::generate(&env);
+
+    fund(&env, &vault_id, &token_id, &user, 1_000_000);
+    vault.activate_vault(&admin);
+
+    // Epoch 1: +500k yield → assets = 1.5M, supply = 1M, price = 1.5x par.
+    distribute(&env, &vault_id, &token_id, &admin, 500_000);
+    // Epoch 2: +500k yield → assets = 2M, supply = 1M, price = 2x par.
+    distribute(&env, &vault_id, &token_id, &admin, 500_000);
+
+    assert_eq!(vault.price_per_share_history(&1u32), 1_500_000);
+    assert_eq!(vault.price_per_share_history(&2u32), 2_000_000);
+}
+
+#[test]
+fn test_price_per_share_history_zero_for_unrecorded_epoch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, _t, _a) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+
+    // No distributions yet — any historical query returns 0.
+    assert_eq!(vault.price_per_share_history(&0u32), 0);
+    assert_eq!(vault.price_per_share_history(&1u32), 0);
+    assert_eq!(vault.price_per_share_history(&999u32), 0);
+}
+
+#[test]
+fn test_price_per_share_history_unaffected_by_later_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vault_id, token_id, admin) = make_vault(&env);
+    let vault = SingleRWAVaultClient::new(&env, &vault_id);
+    let user = Address::generate(&env);
+
+    fund(&env, &vault_id, &token_id, &user, 1_000_000);
+    vault.activate_vault(&admin);
+
+    distribute(&env, &vault_id, &token_id, &admin, 250_000);
+    let epoch1_price = vault.price_per_share_history(&1u32);
+
+    // A later yield distribution must not change historical epoch prices.
+    distribute(&env, &vault_id, &token_id, &admin, 1_000_000);
+    distribute(&env, &vault_id, &token_id, &admin, 1_000_000);
+
+    assert_eq!(vault.price_per_share_history(&1u32), epoch1_price);
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -125,6 +125,10 @@ pub struct RedemptionRequest {
     pub shares: i128,
     pub request_time: u64,
     pub processed: bool,
+    /// Asset value of `shares` snapshotted at request time. Used at processing
+    /// time so that yield distributed (or removed) between request and process
+    /// cannot move the payout the user agreed to.
+    pub locked_asset_value: i128,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Single PR bundling four upstream issues. Each commit is self-contained and closes one issue:

- **`test:` Closes #167** — sanity-check invariants in the fuzz harness (no contract logic change).
- **`fix:` Closes #121** — lock share price at early-redemption request time so yield distributions between request and processing cannot move the user's payout.
- **`feat:` Closes #119** — share-price oracle views (`share_price`, `share_price_with_precision`, `nav_per_share`, `exchange_rate`, `price_per_share_history`).
- **`perf:` Closes #124** — `bench.rs`, `BENCHMARKS.md`, an always-on CPU regression guard, and an audit confirming `bump_instance` is never called from pure view functions.

Branched off the freshly-synced `upstream/main` (HEAD `60bc0d1`) — `git rev-list --count HEAD..upstream/main = 0` at push time, so there are no merge conflicts.

## Per-issue notes

### #167 — fuzz sanity checks
- Added a new `fuzz_balance_sanity_invariants` proptest exercising balance + transfer paths.
- Extended `fuzz_share_conservation` with non-negative / non-overflow asserts.
- All checks are `prop_assert!` (correct form inside the proptest harness — the issue's text said `assert!`, but bare panics break shrinking).

### #121 — redemption price lock
- Added `RedemptionRequest.locked_asset_value: i128`, populated at request time with `preview_redeem(shares)`.
- `process_early_redemption` now uses `req.locked_asset_value` for both payout and fee math, so a yield distribution between the two calls cannot change the user's payout.
- New vault-liquidity guard: reverts with `Error::InsufficientBalance` if the locked payout exceeds the vault's current asset balance (operator can wait or the user can `cancel_early_redemption`).
- Implementation note: the issue suggested adding `Error::InsufficientVaultBalance = 51`, but `#[contracterror]` already sits at 50 variants and adding a 51st triggers `LengthExceedsMax` from soroban-sdk SCSpec. Reused the existing `InsufficientBalance` (#20) — the function context disambiguates the meaning.
- Three new tests cover: locked-price payout after a yield distribution, locked-price unchanged by other requests / subsequent yield, and the underfunded-vault revert.

### #119 — share-price oracle views
- New `OracleDataKey::EpochTotalAssets(u32)` (separate enum to avoid the same SCSpec variant cap as #121 above), populated by `distribute_yield`.
- `share_price` returns `total_assets * 10^share_decimals / total_supply`, falling back to `10^share_decimals` (par) when supply is zero.
- `share_price_with_precision(precision)` accepts an arbitrary precision capped at 18 to keep `pow` and the result inside `i128`.
- `price_per_share_history(epoch)` reads the snapshotted `(EpochTotalAssets, EpTotShr)` pair, returning 0 for unrecorded epochs.
- 8 new tests cover par fallback, par after first deposit, price increase after yield, precision scaling at 0/2/6/8/18, the 18-cap, history records each epoch, history zero for unrecorded epochs, history unaffected by later yield events.

### #124 — benchmarks + bump_instance audit
- `bench.rs` measures CPU + memory for `deposit`, `withdraw`, `transfer`, `distribute_yield`, `claim_yield(1/10/50)`, `redeem_at_maturity`. Each bench is `#[ignore]` so they don't run in routine CI; `cargo test bench:: -- --ignored --nocapture` produces fresh numbers.
- `BENCHMARKS.md` documents the cost table, observed scaling (`claim_yield` is linear at ~310k CPU/epoch native), and three optimization recommendations (batch user snapshots, bound claim_yield epoch window, replace `get_active_vaults` O(n) probe).
- Always-on `bench_deposit_within_cpu_budget` test asserts native `deposit` < 80% of Soroban's 100M per-tx CPU budget (smoke alarm for dramatic regressions; native underestimates WASM cost).
- `bump_instance` audit: all 54 occurrences in `lib.rs` are inside state-mutating entry points; no view function calls it. Documented as an invariant in `BENCHMARKS.md`.

## Test plan

- [x] `cargo test --package single_rwa_vault --lib` — **306 passed, 0 failed, 15 ignored** (7 fuzz + 8 bench).
- [x] `cargo test --package single_rwa_vault --lib bench:: -- --ignored --nocapture` — all 8 benches run cleanly, output captured in `BENCHMARKS.md`.
- [x] `cargo test --package single_rwa_vault --lib early_redemption` — 20/20 (incl. 3 new #121 tests).
- [x] `cargo test --package single_rwa_vault --lib test_share_price` — 8/8 (new #119 tests).
- [x] `cargo test --package single_rwa_vault --lib fuzz_balance_sanity_invariants -- --ignored` — 1000/1000 cases pass.
- [ ] Reviewer to confirm the `Error::InsufficientBalance` reuse for #121's vault-liquidity guard is acceptable, or request a separate variant once an existing one can be retired to free the SCSpec slot.