### PR TITLE
docs: add missing doc comment for symbol() method

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -2925,6 +2925,12 @@ impl SingleRWAVault {
     pub fn name(e: &Env) -> String {
         get_share_name(e)
     }
+    /// Returns the human-readable ticker/display symbol for the share token.
+    ///
+    /// This symbol is immutable and set once during contract initialization via the
+    /// `share_symbol` field in the `InitParams` struct. It cannot be changed after
+    /// contract deployment. The symbol is intended for display purposes in user
+    /// interfaces and wallets.
     pub fn symbol(e: &Env) -> String {
         get_share_symbol(e)
     }


### PR DESCRIPTION
Adds comprehensive documentation for the `symbol()` method explaining:
- That it returns the human-readable ticker/display symbol for the share token
- That the symbol is immutable and set once during initialization  
- That it's configured via the `share_symbol` field in `InitParams`

Closes #329