### PR TITLE
feat: add explicit vault getters and verifier update audit event

### DIFF
--- a/sdk/src/single-rwa-vault-client.ts
+++ b/sdk/src/single-rwa-vault-client.ts
@@ -38,8 +38,14 @@ export class SingleRwaVaultClient {
   zkmeVerifier(): SorobanOperation {
     return this.call("zkme_verifier");
   }
+  getZkmeVerifier(): SorobanOperation {
+    return this.call("get_zkme_verifier");
+  }
   cooperator(): SorobanOperation {
     return this.call("cooperator");
+  }
+  getCooperator(): SorobanOperation {
+    return this.call("get_cooperator");
   }
   setZkmeVerifier(caller: string, verifier: string): SorobanOperation {
     return this.call("set_zkme_verifier", scAddress(caller), scAddress(verifier));
@@ -182,6 +188,9 @@ export class SingleRwaVaultClient {
   }
   minDeposit(): SorobanOperation {
     return this.call("min_deposit");
+  }
+  getMinDeposit(): SorobanOperation {
+    return this.call("get_min_deposit");
   }
   maxDepositPerUser(): SorobanOperation {
     return this.call("max_deposit_per_user");

--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -6,8 +6,9 @@ use soroban_sdk::{symbol_short, Address, Env, String};
 
 use crate::types::{Role, VaultState};
 
-pub fn emit_zkme_verifier_updated(e: &Env, old: Address, new: Address) {
-    e.events().publish((symbol_short!("zkme_upd"),), (old, new));
+pub fn emit_zkme_verifier_updated(e: &Env, caller: Address, old: Address, new: Address) {
+    e.events()
+        .publish((symbol_short!("zkme_upd"), caller), (old, new));
 }
 
 pub fn emit_cooperator_updated(e: &Env, old: Address, new: Address) {

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -313,7 +313,13 @@ impl SingleRWAVault {
     pub fn zkme_verifier(e: &Env) -> Address {
         get_zkme_verifier(e)
     }
+    pub fn get_zkme_verifier(e: &Env) -> Address {
+        get_zkme_verifier(e)
+    }
     pub fn cooperator(e: &Env) -> Address {
+        get_cooperator(e)
+    }
+    pub fn get_cooperator(e: &Env) -> Address {
         get_cooperator(e)
     }
 
@@ -324,7 +330,7 @@ impl SingleRWAVault {
         require_valid_address(e, &verifier);
         let old = get_zkme_verifier(e);
         put_zkme_verifier(e, verifier.clone());
-        emit_zkme_verifier_updated(e, old, verifier);
+        emit_zkme_verifier_updated(e, caller, old, verifier);
         bump_instance(e);
     }
 
@@ -1890,6 +1896,9 @@ impl SingleRWAVault {
     /// - **Units**: Expressed in the vault's underlying asset units, consistent
     ///   with `decimals()`.
     pub fn min_deposit(e: &Env) -> i128 {
+        get_min_deposit(e)
+    }
+    pub fn get_min_deposit(e: &Env) -> i128 {
         get_min_deposit(e)
     }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_constructor.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_constructor.rs
@@ -86,6 +86,7 @@ fn test_vault_config_matches_init_params() {
     assert_eq!(v.funding_target(), ctx.params.funding_target);
     assert_eq!(v.maturity_date(), ctx.params.maturity_date);
     assert_eq!(v.min_deposit(), ctx.params.min_deposit);
+    assert_eq!(v.get_min_deposit(), ctx.params.min_deposit);
     assert_eq!(v.max_deposit_per_user(), ctx.params.max_deposit_per_user);
     assert_eq!(
         v.early_redemption_fee_bps(),
@@ -118,7 +119,9 @@ fn test_zkme_verifier_and_cooperator_stored() {
     let v = ctx.vault();
 
     assert_eq!(v.zkme_verifier(), ctx.kyc_id);
+    assert_eq!(v.get_zkme_verifier(), ctx.kyc_id);
     assert_eq!(v.cooperator(), ctx.cooperator);
+    assert_eq!(v.get_cooperator(), ctx.cooperator);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
@@ -213,3 +213,32 @@ fn test_transfer_exemption_set_emits_event_with_correct_schema() {
     let exempt: bool = data.into_val(&ctx.env);
     assert!(exempt, "transfer exemption event: data must match status");
 }
+
+#[test]
+fn test_set_zkme_verifier_emits_event_with_caller_and_addresses() {
+    let ctx = setup_with_kyc_bypass();
+    let new_verifier = soroban_sdk::Address::generate(&ctx.env);
+    let old_verifier = ctx.vault().zkme_verifier();
+
+    ctx.vault().set_zkme_verifier(&ctx.admin, &new_verifier);
+
+    let events = ctx.env.events().all();
+    let verifier_event = events.iter().find(|(contract, topics, _)| {
+        *contract == ctx.vault_id && {
+            let sym: soroban_sdk::Symbol = topics.get_unchecked(0).into_val(&ctx.env);
+            sym == symbol_short!("zkme_upd")
+        }
+    });
+    let (_, topics, data) = verifier_event.expect("zkme verifier event must be emitted");
+
+    let topic_caller: soroban_sdk::Address = topics.get_unchecked(1).into_val(&ctx.env);
+    assert_eq!(
+        topic_caller, ctx.admin,
+        "zkme verifier event: caller topic must match the authorized caller"
+    );
+
+    let (event_old, event_new): (soroban_sdk::Address, soroban_sdk::Address) =
+        data.into_val(&ctx.env);
+    assert_eq!(event_old, old_verifier, "zkme verifier event: old verifier must match");
+    assert_eq!(event_new, new_verifier, "zkme verifier event: new verifier must match");
+}


### PR DESCRIPTION
## Summary
- add explicit , , and  contract entrypoints while preserving the existing view methods
- update the TypeScript client with matching getter helpers for frontend/read-only usage
- expand the  event to include the authorized caller in the topic for better auditability
- add focused constructor and event coverage for the new getter aliases and verifier update event payload

## Verification
- attempted 

## Notes
-  is currently blocked by a pre-existing parser error in  around the existing  implementation on ; I did not fix that unrelated issue per instruction.

Closes #332
Closes #334
Closes #335
Closes #344