### PR TITLE
single_rwa_vault: add yield reconciliation view functions

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -842,10 +842,10 @@ impl SingleRWAVault {
 
         // Validate inputs
         if users.len() != shares.len() {
-            panic_with_error!(e, Error::InvalidInput);
+            panic_with_error!(e, Error::InvalidInitParams);
         }
         if users.len() > MAX_BATCH_SIZE {
-            panic_with_error!(e, Error::InvalidInput);
+            panic_with_error!(e, Error::InvalidInitParams);
         }
 
         let mut results: Vec<RedemptionPreflight> = Vec::new(e);
@@ -898,6 +898,11 @@ impl SingleRWAVault {
                 can_redeem,
                 reason,
             });
+        }
+
+        results
+    }
+
     /// Batched deposit preflight check (bounded to avoid expensive calls).
     /// Returns per-user deposit validation results with status codes and expected shares.
     /// Max batch size: 50 entries per call.
@@ -1818,6 +1823,107 @@ impl SingleRWAVault {
             is_kyc_verified: Self::is_kyc_verified(e, address),
         }
     }
+
+    /// Global yield accounting reconciliation snapshot for auditors.
+    pub fn get_yield_reconciliation(e: &Env) -> YieldReconciliation {
+        let total_yield_distributed = get_total_yield_distributed(e);
+        let lifetime = get_lifetime_activity(e);
+        let total_yield_claimed = lifetime.yield_claims_volume;
+        let total_yield_unclaimed = total_yield_distributed - total_yield_claimed;
+
+        let vault_asset_balance = asset_balance_of_vault(e);
+
+        // `total_deposited` currently tracks net inflows including yield distributions.
+        // Principal is therefore approximated as (total_deposited - total_yield_distributed).
+        let total_principal_deposited = (get_total_deposited(e) - total_yield_distributed).max(0);
+
+        let principal_plus_unclaimed = total_principal_deposited + total_yield_unclaimed;
+        let balance_discrepancy = vault_asset_balance - principal_plus_unclaimed;
+
+        YieldReconciliation {
+            total_yield_distributed,
+            total_yield_claimed,
+            total_yield_unclaimed,
+            vault_asset_balance,
+            total_principal_deposited,
+            balance_discrepancy,
+        }
+    }
+
+    /// Public reconciliation view of a user's current position.
+    pub fn get_user_position(e: &Env, user: Address) -> UserPosition {
+        let share_balance = get_share_balance(e, &user);
+        let total_supply = get_total_supply(e);
+        let share_percentage = if total_supply <= 0 || share_balance <= 0 {
+            0
+        } else {
+            math::mul_div(e, share_balance, 10_000, total_supply)
+        };
+
+        let pending_yield = Self::pending_yield(e, user.clone());
+        let total_yield_claimed = get_total_yield_claimed(e, &user);
+        let total_deposited = get_user_deposited(e, &user);
+
+        let estimated_redemption_value = if share_balance <= 0 {
+            pending_yield
+        } else {
+            preview_redeem(e, share_balance) + pending_yield
+        };
+
+        let last_interaction_epoch = get_last_interaction_epoch(e, &user);
+        let has_pending_redemption = get_escrowed_shares(e, &user) > 0;
+
+        UserPosition {
+            share_balance,
+            share_percentage,
+            total_deposited,
+            total_yield_claimed,
+            pending_yield,
+            estimated_redemption_value,
+            last_interaction_epoch,
+            has_pending_redemption,
+        }
+    }
+
+    /// High-level vault health snapshot for auditors and dashboards.
+    pub fn get_vault_health(e: &Env) -> VaultHealth {
+        let state = get_vault_state(e);
+        let paused = get_paused(e);
+        let total_supply = get_total_supply(e);
+        let total_assets = total_assets(e);
+        let share_price = if total_supply <= 0 || total_assets <= 0 {
+            0
+        } else {
+            math::mul_div(e, total_assets, PRECISION, total_supply)
+        };
+
+        let current_epoch = get_current_epoch(e);
+        let time_to_maturity = Self::time_to_maturity(e);
+
+        let target = get_funding_target(e);
+        let funding_progress = if target <= 0 || total_assets <= 0 {
+            0
+        } else {
+            math::mul_div(e, total_assets, 10_000, target).clamp(0, 10_000)
+        };
+
+        let lifetime = get_lifetime_activity(e);
+        let investor_count = lifetime
+            .new_investors
+            .saturating_sub(lifetime.exiting_investors);
+
+        VaultHealth {
+            state,
+            paused,
+            total_supply,
+            total_assets,
+            share_price,
+            current_epoch,
+            time_to_maturity,
+            funding_progress,
+            investor_count,
+        }
+    }
     /// Returns the total asset amount targeted during the Funding state.
     ///
     /// ## Decimals & Formatting
@@ -2045,6 +2151,8 @@ impl SingleRWAVault {
                 put_has_claimed_epoch(e, &owner, i, true);
             }
             put_total_yield_claimed(e, &owner, get_total_yield_claimed(e, &owner) + pending);
+            // Keep global reconciliation totals consistent with auto-claims at maturity.
+            record_yield_claim_activity(e, get_current_epoch(e), pending);
         }
 
         update_user_snapshot(e, &owner);

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_reconciliation.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_reconciliation.rs
@@ -1,0 +1,83 @@
+//! Tests for off-chain yield reconciliation view functions.
+
+extern crate std;
+
+use crate::test_helpers::{mint_usdc, setup_with_kyc_bypass, TestContext};
+
+fn deposit(ctx: &TestContext, user: &soroban_sdk::Address, assets: i128) {
+    mint_usdc(&ctx.env, &ctx.asset_id, user, assets);
+    ctx.vault().deposit(user, &assets, user);
+}
+
+fn activate(ctx: &TestContext) {
+    // Ensure funding target is reachable in tests.
+    let current = ctx.vault().total_assets();
+    if current < ctx.params.funding_target {
+        ctx.vault().set_funding_target(&ctx.admin, &current);
+    }
+    ctx.vault().activate_vault(&ctx.admin);
+}
+
+fn distribute_yield(ctx: &TestContext, amount: i128) {
+    mint_usdc(&ctx.env, &ctx.asset_id, &ctx.admin, amount);
+    ctx.vault().distribute_yield(&ctx.admin, &amount);
+}
+
+#[test]
+fn test_get_yield_reconciliation_empty_vault() {
+    let ctx = setup_with_kyc_bypass();
+
+    let rec = ctx.vault().get_yield_reconciliation();
+    assert_eq!(rec.total_yield_distributed, 0);
+    assert_eq!(rec.total_yield_claimed, 0);
+    assert_eq!(rec.total_yield_unclaimed, 0);
+    assert_eq!(rec.vault_asset_balance, 0);
+    assert_eq!(rec.total_principal_deposited, 0);
+    assert_eq!(rec.balance_discrepancy, 0);
+}
+
+#[test]
+fn test_get_yield_reconciliation_and_user_position_multi_user_multi_epoch() {
+    let ctx = setup_with_kyc_bypass();
+
+    // Two users deposit 10 and 30 (units = 6-decimal USDC).
+    deposit(&ctx, &ctx.user, 10_000_000);
+    let user_b = soroban_sdk::Address::generate(&ctx.env);
+    deposit(&ctx, &user_b, 30_000_000);
+
+    activate(&ctx);
+
+    // Distribute yield twice.
+    distribute_yield(&ctx, 4_000_000);
+    distribute_yield(&ctx, 6_000_000);
+
+    // User A claims yield; user B leaves it pending.
+    let claimed_a = ctx.vault().claim_yield(&ctx.user);
+    assert!(claimed_a > 0);
+
+    let rec = ctx.vault().get_yield_reconciliation();
+    assert_eq!(rec.total_yield_distributed, 10_000_000);
+    assert_eq!(rec.total_yield_unclaimed, rec.total_yield_distributed - rec.total_yield_claimed);
+
+    // Basic invariant: balance discrepancy should be zero under normal operation.
+    assert_eq!(
+        rec.balance_discrepancy, 0,
+        "vault accounting should reconcile under normal operations"
+    );
+
+    // User position fields are public and consistent.
+    let pos_a = ctx.vault().get_user_position(&ctx.user);
+    let pos_b = ctx.vault().get_user_position(&user_b);
+
+    assert_eq!(pos_a.total_yield_claimed, claimed_a);
+    assert!(pos_a.pending_yield >= 0);
+    assert!(pos_b.pending_yield > 0);
+
+    // Ownership percentage sums to ~10_000 bps (allow 1 bp rounding slack).
+    let total_bps = pos_a.share_percentage + pos_b.share_percentage;
+    assert!(
+        (9_999..=10_001).contains(&total_bps),
+        "share_percentage should sum to ~10_000 bps"
+    );
+}
+

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -194,6 +194,8 @@ pub struct RedemptionPreflight {
     pub assets_out: i128,
     pub can_redeem: bool,
     pub reason: String,
+}
+
 /// Composite epoch metadata for efficient indexer queries.
 /// Returns yield, total shares, and timestamp in a single call.
 #[contracttype]
@@ -315,6 +317,61 @@ pub struct UserOverview {
     pub total_deposited: i128,
     pub is_blacklisted: bool,
     pub is_kyc_verified: bool,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reconciliation / audit view structs
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Global yield accounting reconciliation snapshot.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct YieldReconciliation {
+    /// Sum of all epoch yields ever distributed.
+    pub total_yield_distributed: i128,
+    /// Sum of all yield ever claimed by users.
+    pub total_yield_claimed: i128,
+    /// Computed: distributed - claimed.
+    pub total_yield_unclaimed: i128,
+    /// Actual underlying token balance held by the vault contract.
+    pub vault_asset_balance: i128,
+    /// Net principal deposited (excludes yield distributions).
+    pub total_principal_deposited: i128,
+    /// Computed: vault_balance - (principal + unclaimed_yield).
+    pub balance_discrepancy: i128,
+}
+
+/// Public per-user position snapshot for reconciliation and support.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UserPosition {
+    pub share_balance: i128,
+    /// User's ownership percentage in basis points (0–10_000).
+    pub share_percentage: i128,
+    pub total_deposited: i128,
+    pub total_yield_claimed: i128,
+    pub pending_yield: i128,
+    pub estimated_redemption_value: i128,
+    pub last_interaction_epoch: u32,
+    pub has_pending_redemption: bool,
+}
+
+/// High-level vault health snapshot for auditors and dashboards.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VaultHealth {
+    pub state: VaultState,
+    pub paused: bool,
+    pub total_supply: i128,
+    pub total_assets: i128,
+    /// total_assets * PRECISION / total_supply (0 when supply is 0).
+    pub share_price: i128,
+    pub current_epoch: u32,
+    pub time_to_maturity: u64,
+    /// Funding progress in basis points (0–10_000).
+    pub funding_progress: i128,
+    /// Current investor count estimate.
+    pub investor_count: u32,
 }
 
 /// High-level vault metadata for one-call client initialization.


### PR DESCRIPTION
Closes #114

---

## Summary\n- Add reconciliation view structs and public getters: get_yield_reconciliation, get_user_position, get_vault_health.\n- Provide balance discrepancy calculation for audit/recon workflows.\n- Add tests covering multi-user, multi-epoch reconciliation and empty-vault edge case.\n\n## Notes\n- 	otal_principal_deposited is derived as (total_deposited - total_yield_distributed) to exclude yield inflows from principal.\n- 	otal_yield_claimed uses lifetime activity tracking; maturity auto-claims now also increment lifetime yield-claim volume for reconciliation consistency.\n\n## Test plan\n- cargo test -p single_rwa_vault\n

Made with [Cursor](https://cursor.com)