### PR TITLE
Add compliance event coverage and getter compatibility helpers

### DIFF
--- a/soroban-contracts/README.md
+++ b/soroban-contracts/README.md
@@ -396,6 +396,12 @@ Each contract operation emits specific events to enable off-chain monitoring and
 | `emg_appr`   | EmergencyApproved        | `approve_emergency_withdraw`                                                                   | Multi-sig emergency withdrawal approved           |
 | `emg_exec`   | EmergencyExecuted        | `execute_emergency_withdraw`                                                                   | Multi-sig emergency withdrawal executed           |
 
+### Event payload semantics
+
+- `set_cooperator` emits `coop_upd` with data tuple `(old_cooperator, new_cooperator)`.
+- `set_zkme_verifier` emits `zkme_upd` with topics `(symbol, caller)` and data `(old_verifier, new_verifier)`.
+- Both events are emitted after authorization and input validation, and are intended for compliance/audit indexers.
+
 ### Yield claiming examples
 
 #### Example: Claim all pending yield
@@ -900,6 +906,8 @@ Key invariants to verify:
 | `pending_yield`    | View       | None     | Assets | Unclaimed yield amount for a user.               |
 | `share_price`      | View       | None     | Assets | Current price of one share (scaled by decimals). |
 | `epoch_yield`      | View       | None     | Assets | Total yield distributed in a given epoch.        |
+| `current_epoch`    | View       | None     | Epochs | Current epoch counter for deterministic request tracking. |
+| `get_current_epoch`| View       | None     | Epochs | Alias for `current_epoch` for `get_*` SDK conventions. |
 
 #### Administration & Configuration
 
@@ -908,6 +916,9 @@ Key invariants to verify:
 | `activate_vault`    | Update     | Operator | —       | Transition `Funding → Active`.   |
 | `mature_vault`      | Update     | Operator | —       | Transition `Active → Matured`.   |
 | `set_maturity_date` | Update     | Operator | Seconds | Update the maturity timestamp.   |
+| `maturity_date`     | View       | None     | Seconds | Read vault maturity timestamp (Unix seconds). |
+| `get_maturity_date` | View       | None     | Seconds | Alias for `maturity_date` for `get_*` SDK conventions. |
+| `early_redemption_fee_bps` | View | None | BPS | Early redemption fee in basis points (10_000 = 100%), rounded down on fee calculations. |
 | `set_operator`      | Update     | Admin    | —       | Grant or revoke operator role.   |
 | `transfer_admin`    | Update     | Admin    | —       | Transfer primary admin role.     |
 | `pause / unpause`   | Update     | Operator | —       | Halt or resume vault operations. |
@@ -921,6 +932,7 @@ Key invariants to verify:
 | `batch_create_vaults`     | Update     | Operator | —     | Deploy multiple vaults in one TX (max 10).   |
 | `get_all_vaults`          | View       | None     | —     | List all registered vault addresses.         |
 | `get_vault_info`          | View       | None     | —     | Read metadata for a specific vault.          |
+| `is_registered_vault`     | View       | None     | Bool  | Returns true if a vault address exists in factory registry. |
 | `set_vault_status`        | Update     | Admin    | —     | Activate/deactivate a vault in the registry. |
 | `set_vault_wasm_hash`     | Update     | Admin    | —     | Update the WASM used for new deployments.    |
 | `version`                 | View       | None     | —     | Factory contract version.                    |

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -1426,6 +1426,10 @@ impl SingleRWAVault {
     pub fn current_epoch(e: &Env) -> u32 {
         get_current_epoch(e)
     }
+    /// Alias getter for integrations expecting `get_*` naming.
+    pub fn get_current_epoch(e: &Env) -> u32 {
+        get_current_epoch(e)
+    }
     pub fn epoch_yield(e: &Env, epoch: u32) -> i128 {
         get_epoch_yield(e, epoch)
     }
@@ -1775,6 +1779,10 @@ impl SingleRWAVault {
     /// - **Maturity Check**: Clients should compare this value with the current
     ///   ledger timestamp to determine if the term has ended.
     pub fn maturity_date(e: &Env) -> u64 {
+        get_maturity_date(e)
+    }
+    /// Alias getter for integrations expecting `get_*` naming.
+    pub fn get_maturity_date(e: &Env) -> u64 {
         get_maturity_date(e)
     }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
@@ -248,3 +248,32 @@ fn test_set_zkme_verifier_emits_event_with_caller_and_addresses() {
         "zkme verifier event: new verifier must match"
     );
 }
+
+#[test]
+fn test_set_cooperator_emits_event_with_old_and_new_addresses() {
+    let ctx = setup_with_kyc_bypass();
+    let old_cooperator = ctx.vault().cooperator();
+    let new_cooperator = soroban_sdk::Address::generate(&ctx.env);
+
+    ctx.vault().set_cooperator(&ctx.admin, &new_cooperator);
+
+    let events = ctx.env.events().all();
+    let cooperator_event = events.iter().find(|(contract, topics, _)| {
+        *contract == ctx.vault_id && {
+            let sym: soroban_sdk::Symbol = topics.get_unchecked(0).into_val(&ctx.env);
+            sym == symbol_short!("coop_upd")
+        }
+    });
+    let (_, _, data) = cooperator_event.expect("cooperator event must be emitted");
+
+    let (event_old, event_new): (soroban_sdk::Address, soroban_sdk::Address) =
+        data.into_val(&ctx.env);
+    assert_eq!(
+        event_old, old_cooperator,
+        "cooperator event: old cooperator must match"
+    );
+    assert_eq!(
+        event_new, new_cooperator,
+        "cooperator event: new cooperator must match"
+    );
+}


### PR DESCRIPTION
## Summary
- add explicit compatibility view aliases `get_current_epoch` and `get_maturity_date` in `single_rwa_vault`
- add event-schema test coverage for `set_cooperator` to verify `coop_upd` payload contains `(old_cooperator, new_cooperator)`
- document event payload semantics, basis-point fee interpretation/rounding, and factory registration helper usage in Soroban README

Closes #345
Closes #337
Closes #370
Closes #352

## Test plan
- `cargo test -p single_rwa_vault --lib test_set_cooperator_emits_event_with_old_and_new_addresses` (build lock was in progress locally from concurrent compile; rerun clean in CI)

Made with [Cursor](https://cursor.com)