### PR TITLE
feat: add setter/operator events and last_interaction_epoch view

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -29,9 +29,16 @@ pub fn emit_vault_state_changed(e: &Env, old: VaultState, new: VaultState) {
     e.events().publish((symbol_short!("st_chg"),), (old, new));
 }
 
-pub fn emit_maturity_date_set(e: &Env, old: u64, new: u64, state: VaultState) {
+pub fn emit_maturity_date_set(
+    e: &Env,
+    caller: Address,
+    old: u64,
+    new: u64,
+    state: VaultState,
+    timestamp: u64,
+) {
     e.events()
-        .publish((symbol_short!("mat_set"),), (old, new, state));
+        .publish((symbol_short!("mat_set"), caller), (old, new, state, timestamp));
 }
 
 pub fn emit_deposit_limits_updated(e: &Env, min: i128, max: i128) {
@@ -41,6 +48,13 @@ pub fn emit_deposit_limits_updated(e: &Env, min: i128, max: i128) {
 pub fn emit_operator_updated(e: &Env, operator: Address, status: bool) {
     e.events()
         .publish((symbol_short!("op_upd"), operator), status);
+}
+
+/// Emitted when an operator is added (status=true).
+/// Includes caller and timestamp for off-chain monitoring.
+pub fn emit_operator_added(e: &Env, caller: Address, operator: Address, timestamp: u64) {
+    e.events()
+        .publish((symbol_short!("op_add"), caller, operator), timestamp);
 }
 
 /// Emitted when the admin grants a role to an address.
@@ -226,9 +240,15 @@ pub fn emit_yield_vesting_period_set(e: &Env, vesting_period: u64) {
 /// Emitted by `set_funding_target` / `set_funding_target_with_reason`.
 ///
 /// `reason` is a short operator-provided context string (may be empty).
-pub fn emit_funding_target_set(e: &Env, target: i128, reason: String) {
+pub fn emit_funding_target_set(
+    e: &Env,
+    caller: Address,
+    target: i128,
+    reason: String,
+    timestamp: u64,
+) {
     e.events()
-        .publish((symbol_short!("fund_set"),), (target, reason));
+        .publish((symbol_short!("fund_set"), caller), (target, reason, timestamp));
 }
 
 /// Emitted by `set_blacklisted`.

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -1910,7 +1910,7 @@ impl SingleRWAVault {
         let old = get_maturity_date(e);
         let state = get_vault_state(e);
         put_maturity_date(e, timestamp);
-        emit_maturity_date_set(e, old, timestamp, state);
+        emit_maturity_date_set(e, caller, old, timestamp, state, e.ledger().timestamp());
         bump_instance(e);
     }
 
@@ -2539,6 +2539,9 @@ impl SingleRWAVault {
         require_admin(e, &caller);
         require_valid_address(e, &addr);
         put_role(e, addr.clone(), role.clone(), true);
+        if role == Role::FullOperator {
+            emit_operator_added(e, caller.clone(), addr.clone(), e.ledger().timestamp());
+        }
         emit_role_granted(e, addr, role);
         bump_instance(e);
     }
@@ -2568,7 +2571,10 @@ impl SingleRWAVault {
         require_admin(e, &caller);
         require_valid_address(e, &operator);
         put_operator(e, operator.clone(), status);
-        emit_operator_updated(e, operator, status);
+        emit_operator_updated(e, operator.clone(), status);
+        if status {
+            emit_operator_added(e, caller, operator, e.ledger().timestamp());
+        }
         bump_instance(e);
     }
 
@@ -3308,8 +3314,15 @@ impl SingleRWAVault {
             panic_with_error!(e, Error::InvalidInitParams);
         }
         put_funding_target(e, target);
-        emit_funding_target_set(e, target, reason);
+        emit_funding_target_set(e, caller, target, reason, e.ledger().timestamp());
         bump_instance(e);
+    }
+
+    /// Returns the most recent epoch where `user` interacted (deposit, withdraw, transfer, etc).
+    ///
+    /// Epoch numbering starts at `0`.
+    pub fn last_interaction_epoch(e: &Env, user: Address) -> u32 {
+        get_last_interaction_epoch(e, &user)
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_epoch_activity.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_epoch_activity.rs
@@ -254,3 +254,19 @@ fn test_get_lifetime_activity_returns_zero_before_any_ops() {
     assert_eq!(act.yield_claims_count, 0);
     assert_eq!(act.redemptions_count, 0);
 }
+
+#[test]
+fn test_last_interaction_epoch_getter_defaults_and_updates() {
+    let ctx = setup_with_kyc_bypass();
+    let e = &ctx.env;
+    let client = SingleRWAVaultClient::new(e, &ctx.vault_id);
+
+    // No interaction yet -> defaults to epoch 0.
+    assert_eq!(client.last_interaction_epoch(&ctx.user), 0);
+
+    mint_usdc(e, &ctx.asset_id, &ctx.user, 1_000_000);
+    client.deposit(&ctx.user, &1_000_000i128, &ctx.user);
+
+    // Deposit records interaction in current epoch.
+    assert_eq!(client.last_interaction_epoch(&ctx.user), client.current_epoch());
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
@@ -277,3 +277,77 @@ fn test_set_cooperator_emits_event_with_old_and_new_addresses() {
         "cooperator event: new cooperator must match"
     );
 }
+
+#[test]
+fn test_set_funding_target_emits_event_with_caller_and_timestamp() {
+    let ctx = setup_with_kyc_bypass();
+    let target = 42_000_000i128;
+
+    ctx.vault().set_funding_target(&ctx.admin, &target);
+
+    let events = ctx.env.events().all();
+    let funding_event = events.iter().find(|(contract, topics, _)| {
+        *contract == ctx.vault_id && {
+            let sym: soroban_sdk::Symbol = topics.get_unchecked(0).into_val(&ctx.env);
+            sym == symbol_short!("fund_set")
+        }
+    });
+    let (_, topics, data) = funding_event.expect("funding target event must be emitted");
+
+    let topic_caller: soroban_sdk::Address = topics.get_unchecked(1).into_val(&ctx.env);
+    assert_eq!(topic_caller, ctx.admin);
+
+    let (event_target, _reason, event_ts): (i128, soroban_sdk::String, u64) = data.into_val(&ctx.env);
+    assert_eq!(event_target, target);
+    assert_eq!(event_ts, ctx.env.ledger().timestamp());
+}
+
+#[test]
+fn test_set_maturity_date_emits_caller_and_timestamp() {
+    let ctx = setup_with_kyc_bypass();
+    let new_maturity = 2_100_000_000u64;
+
+    ctx.vault().set_maturity_date(&ctx.operator, &new_maturity);
+
+    let events = ctx.env.events().all();
+    let maturity_event = events.iter().find(|(contract, topics, _)| {
+        *contract == ctx.vault_id && {
+            let sym: soroban_sdk::Symbol = topics.get_unchecked(0).into_val(&ctx.env);
+            sym == symbol_short!("mat_set")
+        }
+    });
+    let (_, topics, data) = maturity_event.expect("maturity event must be emitted");
+
+    let topic_caller: soroban_sdk::Address = topics.get_unchecked(1).into_val(&ctx.env);
+    assert_eq!(topic_caller, ctx.operator);
+
+    let (_old, event_new, _state, event_ts): (u64, u64, crate::types::VaultState, u64) =
+        data.into_val(&ctx.env);
+    assert_eq!(event_new, new_maturity);
+    assert_eq!(event_ts, ctx.env.ledger().timestamp());
+}
+
+#[test]
+fn test_set_operator_true_emits_operator_added_event() {
+    let ctx = setup_with_kyc_bypass();
+    let new_operator = soroban_sdk::Address::generate(&ctx.env);
+
+    ctx.vault().set_operator(&ctx.admin, &new_operator, &true);
+
+    let events = ctx.env.events().all();
+    let op_add_event = events.iter().find(|(contract, topics, _)| {
+        *contract == ctx.vault_id && {
+            let sym: soroban_sdk::Symbol = topics.get_unchecked(0).into_val(&ctx.env);
+            sym == symbol_short!("op_add")
+        }
+    });
+    let (_, topics, data) = op_add_event.expect("operator-added event must be emitted");
+
+    let topic_caller: soroban_sdk::Address = topics.get_unchecked(1).into_val(&ctx.env);
+    let topic_operator: soroban_sdk::Address = topics.get_unchecked(2).into_val(&ctx.env);
+    assert_eq!(topic_caller, ctx.admin);
+    assert_eq!(topic_operator, new_operator);
+
+    let event_ts: u64 = data.into_val(&ctx.env);
+    assert_eq!(event_ts, ctx.env.ledger().timestamp());
+}


### PR DESCRIPTION
## Summary
Implements issues #342, #343, #353, and #349 in `single_rwa_vault` by improving event payloads for monitoring and adding a lightweight epoch getter.

## Changes
- Added caller+timestamp payload to funding target event emitted by `set_funding_target` / `set_funding_target_with_reason`.
- Added caller+timestamp payload to maturity date event emitted by `set_maturity_date`.
- Added dedicated `op_add` event when operator status is enabled (`set_operator(..., true)`) and when `grant_role(..., FullOperator)` is used.
- Added public getter `last_interaction_epoch(user)` with docs clarifying epoch numbering starts at `0`.
- Added/updated focused tests in `test_events.rs` and `test_epoch_activity.rs`.

## Validation
- `cargo test -p single_rwa_vault test_set_funding_target_emits_event_with_caller_and_timestamp`
- `cargo test -p single_rwa_vault test_set_maturity_date_emits_caller_and_timestamp`
- `cargo test -p single_rwa_vault test_set_operator_true_emits_operator_added_event`
- `cargo test -p single_rwa_vault test_last_interaction_epoch_getter_defaults_and_updates`

Closes #342
Closes #343
Closes #353
Closes #349

Made with [Cursor](https://cursor.com)