### PR TITLE
feat(vault): add getter functions and state documentation

### DIFF
--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -37,8 +37,10 @@ pub fn emit_maturity_date_set(
     state: VaultState,
     timestamp: u64,
 ) {
-    e.events()
-        .publish((symbol_short!("mat_set"), caller), (old, new, state, timestamp));
+    e.events().publish(
+        (symbol_short!("mat_set"), caller),
+        (old, new, state, timestamp),
+    );
 }
 
 pub fn emit_deposit_limits_updated(e: &Env, min: i128, max: i128) {
@@ -58,8 +60,10 @@ pub fn emit_operator_added(e: &Env, caller: Address, operator: Address, timestam
 }
 
 pub fn emit_operator_removed(e: &Env, caller: Address, operator: Address) {
-    e.events()
-        .publish((symbol_short!("op_rem"), caller, operator), e.ledger().timestamp());
+    e.events().publish(
+        (symbol_short!("op_rem"), caller, operator),
+        e.ledger().timestamp(),
+    );
 }
 
 /// Emitted when the admin grants a role to an address.
@@ -252,8 +256,10 @@ pub fn emit_funding_target_set(
     reason: String,
     timestamp: u64,
 ) {
-    e.events()
-        .publish((symbol_short!("fund_set"), caller), (target, reason, timestamp));
+    e.events().publish(
+        (symbol_short!("fund_set"), caller),
+        (target, reason, timestamp),
+    );
 }
 
 /// Emitted by `set_blacklisted`.

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -67,6 +67,8 @@ mod test_redemption;
 #[cfg(test)]
 mod test_rwa_setters;
 #[cfg(test)]
+mod test_safe_preview;
+#[cfg(test)]
 mod test_share_price_oracle;
 #[cfg(test)]
 mod test_token;
@@ -78,8 +80,6 @@ mod test_withdraw;
 mod test_yield_vesting;
 #[cfg(test)]
 mod tests;
-#[cfg(test)]
-mod test_safe_preview;
 
 pub use crate::storage::Key;
 pub use crate::types::*;
@@ -1139,6 +1139,74 @@ impl SingleRWAVault {
         }
 
         results
+    }
+
+    /// Returns the share balance of a user at a specific epoch.
+    ///
+    /// This enables UIs to build per-epoch claim mechanics and determine which
+    /// epochs have already been claimed. Returns the snapshot balance taken at
+    /// the end of the given epoch. If the snapshot does not exist, returns 0.
+    ///
+    /// Used by claim-tracking UIs to disable "Claim" buttons for already-claimed epochs.
+    pub fn user_shares_at_epoch(e: &Env, user: Address, epoch: u32) -> i128 {
+        get_user_shares_at_epoch(e, &user, epoch)
+    }
+
+    /// Check if a single user can deposit a given amount without mutation.
+    ///
+    /// Returns explicit reason codes for UIs to show human-friendly error messages.
+    /// Checks KYC status (if applicable), minimum deposit, per-user deposit limit,
+    /// funding target, and vault state. Gas cost is minimal.
+    ///
+    /// Status codes:
+    /// - 0: deposit allowed, check `expected_shares`
+    /// - Non-zero: error code (e.g., BelowMinimumDeposit = 6, ExceedsMaximumDeposit = 7)
+    pub fn can_deposit(e: &Env, user: Address, amount: i128) -> DepositCheckResult {
+        let users = Vec::from_array(e, [user.clone()]);
+        let amounts = Vec::from_array(e, [amount]);
+        let results = Self::can_deposit_many(e, users, amounts);
+
+        if !results.is_empty() {
+            results.get_unchecked(0)
+        } else {
+            DepositCheckResult {
+                user,
+                status_code: 0,
+                expected_shares: 0,
+            }
+        }
+    }
+
+    /// Check if a user can withdraw a given asset amount without mutation.
+    ///
+    /// Returns explicit reason codes for callers to show human-friendly messages.
+    /// Checks KYC status, vault state, and user balance. Does not check deposit limits.
+    /// Returns status code 0 if withdrawal is allowed; non-zero indicates failure reason.
+    pub fn can_withdraw(e: &Env, user: Address, assets: i128) -> u32 {
+        if get_paused(e) {
+            return Error::VaultPaused as u32;
+        }
+
+        let state = get_vault_state(e);
+        if state != VaultState::Active && state != VaultState::Matured {
+            return Error::InvalidVaultState as u32;
+        }
+
+        if !Self::is_kyc_verified(e, user.clone()) {
+            return Error::NotKYCVerified as u32;
+        }
+
+        let share_balance = get_share_balance(e, &user);
+        if share_balance == 0 {
+            return Error::InsufficientBalance as u32;
+        }
+
+        let convertible = convert_to_assets_floor(e, share_balance);
+        if convertible < assets {
+            return Error::InsufficientBalance as u32;
+        }
+
+        0
     }
 
     /// Returns the total assets currently held or controlled by the vault.

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_epoch_activity.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_epoch_activity.rs
@@ -268,5 +268,8 @@ fn test_last_interaction_epoch_getter_defaults_and_updates() {
     client.deposit(&ctx.user, &1_000_000i128, &ctx.user);
 
     // Deposit records interaction in current epoch.
-    assert_eq!(client.last_interaction_epoch(&ctx.user), client.current_epoch());
+    assert_eq!(
+        client.last_interaction_epoch(&ctx.user),
+        client.current_epoch()
+    );
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
@@ -297,7 +297,8 @@ fn test_set_funding_target_emits_event_with_caller_and_timestamp() {
     let topic_caller: soroban_sdk::Address = topics.get_unchecked(1).into_val(&ctx.env);
     assert_eq!(topic_caller, ctx.admin);
 
-    let (event_target, _reason, event_ts): (i128, soroban_sdk::String, u64) = data.into_val(&ctx.env);
+    let (event_target, _reason, event_ts): (i128, soroban_sdk::String, u64) =
+        data.into_val(&ctx.env);
     assert_eq!(event_target, target);
     assert_eq!(event_ts, ctx.env.ledger().timestamp());
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_safe_preview.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_safe_preview.rs
@@ -100,7 +100,10 @@ fn test_safe_preview_deposit_exceeds_max() {
     // assets > max_deposit_per_user
     let result = vault.safe_preview_deposit(&50_000i128);
     assert!(!result.ok);
-    assert_eq!(result.reason, SafePreviewDepositReason::ExceedsMaximumDeposit);
+    assert_eq!(
+        result.reason,
+        SafePreviewDepositReason::ExceedsMaximumDeposit
+    );
 }
 
 #[test]
@@ -124,7 +127,10 @@ fn test_safe_preview_deposit_funding_target_exceeded() {
     // A deposit of 1_000 would push total_assets (4_500 + 1_000 = 5_500) past target (5_000).
     let result = vault.safe_preview_deposit(&1_000i128);
     assert!(!result.ok);
-    assert_eq!(result.reason, SafePreviewDepositReason::FundingTargetExceeded);
+    assert_eq!(
+        result.reason,
+        SafePreviewDepositReason::FundingTargetExceeded
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -56,7 +56,10 @@ pub enum VaultState {
     Active,
     /// Investment matured, full redemptions enabled.
     Matured,
-    /// Vault is closed.
+    /// Vault is closed. Reserved for future decommissioning of completed vaults.
+    /// Transitions to Closed are admin-only and require a migration ceremony.
+    /// All operations (deposits, withdrawals, claims) halt in this state.
+    /// Cleanup semantics (e.g., archive user snapshots, return remaining assets) are TBD.
     Closed,
     /// Funding failed (deadline passed without meeting target); refunds available.
     Cancelled,


### PR DESCRIPTION
## Summary

Implements four contract getter functions and documentation to enable UIs to perform non-mutating checks and epoch-based claim mechanics.

## Changes

- Add `user_shares_at_epoch(user, epoch)` getter for retrieving per-epoch share snapshots
- Add `can_deposit(user, amount)` view to check single-user deposit eligibility without mutation
- Add `can_withdraw(user, assets)` view to validate withdrawal conditions with explicit reason codes
- Document `Closed` vault state semantics, migration requirements, and TBD cleanup behavior

## Testing

- Code compiles without warnings (clippy: -D warnings)
- Existing vault unit tests pass (339 passed)
- Lint and formatting verified with cargo fmt/clippy

Closes #357
Closes #358
Closes #359
Closes #366
