### PR TITLE
feat: add next_redemption_request_id() getter and emit reason on oper…

### DIFF
--- a/sdk/src/single-rwa-vault-client.ts
+++ b/sdk/src/single-rwa-vault-client.ts
@@ -104,6 +104,9 @@ export class SingleRwaVaultClient {
   redemptionRequest(requestId: number): SorobanOperation {
     return this.call("redemption_request", scU32(requestId));
   }
+  nextRedemptionRequestId(): SorobanOperation {
+    return this.call("next_redemption_request_id");
+  }
   maxDeposit(receiver: string): SorobanOperation {
     return this.call("max_deposit", scAddress(receiver));
   }

--- a/soroban-contracts/contracts/single_rwa_vault/src/events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/events.rs
@@ -59,10 +59,10 @@ pub fn emit_operator_added(e: &Env, caller: Address, operator: Address, timestam
         .publish((symbol_short!("op_add"), caller, operator), timestamp);
 }
 
-pub fn emit_operator_removed(e: &Env, caller: Address, operator: Address) {
+pub fn emit_operator_removed(e: &Env, caller: Address, operator: Address, reason: Option<String>) {
     e.events().publish(
         (symbol_short!("op_rem"), caller, operator),
-        e.ledger().timestamp(),
+        (e.ledger().timestamp(), reason),
     );
 }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -868,6 +868,16 @@ impl SingleRWAVault {
         }
     }
 
+    /// Returns the ID that will be assigned to the next early redemption request.
+    ///
+    /// This is useful for frontends and indexers to predict the next request ID
+    /// without calling `request_early_redemption`.
+    ///
+    /// Note: Redemption IDs are 1-based and monotonically increasing.
+    pub fn next_redemption_request_id(e: &Env) -> u32 {
+        get_redemption_counter(e) + 1
+    }
+
     // ─────────────────────────────────────────────────────────────────
     // ERC-4626 max helpers
     // ─────────────────────────────────────────────────────────────────
@@ -2598,12 +2608,12 @@ impl SingleRWAVault {
     }
 
     /// Revoke `role` from `addr`.  Only the admin may revoke roles.
-    pub fn revoke_role(e: &Env, caller: Address, addr: Address, role: Role) {
+    pub fn revoke_role(e: &Env, caller: Address, addr: Address, role: Role, reason: Option<String>) {
         caller.require_auth();
         require_admin(e, &caller);
         put_role(e, addr.clone(), role.clone(), false);
         if role == Role::FullOperator {
-            emit_operator_removed(e, caller.clone(), addr.clone());
+            emit_operator_removed(e, caller.clone(), addr.clone(), reason.clone());
         }
         emit_role_revoked(e, addr, role);
         bump_instance(e);
@@ -2620,7 +2630,7 @@ impl SingleRWAVault {
 
     /// Backward-compatible: grants or revokes the `FullOperator` superrole.
     /// Prefer `grant_role` / `revoke_role` for new integrations.
-    pub fn set_operator(e: &Env, caller: Address, operator: Address, status: bool) {
+    pub fn set_operator(e: &Env, caller: Address, operator: Address, status: bool, reason: Option<String>) {
         caller.require_auth();
         require_admin(e, &caller);
         require_valid_address(e, &operator);
@@ -2629,7 +2639,7 @@ impl SingleRWAVault {
         if status {
             emit_operator_added(e, caller, operator, e.ledger().timestamp());
         } else {
-            emit_operator_removed(e, caller, operator);
+            emit_operator_removed(e, caller, operator, reason);
         }
         bump_instance(e);
     }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_access_control.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_access_control.rs
@@ -111,7 +111,7 @@ fn test_set_operator_grants_access() {
     // With mock_all_auths, every address passes auth checks
     // So we can't test non-operator status properly
     // Just test that we can set an operator
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     assert!(vault.is_operator(&operator));
 }
 
@@ -123,9 +123,9 @@ fn test_set_operator_revokes_access() {
     let vault = SingleRWAVaultClient::new(&e, &vault_id);
     let operator = Address::generate(&e);
 
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     assert!(vault.is_operator(&operator));
-    vault.set_operator(&admin, &operator, &false);
+    vault.set_operator(&admin, &operator, &false, &None);
     assert!(!vault.is_operator(&operator));
 }
 
@@ -139,7 +139,7 @@ fn test_set_operator_non_admin_panics() {
     let non_admin = Address::generate(&e);
     let operator = Address::generate(&e);
 
-    vault.set_operator(&non_admin, &operator, &true);
+    vault.set_operator(&non_admin, &operator, &true, &None);
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn test_pause_blocks_deposits() {
     let user = Address::generate(&e);
 
     // Grant operator to admin so they can pause
-    vault.set_operator(&admin, &admin, &true);
+    vault.set_operator(&admin, &admin, &true, &None);
     vault.pause(&admin, &String::from_str(&e, "Maintenance"));
     assert!(vault.paused());
 
@@ -189,7 +189,7 @@ fn test_unpause_resumes_operations() {
     let vault = SingleRWAVaultClient::new(&e, &vault_id);
     let user = Address::generate(&e);
 
-    vault.set_operator(&admin, &admin, &true);
+    vault.set_operator(&admin, &admin, &true, &None);
     vault.pause(&admin, &String::from_str(&e, "Maintenance"));
     assert!(vault.paused());
 
@@ -225,7 +225,7 @@ fn test_pause_emits_event_with_reason() {
     let (vault_id, _, _, admin) = make_vault(&e);
     let vault = SingleRWAVaultClient::new(&e, &vault_id);
 
-    vault.set_operator(&admin, &admin, &true);
+    vault.set_operator(&admin, &admin, &true, &None);
     let reason = String::from_str(&e, "Critical failure");
     vault.pause(&admin, &reason);
 
@@ -354,7 +354,7 @@ fn test_full_operator_can_clear_blacklist_under_current_design() {
 
     // Backward-compatible operator assignment grants the FullOperator superrole,
     // which currently satisfies ComplianceOfficer checks as well.
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     vault.set_blacklisted(&operator, &user, &false);
 
     assert!(!vault.is_blacklisted(&user));
@@ -375,7 +375,7 @@ fn test_unblacklisted_user_can_resume_deposit_and_withdraw() {
     let resumed_deposit = 250_000i128;
     let resumed_withdraw = 200_000i128;
 
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     zkme.approve_user(&user);
     token.mint(&user, &2_000_000);
 
@@ -434,7 +434,7 @@ fn test_multiple_consecutive_pauses_and_unpauses() {
     let user = Address::generate(&e);
 
     // Grant operator to admin
-    vault.set_operator(&admin, &admin, &true);
+    vault.set_operator(&admin, &admin, &true, &None);
 
     // Approve user for KYC
     zkme.approve_user(&user);
@@ -504,7 +504,7 @@ fn test_share_transfer_succeeds_while_vault_paused() {
     let from_user = Address::generate(&e);
     let to_user = Address::generate(&e);
 
-    vault.set_operator(&admin, &admin, &true);
+    vault.set_operator(&admin, &admin, &true, &None);
     zkme.approve_user(&from_user);
     zkme.approve_user(&to_user);
 
@@ -558,7 +558,7 @@ fn test_operator_cannot_transfer_admin() {
     let new_admin = Address::generate(&e);
 
     // Grant full operator privileges to `operator`
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     assert!(vault.is_operator(&operator));
 
     // Operator attempts an admin-only action: transfer_admin
@@ -580,7 +580,7 @@ fn test_operator_escalation_attempt_leaves_state_intact() {
     let operator = Address::generate(&e);
     let new_admin = Address::generate(&e);
 
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     assert!(vault.is_operator(&operator));
 
     // Capture the result without panicking
@@ -625,11 +625,11 @@ fn test_operator_cannot_grant_operator_to_others() {
     let operator = Address::generate(&e);
     let new_oper = Address::generate(&e);
 
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     // Operator attempts to grant operator status to another address
     // Must fail with NotAdmin — only admin can manage operator assignments
-    vault.set_operator(&operator, &new_oper, &true);
+    vault.set_operator(&operator, &new_oper, &true, &None);
 }
 
 /// An operator also must not be able to revoke another operator.
@@ -646,9 +646,9 @@ fn test_operator_cannot_revoke_other_operator() {
     let operator_b = Address::generate(&e);
 
     // Admin grants both operators
-    vault.set_operator(&admin, &operator_a, &true);
-    vault.set_operator(&admin, &operator_b, &true);
+    vault.set_operator(&admin, &operator_a, &true, &None);
+    vault.set_operator(&admin, &operator_b, &true, &None);
 
     // operator_a attempts to revoke operator_b — must fail
-    vault.set_operator(&operator_a, &operator_b, &false);
+    vault.set_operator(&operator_a, &operator_b, &false, &None);
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_burn_yield_accounting.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_burn_yield_accounting.rs
@@ -18,7 +18,7 @@ fn test_burn_snapshots_yield_for_explicit_claim() {
     let token = crate::tests::MockTokenClient::new(&env, &token_id);
     let zkme = crate::tests::MockZkmeClient::new(&env, &zkme_id);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     vault.activate_vault(&admin);
 
     // Deposit and create yield
@@ -59,7 +59,7 @@ fn test_burn_from_snapshots_yield_for_explicit_claim() {
     let token = crate::tests::MockTokenClient::new(&env, &token_id);
     let zkme = crate::tests::MockZkmeClient::new(&env, &zkme_id);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
     vault.activate_vault(&admin);
 
     // Deposit and create yield

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_convert_erc4626.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_convert_erc4626.rs
@@ -14,7 +14,7 @@ fn test_convert_to_shares_and_assets_floor_division() {
     let token = crate::tests::MockTokenClient::new(&env, &token_id);
     let zkme = crate::tests::MockZkmeClient::new(&env, &zkme_id);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     // Helper to mint assets to user and deposit into vault
     let mint_and_deposit = |amount: i128| {
@@ -97,7 +97,7 @@ fn test_convert_edge_cases_zero_assets_or_supply() {
     let token = crate::tests::MockTokenClient::new(&env, &token_id);
     let zkme = crate::tests::MockZkmeClient::new(&env, &zkme_id);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     // Zero assets, zero supply: 1:1
     assert_eq!(vault.convert_to_shares(&5000i128), 5000i128);
@@ -127,7 +127,7 @@ fn test_convert_vs_preview_rounding_differences() {
     let token = crate::tests::MockTokenClient::new(&env, &token_id);
     let zkme = crate::tests::MockZkmeClient::new(&env, &zkme_id);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     // Create non-trivial price
     vault.activate_vault(&admin);

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
@@ -333,7 +333,7 @@ fn test_set_operator_true_emits_operator_added_event() {
     let ctx = setup_with_kyc_bypass();
     let new_operator = soroban_sdk::Address::generate(&ctx.env);
 
-    ctx.vault().set_operator(&ctx.admin, &new_operator, &true);
+    ctx.vault().set_operator(&ctx.admin, &new_operator, &true, &None);
 
     let events = ctx.env.events().all();
     let op_add_event = events.iter().find(|(contract, topics, _)| {

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
@@ -209,7 +209,7 @@ pub fn setup() -> TestContext {
     let vault_id = env.register(SingleRWAVault, (params.clone(),));
 
     // Add a secondary operator.
-    SingleRWAVaultClient::new(&env, &vault_id).set_operator(&admin, &operator, &true);
+    SingleRWAVaultClient::new(&env, &vault_id).set_operator(&admin, &operator, &true, &None);
 
     TestContext {
         env,
@@ -278,7 +278,7 @@ fn setup_with_registered_contracts(
     );
     let vault_id = env.register(SingleRWAVault, (params.clone(),));
 
-    SingleRWAVaultClient::new(&env, &vault_id).set_operator(&admin, &operator, &true);
+    SingleRWAVaultClient::new(&env, &vault_id).set_operator(&admin, &operator, &true, &None);
 
     TestContext {
         env,

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_rbac.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_rbac.rs
@@ -73,7 +73,7 @@ fn test_grant_and_revoke_role() {
     client.grant_role(&admin, &addr, &Role::YieldOperator);
     assert!(client.has_role(&addr, &Role::YieldOperator));
 
-    client.revoke_role(&admin, &addr, &Role::YieldOperator);
+    client.revoke_role(&admin, &addr, &Role::YieldOperator, &None);
     assert!(!client.has_role(&addr, &Role::YieldOperator));
 }
 
@@ -127,11 +127,11 @@ fn test_set_operator_grants_full_operator() {
     let op = Address::generate(&env);
 
     // Backward-compat API
-    client.set_operator(&admin, &op, &true);
+    client.set_operator(&admin, &op, &true, &None);
     assert!(client.is_operator(&op));
     assert!(client.has_role(&op, &Role::FullOperator));
 
-    client.set_operator(&admin, &op, &false);
+    client.set_operator(&admin, &op, &false, &None);
     assert!(!client.is_operator(&op));
     assert!(!client.has_role(&op, &Role::FullOperator));
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_safe_preview.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_safe_preview.rs
@@ -33,7 +33,7 @@ fn test_safe_preview_deposit_success_after_yield() {
     let user = Address::generate(&env);
     let operator = Address::generate(&env);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     // Deposit then distribute yield so share price > 1.
     token.mint(&user, &10_000i128);
@@ -162,7 +162,7 @@ fn test_safe_preview_mint_success_after_yield() {
     let user = Address::generate(&env);
     let operator = Address::generate(&env);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     token.mint(&user, &10_000i128);
     vault.deposit(&user, &10_000i128, &user);
@@ -298,7 +298,7 @@ fn test_vault_asset_balance_after_yield() {
     let user = Address::generate(&env);
     let operator = Address::generate(&env);
     zkme.approve_user(&user);
-    vault.set_operator(&admin, &operator, &true);
+    vault.set_operator(&admin, &operator, &true, &None);
 
     token.mint(&user, &10_000i128);
     vault.deposit(&user, &10_000i128, &user);


### PR DESCRIPTION
Closes #351

## Summary
Adds the `next_redemption_request_id()` getter and extends operator 
removal events with an optional reason string for off-chain systems.

## Changes
- `lib.rs` — added `next_redemption_request_id()` getter returning `get_redemption_counter(e) + 1`
- `lib.rs` — updated `revoke_role()` and `set_operator()` to accept `reason: Option<String>`
- `events.rs` — extended `emit_operator_removed()` with `reason: Option<String>` and timestamp
- `single-rwa-vault-client.ts` — added `nextRedemptionRequestId()` method to SDK client
- All test files updated to pass `&None` reason parameter for backward compatibility

## Acceptance Criteria
- [x] `next_redemption_request_id()` getter returns correct next ID
- [x] Operator removal emits reason string when available
- [x] Build passes (`cargo build` succeeds)
- [x] Existing tests pass (pre-existing KYC and timelock failures are unrelated)

## Type of Change
- [x] New feature

## How to Test
1. Call `next_redemption_request_id()` — should return current counter + 1
2. Remove an operator with a reason string — verify event includes reason
3. Remove an operator without a reason (`None`) — verify event still emits correctly

## Checklist
- [x] Self-reviewed my own code
- [x] No debug code left in
- [x] Branch is up to date with `main`