### PR TITLE
chore: remove test comment from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 # Workspace root for Soroban contracts (run `cargo test -p vault_factory` from here).
-# Auto-merge test — safe to delete.
 [workspace]
 resolver = "2"
 members = [

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_events.rs
@@ -333,7 +333,8 @@ fn test_set_operator_true_emits_operator_added_event() {
     let ctx = setup_with_kyc_bypass();
     let new_operator = soroban_sdk::Address::generate(&ctx.env);
 
-    ctx.vault().set_operator(&ctx.admin, &new_operator, &true, &None);
+    ctx.vault()
+        .set_operator(&ctx.admin, &new_operator, &true, &None);
 
     let events = ctx.env.events().all();
     let op_add_event = events.iter().find(|(contract, topics, _)| {

--- a/soroban-contracts/contracts/vault_factory/src/events.rs
+++ b/soroban-contracts/contracts/vault_factory/src/events.rs
@@ -61,8 +61,10 @@ pub fn emit_wasm_hash_updated(
     new_hash: BytesN<32>,
     updated_by: Address,
 ) {
-    e.events()
-        .publish((symbol_short!("wasm_upd"), updated_by), (old_hash, new_hash));
+    e.events().publish(
+        (symbol_short!("wasm_upd"), updated_by),
+        (old_hash, new_hash),
+    );
 }
 
 /// Emitted when the admin grants a role to an address.


### PR DESCRIPTION
Tests the auto-merge + branch-protection gate. Should only merge after All Checks Passed succeeds.