### PR TITLE
feat: implement versioned database migrations

### DIFF
--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,9 +1,14 @@
-// Database connection — configure via DATABASE_URL env var
-// Replace with your preferred client (pg, Drizzle, Prisma, etc.)
+import pg from "pg";
+import { config } from "../config.js";
+
+const { Pool } = pg;
+
+export const pool = new Pool({ connectionString: config.db.url });
 
 export async function query<T = Record<string, unknown>>(
-  _sql: string,
-  _params?: unknown[],
+  sql: string,
+  params?: unknown[],
 ): Promise<T[]> {
-  throw new Error("Not implemented");
+  const result = await pool.query(sql, params);
+  return result.rows;
 }

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,13 +1,53 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { pool } from "./index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = resolve(__dirname, "migrations");
+
+const CREATE_MIGRATIONS_TABLE = `
+  CREATE TABLE IF NOT EXISTS migrations (
+    id          SERIAL PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    applied_at  TIMESTAMPTZ DEFAULT NOW()
+  );
+`;
 
 async function migrate() {
-  const sql = readFileSync(resolve(__dirname, "schema.sql"), "utf8");
-  await pool.query(sql);
+  await pool.query(CREATE_MIGRATIONS_TABLE);
+
+  const { rows: applied } = await pool.query<{ name: string }>(
+    "SELECT name FROM migrations ORDER BY id",
+  );
+  const appliedSet = new Set(applied.map((r) => r.name));
+
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    if (appliedSet.has(file)) {
+      console.log(`  skip ${file} (already applied)`);
+      continue;
+    }
+
+    const sql = readFileSync(resolve(MIGRATIONS_DIR, file), "utf8");
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(sql);
+      await client.query("INSERT INTO migrations (name) VALUES ($1)", [file]);
+      await client.query("COMMIT");
+      console.log(`  applied ${file}`);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   console.log("Migration complete.");
   await pool.end();
 }

--- a/backend/src/db/migrations/001_vaults.sql
+++ b/backend/src/db/migrations/001_vaults.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS vaults (
+  id              SERIAL PRIMARY KEY,
+  contract_id     TEXT NOT NULL UNIQUE,
+  factory_id      TEXT,
+  asset           TEXT NOT NULL,
+  name            TEXT,
+  symbol          TEXT,
+  state           TEXT NOT NULL DEFAULT 'Funding',
+  total_assets    NUMERIC DEFAULT 0,
+  total_supply    NUMERIC DEFAULT 0,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
Closes #415

---

## Summary

Split the monolithic \schema.sql\ into versioned migration files for safer, incremental schema changes. Adds a migrations tracking table so each migration runs only once.

## Changes

- **\db/index.ts\**: Wire up a real \pg.Pool\ using \DATABASE_URL\ from config instead of the placeholder stub.
- **\db/migrations/001_vaults.sql\**: Extract the vaults table DDL from \schema.sql\ as the first versioned migration.
- **\db/migrations\** table: Auto-created by the migration runner — tracks \
ame\ and \pplied_at\ timestamp.
- **\db/migrate.ts\**: Rewritten to:
  - Ensure the \migrations\ table exists.
  - Scan \migrations/*.sql\ in filename order.
  - Skip already-applied migrations.
  - Run each new migration inside a transaction (commit on success, rollback on error).

## Behavior

| Scenario | Result |
|---|---|
| First \
pm run db:migrate\ | Applies \