### PR TITLE
feat: add database migration files for user_vault_positions, epochs, indexed_events, and indexer_state

### DIFF
--- a/backend/src/db/migrations/003_user_vault_positions.sql
+++ b/backend/src/db/migrations/003_user_vault_positions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS user_vault_positions (
+  id              SERIAL PRIMARY KEY,
+  user_address    TEXT NOT NULL,
+  vault_id        INT NOT NULL REFERENCES vaults(id),
+  shares          NUMERIC DEFAULT 0,
+  deposited       NUMERIC DEFAULT 0,
+  last_claimed_epoch INT DEFAULT 0,
+  updated_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_address, vault_id)
+);

--- a/backend/src/db/migrations/004_epochs.sql
+++ b/backend/src/db/migrations/004_epochs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS epochs (
+  id              SERIAL PRIMARY KEY,
+  vault_id        INT NOT NULL REFERENCES vaults(id),
+  epoch           INT NOT NULL,
+  yield_amount    NUMERIC NOT NULL,
+  total_shares    NUMERIC NOT NULL,
+  distributed_at  TIMESTAMPTZ,
+  UNIQUE (vault_id, epoch)
+);

--- a/backend/src/db/migrations/005_indexed_events.sql
+++ b/backend/src/db/migrations/005_indexed_events.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS indexed_events (
+  id              SERIAL PRIMARY KEY,
+  ledger          INT NOT NULL,
+  tx_hash         TEXT NOT NULL,
+  contract_id     TEXT NOT NULL,
+  event_type      TEXT NOT NULL,
+  payload         JSONB NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_indexed_events_contract_event ON indexed_events (contract_id, event_type);

--- a/backend/src/db/migrations/006_indexer_state.sql
+++ b/backend/src/db/migrations/006_indexer_state.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS indexer_state (
+  id              SERIAL PRIMARY KEY,
+  last_ledger     INT NOT NULL DEFAULT 0,
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+INSERT INTO indexer_state (last_ledger)
+SELECT 0
+WHERE NOT EXISTS (SELECT 1 FROM indexer_state);


### PR DESCRIPTION
## Summary

Adds standalone SQL migration files (003–006) to `backend/src/db/migrations/` to cover the remaining database tables defined in `schema.sql`.

### Changes

- **003_user_vault_positions.sql**: Creates `user_vault_positions` table with FK to `vaults(id)` and unique constraint on `(user_address, vault_id)`
- **004_epochs.sql**: Creates `epochs` table with FK to `vaults(id)` and unique constraint on `(vault_id, epoch)`
- **005_indexed_events.sql**: Creates `indexed_events` table with a performance index on `(contract_id, event_type)`
- **006_indexer_state.sql**: Creates `indexer_state` table and seeds an initial row with `last_ledger = 0` if the table is empty

All migrations use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` for idempotent re-runs.

Closes #417
Closes #418
Closes #419
Closes #420