### PR TITLE
feat(yields): add summary endpoint, epoch timestamps, claimedEpochs, and epoch param validation

### DIFF
--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -28,3 +28,12 @@ export async function getUserPendingYield(req: Request, res: Response, next: Nex
     next(err);
   }
 }
+
+export async function getYieldSummary(req: Request, res: Response, next: NextFunction) {
+  try {
+    const summary = await yieldService.getYieldSummary(String(req.params["contractId"]));
+    res.json(summary);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -6,7 +6,12 @@ const yieldService = new YieldService();
 export async function getVaultEpochs(req: Request, res: Response, next: NextFunction) {
   try {
     const epochs = await yieldService.getVaultEpochs(String(req.params["contractId"]));
-    res.json(epochs);
+    res.json(
+      epochs.map((e) => ({
+        ...e,
+        distributedAt: e.distributedAt ? e.distributedAt.toISOString() : null,
+      })),
+    );
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/yields.ts
+++ b/backend/src/api/routes/yields.ts
@@ -1,10 +1,18 @@
 import { Router } from "express";
+import { z } from "zod";
 import {
   getVaultEpochs,
   getUserPendingYield,
+  getYieldSummary,
 } from "../controllers/yields.js";
+import { validateQuery } from "../middleware/validate.js";
+
+const epochQuerySchema = z.object({
+  epoch: z.coerce.number().int().positive().optional(),
+});
 
 export const yieldsRouter = Router();
 
-yieldsRouter.get("/:contractId/epochs", getVaultEpochs);
+yieldsRouter.get("/:contractId/summary", getYieldSummary);
+yieldsRouter.get("/:contractId/epochs", validateQuery(epochQuerySchema), getVaultEpochs);
 yieldsRouter.get("/:contractId/pending/:userAddress", getUserPendingYield);

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -1,8 +1,32 @@
 import type { Epoch } from "../types/index.js";
+import { query } from "../db/index.js";
 
 export class YieldService {
-  async getVaultEpochs(_contractId: string): Promise<Epoch[]> {
-    throw new Error("Not implemented");
+  async getVaultEpochs(contractId: string): Promise<Epoch[]> {
+    const rows = await query<{
+      id: number;
+      vault_id: number;
+      epoch: number;
+      yield_amount: string;
+      total_shares: string;
+      distributed_at: Date | null;
+    }>(
+      `SELECT e.id, e.vault_id, e.epoch, e.yield_amount, e.total_shares, e.distributed_at
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE v.contract_id = $1
+       ORDER BY e.epoch ASC`,
+      [contractId],
+    );
+
+    return rows.map((row) => ({
+      id: row.id,
+      vaultId: row.vault_id,
+      epoch: row.epoch,
+      yieldAmount: row.yield_amount,
+      totalShares: row.total_shares,
+      distributedAt: row.distributed_at,
+    }));
   }
 
   async getUserPendingYield(

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -30,10 +30,58 @@ export class YieldService {
   }
 
   async getUserPendingYield(
-    _contractId: string,
-    _userAddress: string,
-  ): Promise<{ pendingYield: string; epochs: number[] }> {
-    throw new Error("Not implemented");
+    contractId: string,
+    userAddress: string,
+  ): Promise<{ pendingYield: string; epochs: number[]; claimedEpochs: number[] }> {
+    const positionRows = await query<{
+      shares: string;
+      last_claimed_epoch: number;
+    }>(
+      `SELECT uvp.shares, uvp.last_claimed_epoch
+       FROM user_vault_positions uvp
+       JOIN vaults v ON uvp.vault_id = v.id
+       WHERE v.contract_id = $1 AND uvp.user_address = $2`,
+      [contractId, userAddress],
+    );
+
+    const position = positionRows[0];
+    const lastClaimedEpoch = position?.last_claimed_epoch ?? -1;
+    const shares = BigInt(position?.shares ?? "0");
+
+    const epochRows = await query<{
+      epoch: number;
+      yield_amount: string;
+      total_shares: string;
+    }>(
+      `SELECT e.epoch, e.yield_amount, e.total_shares
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE v.contract_id = $1
+       ORDER BY e.epoch ASC`,
+      [contractId],
+    );
+
+    const pendingEpochs: number[] = [];
+    const claimedEpochs: number[] = [];
+    let pendingYield = BigInt(0);
+
+    for (const row of epochRows) {
+      if (row.epoch <= lastClaimedEpoch) {
+        claimedEpochs.push(row.epoch);
+      } else {
+        pendingEpochs.push(row.epoch);
+        const totalShares = BigInt(row.total_shares);
+        if (totalShares > BigInt(0)) {
+          pendingYield += (shares * BigInt(row.yield_amount)) / totalShares;
+        }
+      }
+    }
+
+    return {
+      pendingYield: pendingYield.toString(),
+      epochs: pendingEpochs,
+      claimedEpochs,
+    };
   }
 
   async recordEpoch(

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -84,6 +84,34 @@ export class YieldService {
     };
   }
 
+  async getYieldSummary(contractId: string): Promise<{
+    totalEpochs: string;
+    totalYieldDistributed: string;
+    averageYieldPerEpoch: string;
+  }> {
+    const rows = await query<{
+      total_epochs: string;
+      total_yield: string;
+    }>(
+      `SELECT COUNT(e.id)::text AS total_epochs,
+              COALESCE(SUM(e.yield_amount::numeric), 0)::text AS total_yield
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE v.contract_id = $1`,
+      [contractId],
+    );
+
+    const totalEpochs = BigInt(rows[0]?.total_epochs ?? "0");
+    const totalYield = BigInt(rows[0]?.total_yield ?? "0");
+    const average = totalEpochs > BigInt(0) ? totalYield / totalEpochs : BigInt(0);
+
+    return {
+      totalEpochs: totalEpochs.toString(),
+      totalYieldDistributed: totalYield.toString(),
+      averageYieldPerEpoch: average.toString(),
+    };
+  }
+
   async recordEpoch(
     _vaultId: number,
     _epoch: number,


### PR DESCRIPTION
## Summary

- **#478** — Add `GET /api/v1/yields/:contractId/summary` returning `{ totalEpochs, totalYieldDistributed, averageYieldPerEpoch }` as bigint-safe strings; returns zeroes for vaults with no epochs.
- **#479** — Add Zod validation (`z.coerce.number().int().positive()`) on the `epoch` query param for the epochs endpoint; returns HTTP 400 for negative or non-integer values.
- **#480** — Implement `getVaultEpochs` with real DB query and serialize `distributedAt` as an ISO 8601 string (or `null`) in the epoch response.
- **#481** — Implement `getUserPendingYield` returning `claimedEpochs: number[]` alongside `pendingYield` and `epochs`; claimed epochs are those where `last_claimed_epoch >= epoch`.

## Test plan

- [ ] `GET /api/v1/yields/:contractId/summary` returns correct sums and counts from `epochs` table
- [ ] `GET /api/v1/yields/:contractId/summary` returns `{ totalEpochs: "0", totalYieldDistributed: "0", averageYieldPerEpoch: "0" }` for a vault with no epochs
- [ ] `GET /api/v1/yields/:contractId/epochs` includes `distributedAt` as a valid ISO 8601 string or `null`
- [ ] `GET /api/v1/yields/:contractId/epochs?epoch=-1` returns HTTP 400
- [ ] `GET /api/v1/yields/:contractId/epochs?epoch=abc` returns HTTP 400
- [ ] `GET /api/v1/yields/:contractId/pending/:userAddress` includes `claimedEpochs` array
- [ ] `claimedEpochs` lists only epochs where `last_claimed_epoch >= epoch`



closes #478 closes #479 closes #480 closes #481