### PR TITLE
Tadmin: add indexer & events endpoints; wire notifications; extend stats (closes #494 #495 #496 #497)

### DIFF
--- a/backend/src/api/controllers/admin.test.ts
+++ b/backend/src/api/controllers/admin.test.ts
@@ -12,11 +12,17 @@ describe("Admin Controller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
   describe("getAdminStats", () => {
-    it("returns total user count", async () => {
+    it("returns vault/user/epoch counts and TVL", async () => {
       const { query, getAdminStats } = await getTestContext();
-      query.mockResolvedValue([{ count: "42" }]);
+      // vaultCount
+      query.mockResolvedValueOnce([{ count: "2" }]);
+      // userCount
+      query.mockResolvedValueOnce([{ count: "42" }]);
+      // totalValueLocked
+      query.mockResolvedValueOnce([{ total: "12345" }]);
+      // epochCount
+      query.mockResolvedValueOnce([{ count: "3" }]);
 
       const req = {} as any;
       const res = { json: vi.fn() } as any;
@@ -24,20 +30,7 @@ describe("Admin Controller", () => {
 
       await getAdminStats(req, res, next);
 
-      expect(res.json).toHaveBeenCalledWith({ totalUsers: 42 });
-    });
-
-    it("returns 0 when no users", async () => {
-      const { query, getAdminStats } = await getTestContext();
-      query.mockResolvedValue([{ count: "0" }]);
-
-      const req = {} as any;
-      const res = { json: vi.fn() } as any;
-      const next = vi.fn();
-
-      await getAdminStats(req, res, next);
-
-      expect(res.json).toHaveBeenCalledWith({ totalUsers: 0 });
+      expect(res.json).toHaveBeenCalledWith({ vaultCount: 2, userCount: 42, totalValueLocked: "12345", epochCount: 3 });
     });
   });
 });

--- a/backend/src/api/controllers/admin.ts
+++ b/backend/src/api/controllers/admin.ts
@@ -1,12 +1,68 @@
 import type { Request, Response, NextFunction } from "express";
 import { UserService } from "../../services/user.js";
+import { query } from "../../db/index.js";
+import { indexer } from "../../services/indexerSingleton.js";
 
 const userService = new UserService();
 
 export async function getAdminStats(_req: Request, res: Response, next: NextFunction) {
   try {
-    const totalUsers = await userService.countUsers();
-    res.json({ totalUsers });
+    const vaultCountRows = await query<{ count: string }>("SELECT COUNT(*)::text as count FROM vaults");
+    const userCountRows = await query<{ count: string }>("SELECT COUNT(*)::text as count FROM users");
+    const totalAssetsRows = await query<{ total: string }>("SELECT COALESCE(SUM(total_assets::numeric), 0)::text as total FROM vaults");
+    const epochCountRows = await query<{ count: string }>("SELECT COUNT(*)::text as count FROM epochs");
+
+    const vaultCount = parseInt(vaultCountRows[0]?.count ?? "0", 10);
+    const userCount = parseInt(userCountRows[0]?.count ?? "0", 10);
+    const totalValueLocked = totalAssetsRows[0]?.total ?? "0";
+    const epochCount = parseInt(epochCountRows[0]?.count ?? "0", 10);
+
+    res.json({ vaultCount, userCount, totalValueLocked, epochCount });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getAdminIndexer(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const running = indexer.isRunning();
+    const lastLedger = await indexer.getLastIndexedLedger();
+    const lastTickAtDate = indexer.getLastTickAt();
+    const lastTickAt = lastTickAtDate ? lastTickAtDate.toISOString() : null;
+    const eventsIndexed = await indexer.getEventsIndexedCount();
+
+    res.json({ running, lastLedger, lastTickAt, eventsIndexed });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getAdminEvents(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { contractId, eventType } = req.query as Record<string, string | undefined>;
+    const params: any[] = [];
+    let where: string[] = [];
+
+    if (contractId) {
+      params.push(contractId);
+      where.push(`contract_id = $${params.length}`);
+    }
+    if (eventType) {
+      params.push(eventType);
+      where.push(`event_type = $${params.length}`);
+    }
+
+    const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+    const rows = await query(
+      `SELECT id, ledger, tx_hash, contract_id, event_type, payload, created_at
+       FROM indexed_events
+       ${whereClause}
+       ORDER BY created_at DESC
+       LIMIT 50`,
+      params,
+    );
+
+    res.json(rows);
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getAdminStats } from "../controllers/admin.js";
+import { getAdminStats, getAdminIndexer, getAdminEvents } from "../controllers/admin.js";
 import { requireApiKey } from "../middleware/auth.js";
 
 export const adminRouter = Router();
@@ -7,3 +7,5 @@ export const adminRouter = Router();
 adminRouter.use(requireApiKey({ role: "admin" }));
 
 adminRouter.get("/stats", getAdminStats);
+adminRouter.get("/indexer", getAdminIndexer);
+adminRouter.get("/events", getAdminEvents);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,10 +1,9 @@
 import { createApp } from "./app.js";
 import { config } from "./config.js";
 import { logger } from "./logger.js";
-import { Indexer } from "./services/indexer.js";
+import { indexer } from "./services/indexerSingleton.js";
 
 const app = createApp();
-const indexer = new Indexer();
 
 const server = app.listen(config.port, () => {
   logger.info({ port: config.port, env: config.nodeEnv }, "StellarYield backend started");

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -4,6 +4,7 @@ import { logger } from "../logger.js";
 import { query } from "../db/index.js";
 import { getSorobanRpc } from "./stellar.js";
 import { VaultService } from "./vault.js";
+import { NotificationService } from "./notifications.js";
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -54,13 +55,16 @@ async function withBackoff<T>(
 export class Indexer {
   lastLedger: number;
   private running = false;
+  private lastTickAt: Date | null = null;
   private readonly vaultFactoryContractId: string;
   private vaultService: VaultService;
+  private notificationService?: NotificationService;
 
-  constructor() {
+  constructor(notificationService?: NotificationService) {
     this.lastLedger = config.indexer.startLedger;
     this.vaultFactoryContractId = config.stellar.vaultFactoryContractId;
     this.vaultService = new VaultService();
+    this.notificationService = notificationService;
 
     // Validate contract ID at startup (#449)
     if (!this.vaultFactoryContractId) {
@@ -132,6 +136,7 @@ export class Indexer {
         { latestLedger, lastLedger: this.lastLedger },
         "no events",
       );
+      this.lastTickAt = new Date();
       return;
     }
 
@@ -142,6 +147,7 @@ export class Indexer {
       { ledger: latestLedger },
       "no events",
     );
+    this.lastTickAt = new Date();
   }
 
   async tick(): Promise<void> {
@@ -191,6 +197,7 @@ export class Indexer {
 
     this.lastLedger = latestLedger;
     await this.persistLastLedger();
+    this.lastTickAt = new Date();
   }
 
   private async backfill(tipLedger: number): Promise<void> {
@@ -228,6 +235,7 @@ export class Indexer {
         cursor = batchTo;
         this.lastLedger = cursor;
         await this.persistLastLedger();
+        this.lastTickAt = new Date();
       } catch (err) {
         logger.warn({ err, from: cursor + 1, to: batchTo }, "RPC error during backfill batch");
         break;
@@ -246,18 +254,33 @@ export class Indexer {
     if (deposit) {
       await this.handleDeposit(event.contractId ?? "", deposit);
       await this.recordEvent(event, "deposit");
+      try {
+        await this.notificationService?.notify("deposit", deposit as any);
+      } catch (e) {
+        logger.warn({ err: e }, "NotificationService.notify failed for deposit");
+      }
       return;
     }
 
     const yieldDist = parseYieldDistributedEvent(event);
     if (yieldDist) {
       await this.recordEvent(event, "yield_distributed");
+      try {
+        await this.notificationService?.notify("yield_distributed", yieldDist as any);
+      } catch (e) {
+        logger.warn({ err: e }, "NotificationService.notify failed for yield_distributed");
+      }
       return;
     }
 
     const vaultStateChanged = parseVaultStateChangedEvent(event);
     if (vaultStateChanged) {
       await this.recordEvent(event, "vault_state_changed");
+      try {
+        await this.notificationService?.notify("vault_state_changed", vaultStateChanged as any);
+      } catch (e) {
+        logger.warn({ err: e }, "NotificationService.notify failed for vault_state_changed");
+      }
       return;
     }
 
@@ -265,8 +288,26 @@ export class Indexer {
     if (vaultCreated) {
       await this.handleVaultCreated(event.contractId ?? "", vaultCreated);
       await this.recordEvent(event, "vault_created");
+      try {
+        await this.notificationService?.notify("vault_created", vaultCreated as any);
+      } catch (e) {
+        logger.warn({ err: e }, "NotificationService.notify failed for vault_created");
+      }
       return;
     }
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  getLastTickAt(): Date | null {
+    return this.lastTickAt;
+  }
+
+  async getEventsIndexedCount(): Promise<number> {
+    const rows = await query<{ count: string }>("SELECT COUNT(*)::text as count FROM indexed_events");
+    return parseInt(rows[0]?.count ?? "0", 10);
   }
 
   private async handleDeposit(

--- a/backend/src/services/indexerSingleton.ts
+++ b/backend/src/services/indexerSingleton.ts
@@ -1,0 +1,7 @@
+import { Indexer } from "./indexer.js";
+import { NotificationService } from "./notifications.js";
+
+// Single shared Indexer instance for the application
+export const indexer = new Indexer(new NotificationService());
+
+export default indexer;


### PR DESCRIPTION

Summary

- Adds admin endpoints:
  - `GET /api/v1/admin/stats` — returns `{ vaultCount, userCount, totalValueLocked, epochCount }` (protected by admin API key).
  - `GET /api/v1/admin/indexer` — returns `{ running, lastLedger, lastTickAt, eventsIndexed }`.
  - `GET /api/v1/admin/events` — returns last 50 `indexed_events`, with optional `contractId` and `eventType` filters.
- Wires `NotificationService` into the `Indexer` and calls `notificationService.notify(eventType, payload)` after processing events so webhooks can be triggered.
- Exports a singleton `indexer` instance used by the app so runtime status can be reported.
- Updates unit tests for admin stats.

Files changed

- `backend/src/services/indexer.ts`
- `backend/src/services/indexerSingleton.ts` (new)
- `backend/src/index.ts`
- `backend/src/api/controllers/admin.ts`
- `backend/src/api/routes/admin.ts`
- `backend/src/api/controllers/admin.test.ts`


Closes #494
Closes #495
Closes #496
Closes #497
