### PR TITLE
feat: implement webhook management API and NotificationService

### DIFF
--- a/backend/src/api/controllers/webhooks.test.ts
+++ b/backend/src/api/controllers/webhooks.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../db/index.js", () => ({ query: vi.fn() }));
+
+async function getTestContext() {
+  const { query } = await import("../../db/index.js");
+  const { createWebhook, listWebhooks, deleteWebhook } = await import("./webhooks.js");
+  return {
+    query: query as ReturnType<typeof vi.fn>,
+    createWebhook,
+    listWebhooks,
+    deleteWebhook,
+  };
+}
+
+describe("Webhook Controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createWebhook", () => {
+    it("inserts a webhook and returns 201 without secret", async () => {
+      const { query, createWebhook } = await getTestContext();
+      const row = {
+        id: 1,
+        url: "https://example.com/hook",
+        events: ["deposit"],
+        active: true,
+        created_at: new Date("2024-01-01T00:00:00Z"),
+      };
+      query.mockResolvedValue([row]);
+
+      const req = { body: { url: "https://example.com/hook", events: ["deposit"] } } as any;
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await createWebhook(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        url: "https://example.com/hook",
+        events: ["deposit"],
+        active: true,
+        createdAt: row.created_at,
+      });
+    });
+
+    it("passes secret as null when not provided", async () => {
+      const { query, createWebhook } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 2, url: "https://example.com/hook", events: ["deposit"], active: true, created_at: new Date() },
+      ]);
+
+      const req = { body: { url: "https://example.com/hook", events: ["deposit"] } } as any;
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await createWebhook(req, res, next);
+
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO webhooks"),
+        ["https://example.com/hook", ["deposit"], null],
+      );
+    });
+
+    it("calls next on db error", async () => {
+      const { query, createWebhook } = await getTestContext();
+      const err = new Error("db error");
+      query.mockRejectedValue(err);
+
+      const req = { body: { url: "https://example.com/hook", events: ["deposit"] } } as any;
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await createWebhook(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe("listWebhooks", () => {
+    it("returns active webhooks without secret field", async () => {
+      const { query, listWebhooks } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://a.com/hook", events: ["deposit"], active: true, created_at: new Date() },
+        { id: 2, url: "https://b.com/hook", events: ["vault_created"], active: true, created_at: new Date() },
+      ]);
+
+      const req = {} as any;
+      const res = { json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await listWebhooks(req, res, next);
+
+      const result = res.json.mock.calls[0][0];
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(2);
+      result.forEach((w: any) => {
+        expect(w).not.toHaveProperty("secret");
+      });
+    });
+
+    it("returns empty array when no webhooks", async () => {
+      const { query, listWebhooks } = await getTestContext();
+      query.mockResolvedValue([]);
+
+      const req = {} as any;
+      const res = { json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await listWebhooks(req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe("deleteWebhook", () => {
+    it("returns 204 when webhook is soft-deleted", async () => {
+      const { query, deleteWebhook } = await getTestContext();
+      query.mockResolvedValue([{ id: 1 }]);
+
+      const req = { params: { id: "1" } } as any;
+      const res = { status: vi.fn().mockReturnThis(), send: vi.fn(), json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await deleteWebhook(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+
+    it("returns 404 when webhook is not found", async () => {
+      const { query, deleteWebhook } = await getTestContext();
+      query.mockResolvedValue([]);
+
+      const req = { params: { id: "999" } } as any;
+      const res = { status: vi.fn().mockReturnThis(), send: vi.fn(), json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await deleteWebhook(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "NotFound", message: "Webhook not found" });
+    });
+
+    it("uses soft delete (sets active=FALSE)", async () => {
+      const { query, deleteWebhook } = await getTestContext();
+      query.mockResolvedValue([{ id: 5 }]);
+
+      const req = { params: { id: "5" } } as any;
+      const res = { status: vi.fn().mockReturnThis(), send: vi.fn(), json: vi.fn() } as any;
+      const next = vi.fn();
+
+      await deleteWebhook(req, res, next);
+
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("active = FALSE"),
+        [5],
+      );
+    });
+  });
+});

--- a/backend/src/api/controllers/webhooks.ts
+++ b/backend/src/api/controllers/webhooks.ts
@@ -1,0 +1,63 @@
+import type { Request, Response, NextFunction } from "express";
+import { query } from "../../db/index.js";
+
+interface WebhookRow {
+  id: number;
+  url: string;
+  events: string[];
+  active: boolean;
+  created_at: Date;
+}
+
+function formatWebhook(w: WebhookRow) {
+  return { id: w.id, url: w.url, events: w.events, active: w.active, createdAt: w.created_at };
+}
+
+export async function createWebhook(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { url, events, secret } = req.body as { url: string; events: string[]; secret?: string };
+
+    const rows = await query<WebhookRow>(
+      `INSERT INTO webhooks (url, events, secret)
+       VALUES ($1, $2, $3)
+       RETURNING id, url, events, active, created_at`,
+      [url, events, secret ?? null],
+    );
+
+    res.status(201).json(formatWebhook(rows[0]));
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listWebhooks(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const rows = await query<WebhookRow>(
+      "SELECT id, url, events, active, created_at FROM webhooks WHERE active = TRUE ORDER BY created_at DESC",
+    );
+
+    res.json(rows.map(formatWebhook));
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteWebhook(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params["id"] as string, 10);
+
+    const rows = await query<{ id: number }>(
+      "UPDATE webhooks SET active = FALSE WHERE id = $1 AND active = TRUE RETURNING id",
+      [id],
+    );
+
+    if (rows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "Webhook not found" });
+      return;
+    }
+
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/routes/webhooks.ts
+++ b/backend/src/api/routes/webhooks.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import { z } from "zod";
+import { createWebhook, listWebhooks, deleteWebhook } from "../controllers/webhooks.js";
+import { requireApiKey } from "../middleware/auth.js";
+import { validateBody, validateParams } from "../middleware/validate.js";
+
+const KNOWN_EVENTS = [
+  "deposit",
+  "yield_distributed",
+  "vault_state_changed",
+  "vault_created",
+] as const;
+
+const createWebhookSchema = z.object({
+  url: z
+    .string()
+    .url()
+    .refine((v) => v.startsWith("https://"), { message: "Webhook URL must use HTTPS" }),
+  events: z
+    .array(z.enum(KNOWN_EVENTS))
+    .min(1, "At least one event must be specified"),
+  secret: z.string().optional(),
+});
+
+const webhookParamsSchema = z.object({
+  id: z.string().regex(/^\d+$/, "ID must be a positive integer"),
+});
+
+export const webhooksRouter = Router();
+
+webhooksRouter.use(requireApiKey());
+
+webhooksRouter.post("/", validateBody(createWebhookSchema), createWebhook);
+webhooksRouter.get("/", listWebhooks);
+webhooksRouter.delete("/:id", validateParams(webhookParamsSchema), deleteWebhook);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import { vaultsRouter } from "./api/routes/vaults.js";
 import { usersRouter } from "./api/routes/users.js";
 import { yieldsRouter } from "./api/routes/yields.js";
 import { adminRouter } from "./api/routes/admin.js";
+import { webhooksRouter } from "./api/routes/webhooks.js";
 import { errorHandler } from "./api/middleware/errors.js";
 import { publicLimiter, authLimiter } from "./api/middleware/rateLimit.js";
 
@@ -25,6 +26,7 @@ export function createApp(): Express {
   app.use("/api/v1/users", publicLimiter, usersRouter);
   app.use("/api/v1/yields", publicLimiter, yieldsRouter);
   app.use("/api/v1/admin", authLimiter, adminRouter);
+  app.use("/api/v1/webhooks", authLimiter, webhooksRouter);
 
   app.use(errorHandler);
 

--- a/backend/src/services/notifications.test.ts
+++ b/backend/src/services/notifications.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../db/index.js", () => ({ query: vi.fn() }));
+vi.mock("../logger.js", () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+
+async function getTestContext() {
+  const { query } = await import("../db/index.js");
+  const { logger } = await import("../logger.js");
+  const { NotificationService } = await import("./notifications.js");
+  return {
+    query: query as ReturnType<typeof vi.fn>,
+    logger: logger as { warn: ReturnType<typeof vi.fn> },
+    service: new NotificationService(),
+  };
+}
+
+describe("NotificationService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("notify", () => {
+    it("does nothing when no webhooks match the event", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([]);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      await service.notify("deposit", { amount: "100" });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("POSTs JSON payload to matching webhook URLs", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://example.com/hook", events: ["deposit"], secret: null },
+      ]);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+
+      await service.notify("deposit", { amount: "100" });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://example.com/hook");
+      expect(init?.method).toBe("POST");
+
+      const body = JSON.parse(init?.body as string);
+      expect(body.event).toBe("deposit");
+      expect(body.data).toEqual({ amount: "100" });
+      expect(body).toHaveProperty("timestamp");
+    });
+
+    it("adds HMAC-SHA256 signature header when secret is set", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://example.com/hook", events: ["deposit"], secret: "mysecret" },
+      ]);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+
+      await service.notify("deposit", { amount: "50" });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["X-StellarYield-Signature"]).toMatch(/^sha256=[a-f0-9]{64}$/);
+    });
+
+    it("omits signature header when no secret is set", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://example.com/hook", events: ["deposit"], secret: null },
+      ]);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+
+      await service.notify("deposit", {});
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const headers = init?.headers as Record<string, string>;
+      expect(headers).not.toHaveProperty("X-StellarYield-Signature");
+    });
+
+    it("logs a warning on non-2xx response, does not throw", async () => {
+      const { query, logger, service } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://example.com/hook", events: ["deposit"], secret: null },
+      ]);
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 500 }),
+      );
+
+      await expect(service.notify("deposit", {})).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("logs a warning on network error, does not throw", async () => {
+      const { query, logger, service } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://example.com/hook", events: ["deposit"], secret: null },
+      ]);
+
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network error"));
+
+      await expect(service.notify("deposit", {})).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("delivers to all webhooks even if one fails", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([
+        { id: 1, url: "https://ok.com/hook", events: ["deposit"], secret: null },
+        { id: 2, url: "https://fail.com/hook", events: ["deposit"], secret: null },
+      ]);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
+        if (String(url).includes("fail")) return Promise.reject(new Error("timeout"));
+        return Promise.resolve(new Response(null, { status: 200 }));
+      });
+
+      await expect(service.notify("deposit", {})).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("registerWebhook", () => {
+    it("inserts a webhook row into the database", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([]);
+
+      await service.registerWebhook("https://example.com/hook", ["deposit"], "secret123");
+
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO webhooks"),
+        ["https://example.com/hook", ["deposit"], "secret123"],
+      );
+    });
+
+    it("uses null when no secret is provided", async () => {
+      const { query, service } = await getTestContext();
+      query.mockResolvedValue([]);
+
+      await service.registerWebhook("https://example.com/hook", ["vault_created"]);
+
+      expect(query).toHaveBeenCalledWith(
+        expect.any(String),
+        ["https://example.com/hook", ["vault_created"], null],
+      );
+    });
+  });
+});

--- a/backend/src/services/notifications.ts
+++ b/backend/src/services/notifications.ts
@@ -1,9 +1,62 @@
+import { createHmac } from "crypto";
+import { query } from "../db/index.js";
+import { logger } from "../logger.js";
+
+interface WebhookRow {
+  id: number;
+  url: string;
+  events: string[];
+  secret: string | null;
+}
+
 export class NotificationService {
-  async notify(_event: string, _data: Record<string, unknown>): Promise<void> {
-    throw new Error("Not implemented");
+  async notify(event: string, data: Record<string, unknown>): Promise<void> {
+    const webhooks = await query<WebhookRow>(
+      "SELECT id, url, events, secret FROM webhooks WHERE active = TRUE AND $1 = ANY(events)",
+      [event],
+    );
+
+    if (webhooks.length === 0) return;
+
+    const payload = JSON.stringify({ event, data, timestamp: new Date().toISOString() });
+
+    await Promise.allSettled(webhooks.map((webhook) => this.deliver(webhook, payload)));
   }
 
-  async registerWebhook(_url: string, _events: string[], _secret?: string): Promise<void> {
-    throw new Error("Not implemented");
+  private async deliver(webhook: WebhookRow, payload: string): Promise<void> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (webhook.secret) {
+      const signature = createHmac("sha256", webhook.secret).update(payload).digest("hex");
+      headers["X-StellarYield-Signature"] = `sha256=${signature}`;
+    }
+
+    try {
+      const response = await fetch(webhook.url, {
+        method: "POST",
+        headers,
+        body: payload,
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!response.ok) {
+        logger.warn(
+          { webhookId: webhook.id, url: webhook.url, status: response.status },
+          "Webhook delivery returned non-2xx status",
+        );
+      }
+    } catch (err) {
+      logger.warn({ webhookId: webhook.id, url: webhook.url, err }, "Webhook delivery failed");
+    }
+  }
+
+  async registerWebhook(url: string, events: string[], secret?: string): Promise<void> {
+    await query("INSERT INTO webhooks (url, events, secret) VALUES ($1, $2, $3)", [
+      url,
+      events,
+      secret ?? null,
+    ]);
   }
 }


### PR DESCRIPTION
## Summary

Implements the full webhook feature across four issues:

- **`POST /api/v1/webhooks`** — accepts `{ url, events, secret? }`, validates that URL is HTTPS and events is a non-empty array of known event names (`deposit`, `yield_distributed`, `vault_state_changed`, `vault_created`), inserts the row, and returns HTTP 201 with the created webhook (secret omitted from response).
- **`GET /api/v1/webhooks`** — returns all active webhooks as a JSON array; secret field is never included in any response.
- **`DELETE /api/v1/webhooks/:id`** — soft-deletes by setting `active = FALSE`; returns 204 on success and 404 if the webhook is not found or already inactive.
- **`NotificationService.notify`** — queries active webhooks matching the event, POSTs a JSON payload `{ event, data, timestamp }` to each URL within a 5-second timeout, signs with `X-StellarYield-Signature: sha256=<hmac>` when a per-webhook secret is set, and uses `Promise.allSettled` so one failing delivery never blocks the others. Non-2xx responses and network errors are logged as warnings, not errors.

All three routes are protected by the existing `requireApiKey()` middleware and use the shared `validateBody`/`validateParams` + Zod pipeline consistent with the rest of the API.

## Files changed

| File | Change |
|------|--------|
| `backend/src/services/notifications.ts` | Full implementation replacing stubs |
| `backend/src/api/controllers/webhooks.ts` | New — `createWebhook`, `listWebhooks`, `deleteWebhook` |
| `backend/src/api/routes/webhooks.ts` | New — router wiring with auth + validation |
| `backend/src/app.ts` | Register `/api/v1/webhooks` under `authLimiter` |
| `backend/src/api/controllers/webhooks.test.ts` | New — controller unit tests |
| `backend/src/services/notifications.test.ts` | New — NotificationService unit tests |

## Test plan

- [ ] `POST /api/v1/webhooks` with valid HTTPS body → 201, no secret in response
- [ ] `POST /api/v1/webhooks` with HTTP URL → 400 ValidationError
- [ ] `POST /api/v1/webhooks` with empty events array → 400 ValidationError
- [ ] `GET /api/v1/webhooks` → 200 array, no `secret` field on any item
- [ ] `DELETE /api/v1/webhooks/:id` (existing) → 204
- [ ] `DELETE /api/v1/webhooks/:id` (deleted webhook) → 404 (no longer in GET list)
- [ ] `NotificationService.notify` fires POST within 5 s to registered URL
- [ ] 500 from webhook URL logged as warning, other webhooks still delivered
- [ ] Signature header present and correct when secret is set; absent when no secret

Closes #490
Closes #491
Closes #492
Closes #493