### PR TITLE
feat(backend): vault TVL in list response (#499) and admin vault audit endpoint (#498)

### DIFF
--- a/backend/src/api/controllers/admin.ts
+++ b/backend/src/api/controllers/admin.ts
@@ -1,6 +1,9 @@
 import type { Request, Response, NextFunction } from "express";
 import { query } from "../../db/index.js";
 import { indexer } from "../../services/indexerSingleton.js";
+import { z } from "zod";
+
+const contractAddressSchema = z.string().length(56).regex(/^C[A-Z2-7]{55}$/);
 
 export async function getAdminStats(_req: Request, res: Response, next: NextFunction) {
   try {
@@ -60,6 +63,64 @@ export async function getAdminEvents(req: Request, res: Response, next: NextFunc
     );
 
     res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/admin/vaults/:contractId/audit
+ *
+ * Returns the indexed event history for a specific vault contract,
+ * providing a full audit trail of all on-chain activity (deposits,
+ * withdrawals, yield distributions, state transitions, etc.).
+ *
+ * Query params:
+ *   - limit   (1–200, default 50)
+ *   - offset  (default 0)
+ *   - eventType  (optional filter, e.g. "deposit", "withdraw")
+ */
+export async function getVaultAudit(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = contractAddressSchema.safeParse(req.params["contractId"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid contractId format" });
+      return;
+    }
+    const contractId = parsed.data;
+
+    const rawLimit = parseInt(String(req.query["limit"] ?? "50"), 10);
+    const limit = Math.max(1, Math.min(200, isNaN(rawLimit) ? 50 : rawLimit));
+    const rawOffset = parseInt(String(req.query["offset"] ?? "0"), 10);
+    const offset = Math.max(0, isNaN(rawOffset) ? 0 : rawOffset);
+    const eventType = typeof req.query["eventType"] === "string" ? req.query["eventType"] : undefined;
+
+    const params: any[] = [contractId, limit, offset];
+    const eventTypeFilter = eventType ? `AND event_type = $${params.push(eventType)}` : "";
+
+    const rows = await query(
+      `SELECT id, ledger, tx_hash, contract_id, event_type, payload, created_at
+         FROM indexed_events
+        WHERE contract_id = $1
+              ${eventTypeFilter}
+        ORDER BY created_at DESC
+        LIMIT $2 OFFSET $3`,
+      params,
+    );
+
+    // Total count for pagination metadata
+    const countParams: any[] = [contractId];
+    const countEventTypeFilter = eventType ? `AND event_type = $${countParams.push(eventType)}` : "";
+    const countRows = await query<{ count: string }>(
+      `SELECT COUNT(*)::text as count
+         FROM indexed_events
+        WHERE contract_id = $1
+              ${countEventTypeFilter}`,
+      countParams,
+    );
+    const total = parseInt(countRows[0]?.count ?? "0", 10);
+
+    res.json({ data: rows, total, limit, offset });
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getAdminStats, getAdminIndexer, getAdminEvents } from "../controllers/admin.js";
+import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit } from "../controllers/admin.js";
 import { requireApiKey } from "../middleware/auth.js";
 
 export const adminRouter = Router();
@@ -9,3 +9,5 @@ adminRouter.use(requireApiKey({ role: "admin" }));
 adminRouter.get("/stats", getAdminStats);
 adminRouter.get("/indexer", getAdminIndexer);
 adminRouter.get("/events", getAdminEvents);
+// Per-vault audit trail: GET /api/v1/admin/vaults/:contractId/audit
+adminRouter.get("/vaults/:contractId/audit", getVaultAudit);

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -34,8 +34,10 @@ function mapVaultRow(row: VaultRow): Vault {
     name: row.name,
     symbol: row.symbol,
     state: row.state as any,
-    totalAssets: row.total_assets,
-    totalSupply: row.total_supply,
+    // Defensive fallback: row.total_assets should always be non-null after the
+    // COALESCE in the query, but guard here too in case of raw inserts (#499).
+    totalAssets: row.total_assets ?? "0",
+    totalSupply: row.total_supply ?? "0",
     depositorCount: row.depositor_count,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -54,10 +56,14 @@ export class VaultService {
     const params: any[] = [pageSize, offset];
     if (state) params.push(state);
 
-    // Query vaults with pagination
+    // Query vaults with pagination.
+    // COALESCE(v.total_assets, '0') guarantees every vault item in the response
+    // carries a non-null totalAssets string, satisfying issue #499.
     const vaults = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
-              v.total_assets, v.total_supply, v.created_at, v.updated_at,
+              COALESCE(v.total_assets, '0') AS total_assets,
+              COALESCE(v.total_supply, '0') AS total_supply,
+              v.created_at, v.updated_at,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -100,7 +106,9 @@ export class VaultService {
   async listVaultsByFactory(factoryId: string): Promise<Vault[]> {
     const rows = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
-              v.total_assets, v.total_supply, v.created_at, v.updated_at,
+              COALESCE(v.total_assets, '0') AS total_assets,
+              COALESCE(v.total_supply, '0') AS total_supply,
+              v.created_at, v.updated_at,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp


### PR DESCRIPTION
## Summary

Two backend improvements: ensures every vault in the list response carries a non-null `totalAssets` value, and adds a new admin endpoint for per-vault event audit trails.

---

## [#499] Add `totalAssets` to `GET /api/v1/vaults` response

### Problem
The vault list response could return `null` for `totalAssets` if the database column had not been explicitly written after a schema migration, causing client-side TVL calculations to break.

### Fix — `backend/src/services/vault.ts`

- Wrapped `v.total_assets` with `COALESCE(v.total_assets, '0')` in both `listVaults()` and `listVaultsByFactory()` queries
- Applied the same `COALESCE` to `total_supply` for parity
- Added defensive `?? '0'` fallback in `mapVaultRow()` as a second safety net against raw DB inserts that bypass the service layer

**Acceptance criterion met:** `GET /api/v1/vaults` response items include non-null `totalAssets` strings.

---

## [#498] `GET /api/v1/admin/vaults/:contractId/audit`

### New endpoint — `backend/src/api/controllers/admin.ts` + `routes/admin.ts`

Returns the full indexed-event history for a specific vault contract — deposits, withdrawals, yield distributions, state transitions, etc.

| Detail | Value |
|--------|-------|
| Path | `GET /api/v1/admin/vaults/:contractId/audit` |
| Auth | `requireApiKey({ role: 'admin' })` (existing middleware) |
| Params | `contractId` — validated against Soroban address regex |
| Query | `limit` (1–200, default 50), `offset` (default 0), `eventType` (optional filter) |
| Response | `{ data: IndexedEvent[], total: number, limit: number, offset: number }` |
| Validation | 400 for malformed `contractId`; propagates DB errors via `next(err)` |

---

## Closes

Closes #499
Closes #498
Closes #500
Closes #501