### PR TITLE
feat: expose backend version in health endpoint

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -69,7 +69,7 @@ export async function getVaultLiveState(req: Request, res: Response) {
   try {
     const state = await readVaultState(String(req.params["contractId"]));
     res.json({ state });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({
       error: "RpcError",
       message: "Failed to read live vault state from chain",
@@ -81,7 +81,7 @@ export async function getVaultLiveTotalAssets(req: Request, res: Response) {
   try {
     const totalAssets = await readTotalAssets(String(req.params["contractId"]));
     res.json({ totalAssets: totalAssets.toString() });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({
       error: "RpcError",
       message: "Failed to read live total assets from chain",

--- a/backend/src/api/routes/health.ts
+++ b/backend/src/api/routes/health.ts
@@ -1,13 +1,18 @@
+import { readFileSync } from "fs";
 import { Router } from "express";
 import { pool } from "../../db/index.js";
+
+const { version } = JSON.parse(
+  readFileSync(new URL("../../../package.json", import.meta.url), "utf-8"),
+) as { version: string };
 
 export const healthRouter = Router();
 
 healthRouter.get("/", async (_req, res) => {
   try {
     await pool.query("SELECT 1");
-    res.json({ status: "ok" });
+    res.json({ version, status: "ok" });
   } catch {
-    res.status(503).json({ status: "error" });
+    res.status(503).json({ version, status: "error" });
   }
 });


### PR DESCRIPTION
## Summary

Reads the `version` field from `package.json` at module load time (once, at startup) and includes it in the `GET /health` response.

**Changes — `backend/src/api/routes/health.ts`**
- Added `readFileSync` + `URL` import-meta to read `package.json` at startup
- `GET /health` now returns `{ version, status }` on both success and error paths

**Changes — `backend/src/api/controllers/vaults.ts`**
- Fixed pre-existing lint error: renamed caught-but-unused `err` variables to `_err` to satisfy the `@typescript-eslint/no-unused-vars` rule (required for CI lint to pass)

## Acceptance criteria

- [x] `GET /health` returns `{ "version": "0.1.0", "status": "ok" }`

## Test plan

```
cd backend
npm run lint   # ✓ 0 errors
npm run build  # ✓ no TS errors
npm run test   # ✓ 55/55 tests pass
```

Closes #512