### PR TITLE
feat: add pino-http request logging middleware

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -69,7 +69,7 @@ export async function getVaultLiveState(req: Request, res: Response) {
   try {
     const state = await readVaultState(String(req.params["contractId"]));
     res.json({ state });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({
       error: "RpcError",
       message: "Failed to read live vault state from chain",
@@ -81,7 +81,7 @@ export async function getVaultLiveTotalAssets(req: Request, res: Response) {
   try {
     const totalAssets = await readTotalAssets(String(req.params["contractId"]));
     res.json({ totalAssets: totalAssets.toString() });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({
       error: "RpcError",
       message: "Failed to read live total assets from chain",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,8 @@
 import cors from "cors";
 import express, { type Express } from "express";
+import { pinoHttp } from "pino-http";
 import { config } from "./config.js";
+import { logger } from "./logger.js";
 import { healthRouter } from "./api/routes/health.js";
 import { vaultsRouter } from "./api/routes/vaults.js";
 import { usersRouter } from "./api/routes/users.js";
@@ -13,6 +15,7 @@ import { publicLimiter, authLimiter } from "./api/middleware/rateLimit.js";
 export function createApp(): Express {
   const app = express();
 
+  app.use(pinoHttp({ logger }));
   app.use(express.json());
 
   const origins = config.allowedOrigins;


### PR DESCRIPTION
## Summary

Wires `pino-http` (already in `dependencies`) into `app.ts` before all routes, so every request produces a structured log line with method, URL, status code, and response time.

**Changes — `backend/src/app.ts`**
- Imported `{ pinoHttp }` from `"pino-http"` (named export avoids the CJS/ESM default-import callable issue under NodeNext module resolution)
- Imported `{ logger }` from `"./logger.js"`
- Added `app.use(pinoHttp({ logger }))` as the first middleware, before `express.json()`

**Changes — `backend/src/api/controllers/vaults.ts`**
- Fixed pre-existing lint error: renamed `err` → `_err` in two unused catch variables (required for CI lint to pass)

## Acceptance criteria

- [x] Each request produces a structured log line with `method`, `url`, `statusCode`, `responseTime`

## Test plan

```
cd backend
npm run lint   # ✓ 0 errors
npm run build  # ✓ no TS errors
npm run test   # ✓ 55/55 tests pass
```

Closes #510