### PR TITLE
feat: add SIGINT graceful shutdown

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -69,7 +69,7 @@ export async function getVaultLiveState(req: Request, res: Response) {
   try {
     const state = await readVaultState(String(req.params["contractId"]));
     res.json({ state });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({
       error: "RpcError",
       message: "Failed to read live vault state from chain",
@@ -81,7 +81,7 @@ export async function getVaultLiveTotalAssets(req: Request, res: Response) {
   try {
     const totalAssets = await readTotalAssets(String(req.params["contractId"]));
     res.json({ totalAssets: totalAssets.toString() });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({
       error: "RpcError",
       message: "Failed to read live total assets from chain",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,9 +10,13 @@ const server = app.listen(config.port, () => {
   void indexer.start();
 });
 
-process.on("SIGTERM", () => {
+function shutdown(): void {
+  logger.info("Shutting down");
   indexer.stop();
   server.close(() => {
     logger.info("StellarYield backend stopped");
   });
-});
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);


### PR DESCRIPTION
## Summary

Handles `SIGINT` (Ctrl+C) the same way as the existing `SIGTERM` handler: stops the indexer, closes the HTTP server, and logs before exiting. A shared `shutdown()` function eliminates duplication between the two signal handlers.

**Changes — `backend/src/index.ts`**
- Extracted a `shutdown()` function that logs `"Shutting down"`, calls `indexer.stop()`, and closes the server
- Registered `shutdown` for both `SIGTERM` and `SIGINT`

**Changes — `backend/src/api/controllers/vaults.ts`**
- Fixed pre-existing lint error: renamed `err` → `_err` in two unused catch variables (required for CI lint to pass)

## Acceptance criteria

- [x] Pressing Ctrl+C logs `"Shutting down"` and exits cleanly
- [x] `SIGINT` handled identically to `SIGTERM`

## Test plan

```
cd backend
npm run lint   # ✓ 0 errors
npm run build  # ✓ no TS errors
npm run test   # ✓ 55/55 tests pass
```

Closes #511