### PR TITLE
fix: implement lock-up period, yield_claimed & early redemption parsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,30 +2,6 @@ name: CI
 
 on:
   push:
-<<<<<<< feature/vault-response-fields-and-ci
-    branches: [main, "feature/**"]
-  pull_request:
-    branches: [main]
-
-jobs:
-  # ── Soroban / Rust contracts ────────────────────────────────────────────────
-  contracts:
-    name: Contracts (fmt + clippy + test)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: soroban-contracts
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-          components: rustfmt, clippy
-
-      - name: Cache cargo
-=======
     branches: [main]
   pull_request:
     branches: [main]
@@ -118,74 +94,11 @@ jobs:
           targets: wasm32-unknown-unknown, wasm32v1-none
           components: clippy
       - name: Cache cargo registry & build
->>>>>>> main
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-<<<<<<< feature/vault-response-fields-and-ci
-            soroban-contracts/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('soroban-contracts/**/Cargo.lock') }}
-
-      - name: cargo fmt --check
-        run: cargo fmt --all -- --check
-
-      - name: cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: cargo test
-        run: cargo test --all-features
-
-  # ── Backend (Node / TypeScript) ─────────────────────────────────────────────
-  # Issue #514: backend must be included in the merge-gate so a failing
-  # backend test blocks merging via the "All Checks Passed" required status.
-  backend:
-    name: Backend (lint + test)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: server/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Tests
-        run: npm test
-
-  # ── Merge-gate ───────────────────────────────────────────────────────────────
-  # Issue #514: `backend` added to `needs` so that a failing backend job
-  # prevents the PR from being merged via the "All Checks Passed" status check.
-  all-checks-passed:
-    name: All Checks Passed
-    runs-on: ubuntu-latest
-    needs: [contracts, backend]
-    if: always()
-    steps:
-      - name: Evaluate job results
-        run: |
-          if [[ "${{ needs.contracts.result }}" != "success" ]]; then
-            echo "::error::contracts job did not succeed (result: ${{ needs.contracts.result }})"
-            exit 1
-          fi
-          if [[ "${{ needs.backend.result }}" != "success" ]]; then
-            echo "::error::backend job did not succeed (result: ${{ needs.backend.result }})"
-            exit 1
-          fi
-          echo "All required checks passed."
-=======
             target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.toml', 'soroban-contracts/**/Cargo.toml') }}
           restore-keys: |
@@ -305,4 +218,3 @@ jobs:
             echo "Failed: sdk=$SDK backend=$BACKEND fmt=$FMT clippy=$CLIPPY test=$TEST build=$BUILD"
             exit 1
           fi
->>>>>>> main

--- a/backend/src/db/migrations/010_last_claimed_epoch.sql
+++ b/backend/src/db/migrations/010_last_claimed_epoch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_vault_positions
+  ADD COLUMN IF NOT EXISTS last_claimed_epoch INT DEFAULT 0;

--- a/backend/src/services/indexer.test.ts
+++ b/backend/src/services/indexer.test.ts
@@ -246,3 +246,73 @@ describe("Indexer tick", () => {
   });
 
 });
+
+// ── Issue #569: yield_claimed parsers ──────────────────────────────────────────
+
+import {
+  parseYieldClaimedEvent,
+  parseYieldClaimedPartialEvent,
+  parseEarlyRedemptionRequestedEvent,
+} from "./indexer.js";
+
+describe("parseYieldClaimedEvent", () => {
+  it("parses a valid yield_clm event", () => {
+    const topics = [nativeToScVal("yield_clm"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal([5000n, 3]);
+    const result = parseYieldClaimedEvent({ topics, data });
+    expect(result).not.toBeNull();
+    expect(result?.user).toBe(ACCOUNT);
+    expect(result?.amount).toBe(5000n);
+    expect(result?.epoch).toBe(3);
+  });
+
+  it("returns null for malformed events", () => {
+    expect(parseYieldClaimedEvent(null)).toBeNull();
+    expect(parseYieldClaimedEvent({})).toBeNull();
+    expect(parseYieldClaimedEvent({ topics: [nativeToScVal("wrong")], data: nativeToScVal([]) })).toBeNull();
+  });
+});
+
+describe("parseYieldClaimedPartialEvent", () => {
+  it("parses a valid prt_yld event", () => {
+    const topics = [nativeToScVal("prt_yld"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal([3000n, 500n, 7]);
+    const result = parseYieldClaimedPartialEvent({ topics, data });
+    expect(result).not.toBeNull();
+    expect(result?.user).toBe(ACCOUNT);
+    expect(result?.claimed).toBe(3000n);
+    expect(result?.shortfall).toBe(500n);
+    expect(result?.epoch).toBe(7);
+  });
+
+  it("returns null for malformed events", () => {
+    expect(parseYieldClaimedPartialEvent(null)).toBeNull();
+    expect(parseYieldClaimedPartialEvent({})).toBeNull();
+  });
+});
+
+// ── Issue #571: parseEarlyRedemptionRequestedEvent ────────────────────────────
+
+describe("parseEarlyRedemptionRequestedEvent", () => {
+  it("parses a valid erq_req event", () => {
+    const topics = [nativeToScVal("erq_req"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal([42, 10000n, 2]);
+    const result = parseEarlyRedemptionRequestedEvent({ topics, data });
+    expect(result).not.toBeNull();
+    expect(result?.user).toBe(ACCOUNT);
+    expect(result?.requestId).toBe(42);
+    expect(result?.shares).toBe(10000n);
+    expect(result?.queuePosition).toBe(2);
+  });
+
+  it("returns null for unrecognised topic", () => {
+    const topics = [nativeToScVal("unknown_event"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal([1, 100n, 1]);
+    expect(parseEarlyRedemptionRequestedEvent({ topics, data })).toBeNull();
+  });
+
+  it("returns null for malformed events", () => {
+    expect(parseEarlyRedemptionRequestedEvent(null)).toBeNull();
+    expect(parseEarlyRedemptionRequestedEvent({})).toBeNull();
+  });
+});

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -372,6 +372,20 @@ export class Indexer {
       }
       return;
     }
+
+    const yieldClaimed = parseYieldClaimedEvent(event);
+    if (yieldClaimed) {
+      await this.handleYieldClaimed(event.contractId ?? "", yieldClaimed.user, yieldClaimed.epoch);
+      await this.recordEvent(event, "yield_claimed");
+      return;
+    }
+
+    const yieldClaimedPartial = parseYieldClaimedPartialEvent(event);
+    if (yieldClaimedPartial) {
+      await this.handleYieldClaimed(event.contractId ?? "", yieldClaimedPartial.user, yieldClaimedPartial.epoch);
+      await this.recordEvent(event, "yield_claimed_partial");
+      return;
+    }
   }
 
   isRunning(): boolean {
@@ -489,6 +503,19 @@ export class Indexer {
       minDeposit: vaultCreated.minDeposit,
       maxDepositPerUser: vaultCreated.maxDepositPerUser,
     });
+  }
+
+  private async handleYieldClaimed(contractId: string, userAddress: string, epoch: number): Promise<void> {
+    await query(
+      `UPDATE user_vault_positions uvp
+       SET last_claimed_epoch = GREATEST(last_claimed_epoch, $1), updated_at = NOW()
+       FROM vaults v
+       WHERE v.contract_id = $2
+         AND uvp.vault_id = v.id
+         AND uvp.user_address = $3`,
+      [epoch, contractId, userAddress],
+    );
+    logger.info({ contractId, userAddress, epoch }, "Processed yield_claimed event");
   }
 
   private async handleRequestEarlyRedemption(
@@ -834,6 +861,143 @@ export function parseRequestEarlyRedemptionEvent(rawEvent: unknown): ParsedReque
     const timestamp = decodeBigInt(arr[1]);
 
     return { userAddress, shares, timestamp };
+  } catch {
+    return null;
+  }
+}
+
+// ── Issue #571: parseEarlyRedemptionRequestedEvent ────────────────────────────
+
+export interface ParsedEarlyRedemptionRequestedEvent {
+  user: string;
+  requestId: number;
+  shares: bigint;
+  queuePosition: number;
+}
+
+export function parseEarlyRedemptionRequestedEvent(rawEvent: unknown): ParsedEarlyRedemptionRequestedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "erq_req") return null;
+
+    const user = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const data = scValToNative(parsedValue as xdr.ScVal);
+    const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
+    const requestId = Number(arr[0] ?? 0);
+    const shares = decodeBigInt(arr[1]);
+    const queuePosition = Number(arr[2] ?? 0);
+
+    return { user, requestId, shares, queuePosition };
+  } catch {
+    return null;
+  }
+}
+
+// ── Issue #569: parseYieldClaimedEvent / parseYieldClaimedPartialEvent ─────────
+
+export interface ParsedYieldClaimedEvent {
+  user: string;
+  amount: bigint;
+  epoch: number;
+}
+
+export function parseYieldClaimedEvent(rawEvent: unknown): ParsedYieldClaimedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "yield_clm") return null;
+
+    const user = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const data = scValToNative(parsedValue as xdr.ScVal);
+    const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
+    const amount = decodeBigInt(arr[0]);
+    const epoch = Number(arr[1] ?? 0);
+
+    return { user, amount, epoch };
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedYieldClaimedPartialEvent {
+  user: string;
+  claimed: bigint;
+  shortfall: bigint;
+  epoch: number;
+}
+
+export function parseYieldClaimedPartialEvent(rawEvent: unknown): ParsedYieldClaimedPartialEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "prt_yld") return null;
+
+    const user = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const data = scValToNative(parsedValue as xdr.ScVal);
+    const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
+    const claimed = decodeBigInt(arr[0]);
+    const shortfall = decodeBigInt(arr[1]);
+    const epoch = Number(arr[2] ?? 0);
+
+    return { user, claimed, shortfall, epoch };
   } catch {
     return null;
   }

--- a/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/errors.rs
@@ -90,5 +90,5 @@ pub enum Error {
     /// No yield shortfall is recorded for this user.
     YieldShortfallNotFound = 51,
     /// The resolution amount is greater than the recorded shortfall.
-    InsufficientShortfall = 52,
+    InsufficientShortfall = 2,
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/fuzz_tests.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/fuzz_tests.rs
@@ -93,6 +93,7 @@ fn setup() -> TestCtx {
             expected_apy: 500u32,
             timelock_delay: 172800u64, // 48 hours
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/lib.rs
@@ -57,6 +57,8 @@ mod test_inflation_attack;
 #[cfg(test)]
 mod test_lifecycle;
 #[cfg(test)]
+mod test_lock_up;
+#[cfg(test)]
 mod test_multiple_deposit_times;
 #[cfg(test)]
 mod test_multisig_emergency;
@@ -215,6 +217,9 @@ impl SingleRWAVault {
         // Timelock configuration
         put_timelock_delay(e, params.timelock_delay);
         put_timelock_counter(e, 0u32);
+
+        // Lock-up period configuration
+        put_lock_up_period(e, params.lock_up_period);
 
         e.storage()
             .instance()
@@ -422,6 +427,8 @@ impl SingleRWAVault {
         put_total_deposited(e, get_total_deposited(e) + assets);
         _mint(e, &receiver, shares);
         record_deposit_activity(e, get_current_epoch(e), assets, is_new_investor);
+        // Record the deposit timestamp for lock-up enforcement
+        put_deposit_timestamp(e, &receiver, e.ledger().timestamp());
 
         // --- Interaction (external call last) ---
         transfer_asset_to_vault(e, &caller, assets);
@@ -477,6 +484,8 @@ impl SingleRWAVault {
         put_total_deposited(e, get_total_deposited(e) + assets);
         _mint(e, &receiver, shares);
         record_deposit_activity(e, get_current_epoch(e), assets, is_new_investor);
+        // Record the deposit timestamp for lock-up enforcement
+        put_deposit_timestamp(e, &receiver, e.ledger().timestamp());
 
         // --- Interaction (external call last) ---
         transfer_asset_to_vault(e, &caller, assets);
@@ -513,6 +522,7 @@ impl SingleRWAVault {
         require_not_blacklisted_withdraw_parties(e, &caller, &owner, &receiver);
         require_active_or_matured(e);
         require_positive(e, assets);
+        require_lock_up_elapsed(e, &owner);
 
         let shares = preview_withdraw(e, assets);
 
@@ -566,6 +576,7 @@ impl SingleRWAVault {
         require_not_blacklisted_withdraw_parties(e, &caller, &owner, &receiver);
         require_active_or_matured(e);
         require_positive(e, shares);
+        require_lock_up_elapsed(e, &owner);
 
         if caller != owner {
             let allowance = get_share_allowance(e, &owner, &caller);
@@ -2512,6 +2523,7 @@ impl SingleRWAVault {
         require_state(e, VaultState::Active);
         require_not_blacklisted(e, &caller);
         require_positive(e, shares);
+        require_lock_up_elapsed(e, &caller);
 
         update_user_snapshot(e, &caller);
 
@@ -2808,6 +2820,35 @@ impl SingleRWAVault {
         put_yield_vesting_period(e, vesting_period);
         emit_yield_vesting_period_set(e, vesting_period);
         bump_instance(e);
+    }
+
+    /// Update the global lock-up period (seconds).  Only applies to future
+    /// deposits — existing `DepositTimestamp` entries are unaffected.
+    pub fn set_lock_up_period(e: &Env, admin: Address, period: u64) {
+        admin.require_auth();
+        require_admin(e, &admin);
+        put_lock_up_period(e, period);
+        bump_instance(e);
+    }
+
+    /// Returns the remaining lock-up time in seconds for `user`.
+    /// Returns 0 when there is no lock-up or it has already elapsed.
+    pub fn lock_up_remaining(e: &Env, user: Address) -> u64 {
+        let period = get_lock_up_period(e);
+        if period == 0 {
+            return 0;
+        }
+        let deposit_ts = get_deposit_timestamp(e, &user);
+        if deposit_ts == 0 {
+            return 0;
+        }
+        let now = e.ledger().timestamp();
+        let unlock_at = deposit_ts + period;
+        if now >= unlock_at {
+            0
+        } else {
+            unlock_at - now
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────
@@ -3724,6 +3765,7 @@ impl SingleRWAVault {
 
     pub fn transfer(e: &Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
+        require_lock_up_elapsed(e, &from);
         require_transfer_parties_allowed(e, &from, &to);
         update_user_snapshots_for_transfer(e, &from, &to);
         spend_share_balance(e, &from, amount);
@@ -3736,6 +3778,7 @@ impl SingleRWAVault {
     pub fn transfer_from(e: &Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
         require_not_blacklisted(e, &spender);
+        require_lock_up_elapsed(e, &from);
         require_transfer_parties_allowed(e, &from, &to);
         update_user_snapshots_for_transfer(e, &from, &to);
         let allowance = get_share_allowance(e, &from, &spender);
@@ -4125,6 +4168,24 @@ fn require_not_blacklisted(e: &Env, addr: &Address) {
     }
 }
 
+/// Panics with `Error::VaultPaused` (SharesLocked) when the user's deposit lock-up has not
+/// yet elapsed.  A lock-up period of 0 always passes.
+fn require_lock_up_elapsed(e: &Env, user: &Address) {
+    let period = get_lock_up_period(e);
+    if period == 0 {
+        return;
+    }
+    let deposit_ts = get_deposit_timestamp(e, user);
+    if deposit_ts == 0 {
+        // No deposit recorded — nothing is locked.
+        return;
+    }
+    let now = e.ledger().timestamp();
+    if now < deposit_ts + period {
+        panic_with_error!(e, Error::VaultPaused);
+    }
+}
+
 fn transfer_restrictions_exempt(e: &Env, from: &Address, to: &Address) -> bool {
     get_transfer_exempt(e, from) || get_transfer_exempt(e, to)
 }
@@ -4258,6 +4319,7 @@ mod test {
             expected_apy: 500,
             timelock_delay: 172800u64,  // 48 hours
             yield_vesting_period: 0u64, // Default to 0 for instant claiming
+            lock_up_period: 0u64,
         };
 
         let vault_addr = e.register(SingleRWAVault, (params,));

--- a/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/storage.rs
@@ -147,6 +147,12 @@ pub enum Key {
 
     // --- Operator fee ---
     OpFee,
+
+    // --- Lock-up period ---
+    /// Global lock-up duration in seconds (set at init, updatable by admin).
+    LockUpPeriod,
+    /// Per-user timestamp of last deposit (used to enforce lock-up).
+    DepositTimestamp(Address),
 }
 
 // Manual serialization for `Key`: unit variants use a bare `u32` tag; any key that
@@ -174,6 +180,7 @@ const K_TAG_HAS_CLM_EMG: u32 = 217;
 const K_TAG_TLK_ACT: u32 = 218;
 const K_TAG_TRANSFER_EXEMPT: u32 = 219;
 const K_TAG_YIELD_SHORTFALL: u32 = 220;
+const K_TAG_DEPOSIT_TIMESTAMP: u32 = 221;
 
 impl soroban_sdk::IntoVal<Env, soroban_sdk::Val> for Key {
     fn into_val(&self, env: &Env) -> soroban_sdk::Val {
@@ -199,6 +206,7 @@ impl soroban_sdk::IntoVal<Env, soroban_sdk::Val> for Key {
             Key::HasClmEmg(a) => (K_TAG_HAS_CLM_EMG, a.clone()).into_val(env),
             Key::TlkAct(n) => (K_TAG_TLK_ACT, *n).into_val(env),
             Key::YieldShortfall(a) => (K_TAG_YIELD_SHORTFALL, a.clone()).into_val(env),
+            Key::DepositTimestamp(a) => (K_TAG_DEPOSIT_TIMESTAMP, a.clone()).into_val(env),
 
             Key::ShareName => 0u32.into_val(env),
             Key::ShrSymb => 1u32.into_val(env),
@@ -240,6 +248,7 @@ impl soroban_sdk::IntoVal<Env, soroban_sdk::Val> for Key {
             Key::TlkDelay => 50u32.into_val(env),
             Key::TlkCount => 51u32.into_val(env),
             Key::OpFee => 54u32.into_val(env),
+            Key::LockUpPeriod => 55u32.into_val(env),
         }
     }
 }
@@ -273,6 +282,7 @@ impl soroban_sdk::TryFromVal<Env, soroban_sdk::Val> for Key {
                 K_TAG_TRANSFER_EXEMPT => Key::TransferExempt(a),
                 K_TAG_HAS_CLM_EMG => Key::HasClmEmg(a),
                 K_TAG_YIELD_SHORTFALL => Key::YieldShortfall(a),
+                K_TAG_DEPOSIT_TIMESTAMP => Key::DepositTimestamp(a),
                 _ => return Err(soroban_sdk::Error::from_contract_error(1)),
             });
         }
@@ -332,6 +342,7 @@ impl soroban_sdk::TryFromVal<Env, soroban_sdk::Val> for Key {
             50 => Ok(Key::TlkDelay),
             51 => Ok(Key::TlkCount),
             54 => Ok(Key::OpFee),
+            55 => Ok(Key::LockUpPeriod),
             100 => Ok(Key::YldVstPer),
             _ => Err(soroban_sdk::Error::from_contract_error(1)),
         }
@@ -1391,4 +1402,35 @@ pub fn delete_yield_shortfall(e: &Env, user: &Address) {
     e.storage()
         .persistent()
         .remove(&Key::YieldShortfall(user.clone()));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lock-up period storage helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns the global lock-up period in seconds. 0 means no lock-up.
+pub fn get_lock_up_period(e: &Env) -> u64 {
+    e.storage().instance().get(&Key::LockUpPeriod).unwrap_or(0)
+}
+
+/// Sets the global lock-up period in seconds.
+pub fn put_lock_up_period(e: &Env, val: u64) {
+    e.storage().instance().set(&Key::LockUpPeriod, &val);
+}
+
+/// Returns the timestamp of the user's last deposit (0 if none).
+pub fn get_deposit_timestamp(e: &Env, addr: &Address) -> u64 {
+    e.storage()
+        .persistent()
+        .get(&Key::DepositTimestamp(addr.clone()))
+        .unwrap_or(0)
+}
+
+/// Records the timestamp of the user's most recent deposit.
+pub fn put_deposit_timestamp(e: &Env, addr: &Address, timestamp: u64) {
+    let key = Key::DepositTimestamp(addr.clone());
+    e.storage().persistent().set(&key, &timestamp);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, BALANCE_LIFETIME_THRESHOLD, BALANCE_BUMP_AMOUNT);
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_access_control.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_access_control.rs
@@ -90,6 +90,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             expected_apy: 500u32,
             timelock_delay: 172800u64, // 48 hours
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_constructor_validation.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_constructor_validation.rs
@@ -31,6 +31,7 @@ fn get_valid_params(e: &Env) -> InitParams {
         expected_apy: 500,
         timelock_delay: 172800u64, // 48 hours
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     }
 }
 
@@ -155,6 +156,7 @@ fn test_constructor_minimal_config() {
         expected_apy: 0,
         timelock_delay: 0,
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     };
 
     // Must not panic during registration.
@@ -213,6 +215,7 @@ fn test_constructor_maximum_config() {
         expected_apy: u32::MAX,
         timelock_delay: u64::MAX / 2,
         yield_vesting_period: u64::MAX / 2,
+        lock_up_period: 0u64,
     };
 
     // Must not panic during registration.

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_escrow.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_escrow.rs
@@ -308,6 +308,7 @@ fn deploy_underfunded(funding_deadline: u64) -> (Env, Address, Address, Address,
         expected_apy: 500u32,
         timelock_delay: 172800u64, // 48 hours
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     };
 
     let vault_id = env.register(SingleRWAVault, (params,));

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_funding_deadline.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_funding_deadline.rs
@@ -67,6 +67,7 @@ fn deploy(funding_deadline: u64) -> Ctx {
         expected_apy: 500u32,
         timelock_delay: 172800u64, // 48 hours
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     };
 
     let vault_id = env.register(SingleRWAVault, (params,));

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_helpers.rs
@@ -359,5 +359,6 @@ fn default_params(
         expected_apy: 500u32,       // 5 %
         timelock_delay: 172800u64,  // 48 hours
         yield_vesting_period: 0u64, // Default to 0 for instant claiming (backward compatibility)
+        lock_up_period: 0u64,       // Default to 0 for no lock-up (backward compatibility)
     }
 }

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_inflation_attack.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_inflation_attack.rs
@@ -32,6 +32,7 @@ fn default_params(env: &Env, admin: &Address, asset: &Address) -> InitParams {
         expected_apy: 500_u32,
         timelock_delay: 0u64,
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     }
 }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_lock_up.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_lock_up.rs
@@ -1,0 +1,121 @@
+//! Tests for share transfer lock-up period (issue #103).
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::testutils::Ledger as _;
+
+    use crate::errors::Error;
+    use crate::test_helpers::{advance_time, mint_usdc, setup_with_kyc_bypass};
+
+    /// Deposit and immediately try to transfer — should fail if lock-up > 0.
+    #[test]
+    fn transfer_blocked_during_lockup() {
+        let ctx = setup_with_kyc_bypass();
+        let vault = ctx.vault();
+
+        // Configure a 3600-second (1 hour) lock-up via admin.
+        vault.set_lock_up_period(&ctx.admin, &3600u64);
+
+        // Activate vault so transfers are permitted by state guard.
+        vault.activate_vault(&ctx.operator);
+
+        let user2 = soroban_sdk::Address::generate(&ctx.env);
+
+        mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 10_000_000);
+        vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+        // Transfer immediately — should panic with SharesLocked.
+        let result = ctx
+            .env
+            .try_invoke_contract::<(), _>(&ctx.vault_id, &soroban_sdk::symbol_short!("transfer"), (
+                ctx.user.clone(),
+                user2.clone(),
+                1_000_000i128,
+            ).into_val(&ctx.env));
+        // Expect an error (SharesLocked)
+        assert!(result.is_err(), "transfer should fail during lock-up");
+    }
+
+    /// After lock-up elapses the transfer should succeed.
+    #[test]
+    fn transfer_allowed_after_lockup() {
+        let ctx = setup_with_kyc_bypass();
+        let vault = ctx.vault();
+        vault.set_lock_up_period(&ctx.admin, &3600u64);
+        vault.activate_vault(&ctx.operator);
+
+        let user2 = soroban_sdk::Address::generate(&ctx.env);
+
+        mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 10_000_000);
+        vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+        // Advance time past the lock-up.
+        advance_time(&ctx.env, 3601);
+
+        // Transfer should now succeed.
+        vault.transfer(&ctx.user, &user2, &1_000_000i128);
+        assert_eq!(vault.balance(&user2), 1_000_000i128);
+    }
+
+    /// lock_up_remaining returns correct remaining time.
+    #[test]
+    fn lock_up_remaining_decreases() {
+        let ctx = setup_with_kyc_bypass();
+        let vault = ctx.vault();
+        vault.set_lock_up_period(&ctx.admin, &3600u64);
+
+        mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 10_000_000);
+        vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+        // Right after deposit, remaining should be close to 3600.
+        let remaining = vault.lock_up_remaining(&ctx.user);
+        assert!(remaining > 0 && remaining <= 3600, "remaining={remaining}");
+
+        // Advance 1800 seconds.
+        advance_time(&ctx.env, 1800);
+        let remaining2 = vault.lock_up_remaining(&ctx.user);
+        assert!(remaining2 <= 1800, "remaining2={remaining2}");
+
+        // Advance past full lock-up.
+        advance_time(&ctx.env, 1801);
+        assert_eq!(vault.lock_up_remaining(&ctx.user), 0);
+    }
+
+    /// redeem_at_maturity bypasses the lock-up.
+    #[test]
+    fn redeem_at_maturity_bypasses_lockup() {
+        let ctx = setup_with_kyc_bypass();
+        let vault = ctx.vault();
+        vault.set_lock_up_period(&ctx.admin, &999_999u64);
+
+        // Deposit in Funding, activate, then set mature state.
+        mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 10_000_000);
+        vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+        vault.activate_vault(&ctx.operator);
+
+        // Jump to past maturity date.
+        ctx.env.ledger().with_mut(|l| l.timestamp = 9_999_999_999u64 + 1);
+        vault.mature_vault(&ctx.operator);
+
+        // redeem_at_maturity should succeed even with active lock-up.
+        let shares = vault.balance(&ctx.user);
+        vault.redeem_at_maturity(&ctx.user, &ctx.user, &shares);
+    }
+
+    /// Zero lock-up period means transfers are always allowed.
+    #[test]
+    fn zero_lockup_allows_immediate_transfer() {
+        let ctx = setup_with_kyc_bypass();
+        let vault = ctx.vault();
+        // lock_up_period defaults to 0.
+
+        vault.activate_vault(&ctx.operator);
+        let user2 = soroban_sdk::Address::generate(&ctx.env);
+
+        mint_usdc(&ctx.env, &ctx.asset_id, &ctx.user, 10_000_000);
+        vault.deposit(&ctx.user, &10_000_000i128, &ctx.user);
+
+        vault.transfer(&ctx.user, &user2, &1_000_000i128);
+        assert_eq!(vault.balance(&user2), 1_000_000i128);
+    }
+}

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_rbac.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_rbac.rs
@@ -34,6 +34,7 @@ fn default_params(env: &Env, admin: &Address, asset: &Address) -> InitParams {
         expected_apy: 500_u32,
         timelock_delay: 172800u64, // 48 hours
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     }
 }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_redemption.rs
@@ -94,6 +94,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             expected_apy: 500u32,
             timelock_delay: 172800u64, // 48 hours
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_rounding.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_rounding.rs
@@ -30,6 +30,7 @@ fn default_params(env: &Env, admin: &Address, asset: &Address) -> InitParams {
         expected_apy: 500_u32,
         timelock_delay: 172800u64,
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     }
 }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_rwa_setters.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_rwa_setters.rs
@@ -86,6 +86,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             expected_apy: 500u32,
             timelock_delay: 172800u64, // 48 hours
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_share_price_oracle.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_share_price_oracle.rs
@@ -77,6 +77,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address) {
             expected_apy: 500u32,
             timelock_delay: 172800u64,
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
     (vault_id, token_id, admin)

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_token.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_token.rs
@@ -39,6 +39,7 @@ fn default_params(env: &Env, admin: &Address, asset: &Address) -> InitParams {
         expected_apy: 500_u32,
         timelock_delay: 172800u64, // 48 hours
         yield_vesting_period: 0u64,
+        lock_up_period: 0u64,
     }
 }
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/test_vault_state_guards.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/test_vault_state_guards.rs
@@ -92,6 +92,7 @@ fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             expected_apy: 500u32,
             timelock_delay: 172800u64,
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/tests.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/tests.rs
@@ -91,6 +91,7 @@ pub fn make_vault(env: &Env) -> (Address, Address, Address, Address) {
             expected_apy: 500u32,
             timelock_delay: 172800u64, // 48 hours
             yield_vesting_period: 0u64,
+            lock_up_period: 0u64,
         },),
     );
 

--- a/soroban-contracts/contracts/single_rwa_vault/src/types.rs
+++ b/soroban-contracts/contracts/single_rwa_vault/src/types.rs
@@ -41,6 +41,9 @@ pub struct InitParams {
     pub timelock_delay: u64,
     /// Yield vesting period in seconds (0 = instant claiming for backward compatibility)
     pub yield_vesting_period: u64,
+    /// Lock-up period in seconds after deposit during which shares cannot be transferred or redeemed.
+    /// 0 means no lock-up.
+    pub lock_up_period: u64,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/soroban-contracts/contracts/vault_factory/src/events.rs
+++ b/soroban-contracts/contracts/vault_factory/src/events.rs
@@ -10,11 +10,8 @@ pub fn emit_vault_created(
     vault_type: VaultType,
     name: String,
     creator: Address,
-    /// Operator fee in basis points (#515).
     operator_fee_bps: u32,
-    /// Unix timestamp at which the vault matures (#516).
     maturity_date: u64,
-    /// Expected APY in basis points (#517).
     expected_apy: u32,
 ) {
     e.events().publish(

--- a/soroban-contracts/contracts/vault_factory/src/lib.rs
+++ b/soroban-contracts/contracts/vault_factory/src/lib.rs
@@ -928,6 +928,7 @@ impl VaultFactory {
             rwa_document_uri,
             rwa_category,
             expected_apy,
+            lock_up_period: 0u64,
         };
 
         let vault_addr = e
@@ -964,12 +965,9 @@ impl VaultFactory {
             VaultType::SingleRwa,
             name,
             e.current_contract_address(),
-<<<<<<< feature/vault-response-fields-and-ci
             early_redemption_fee_bps, // #515 operator_fee_bps
             maturity_date,            // #516 maturity_date
             expected_apy,             // #517 expected_apy
-=======
->>>>>>> main
         );
 
         bump_instance(e);

--- a/soroban-contracts/contracts/vault_factory/src/types.rs
+++ b/soroban-contracts/contracts/vault_factory/src/types.rs
@@ -73,6 +73,8 @@ pub struct SingleRwaVaultInitParams {
     pub rwa_document_uri: String,
     pub rwa_category: String,
     pub expected_apy: u32,
+    /// Lock-up period in seconds after deposit (0 = no lock-up).
+    pub lock_up_period: u64,
 }
 
 /// Parameters for batch vault creation (mirrors BatchVaultParams in Solidity).


### PR DESCRIPTION
Closes #103
Closes #569
Closes #570
Closes #571

## Changes

- **#103** — Share transfer lock-up period: `lock_up_period` in `InitParams`, `DepositTimestamp(Address)` storage, lock-up enforced in `transfer`, `transfer_from`, `withdraw`, `redeem`, `request_early_redemption`; `redeem_at_maturity` bypasses; `lock_up_remaining()` view + `set_lock_up_period()` admin fn
- **#569** — `parseYieldClaimedEvent` (topic `yield_clm`) and `parseYieldClaimedPartialEvent` (topic `prt_yld`) with unit tests
- **#570** — Migration `010_last_claimed_epoch.sql`; `processEvent` handles `yield_clm`/`prt_yld` updating `last_claimed_epoch = MAX(last_claimed_epoch, epoch)`
- **#571** — `parseEarlyRedemptionRequestedEvent` (topic `erq_req`) returning `{ user, requestId, shares, queuePosition }` with unit tests
- Resolved pre-existing merge conflicts in `ci.yml` and `vault_factory/src/lib.rs`