### PR TITLE
feat: add GET /api/v1/users/:address/yield-history (#587)

### DIFF
--- a/backend/src/api/controllers/users.test.ts
+++ b/backend/src/api/controllers/users.test.ts
@@ -116,6 +116,83 @@ describe("UserService Integration", () => {
   });
 });
 
+describe("UserService.getUserYieldHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns paginated yield history for a user", async () => {
+    const { query, service } = await getTestContext();
+    const now = new Date();
+    query
+      .mockResolvedValueOnce([
+        {
+          contract_id: "CVAULT00000000000000000000000000000000000000000000000000",
+          event_type: "yield_clm",
+          payload: { user: "GABCDEF", epoch: 3, amount: "1000", timestamp: "1700000000" },
+          created_at: now,
+        },
+      ])
+      .mockResolvedValueOnce([{ count: "1" }]);
+
+    const result = await service.getUserYieldHistory("GABCDEF", 1, 20);
+
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].vaultContractId).toBe("CVAULT00000000000000000000000000000000000000000000000000");
+    expect(result.data[0].epoch).toBe(3);
+    expect(result.data[0].amount).toBe("1000");
+    expect(result.data[0].eventType).toBe("yield_clm");
+    expect(result.data[0].timestamp).toBe(new Date(1700000000 * 1000).toISOString());
+  });
+
+  it("falls back to created_at when payload has no timestamp", async () => {
+    const { query, service } = await getTestContext();
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    query
+      .mockResolvedValueOnce([
+        {
+          contract_id: "CVAULT00000000000000000000000000000000000000000000000000",
+          event_type: "prt_yld",
+          payload: { user: "GABCDEF", amount: "500" },
+          created_at: now,
+        },
+      ])
+      .mockResolvedValueOnce([{ count: "1" }]);
+
+    const result = await service.getUserYieldHistory("GABCDEF", 1, 20);
+
+    expect(result.data[0].timestamp).toBe(now.toISOString());
+    expect(result.data[0].epoch).toBeNull();
+  });
+
+  it("returns empty data when no yield events found", async () => {
+    const { query, service } = await getTestContext();
+    query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ count: "0" }]);
+
+    const result = await service.getUserYieldHistory("GNOYIELD0000000000000000000000000000000000000000000000000", 1, 20);
+
+    expect(result.data).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("applies correct offset for page 2", async () => {
+    const { query, service } = await getTestContext();
+    query.mockResolvedValueOnce([]).mockResolvedValueOnce([{ count: "0" }]);
+
+    await service.getUserYieldHistory("GABCDEF", 2, 10);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("OFFSET $3"),
+      ["GABCDEF", 10, 10],
+    );
+  });
+});
+
 describe("User Controller - search validation", () => {
   it("searchUsers controller calls service with query param", async () => {
     const { query } = await import("../../db/index.js");

--- a/backend/src/api/controllers/users.ts
+++ b/backend/src/api/controllers/users.ts
@@ -53,3 +53,19 @@ export async function searchUsers(req: Request, res: Response, next: NextFunctio
     next(err);
   }
 }
+
+export async function getUserYieldHistory(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const address = String(req.params["address"]);
+    const page = Number(req.query["page"] ?? 1);
+    const pageSize = Number(req.query["pageSize"] ?? 20);
+    const result = await userService.getUserYieldHistory(address, page, pageSize);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -4,6 +4,7 @@ import {
   getUser,
   getUserKyc,
   getUserPortfolio,
+  getUserYieldHistory,
   searchUsers,
 } from "../controllers/users.js";
 import {
@@ -26,12 +27,23 @@ const kycQuerySchema = z.object({
   vaultId: z.string().length(56).regex(/^C[A-Z2-7]{55}$/),
 });
 
+const yieldHistoryQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).default(20).transform((v) => Math.min(v, 50)),
+});
+
 usersRouter.get("/", validateQuery(searchQuerySchema), searchUsers);
 usersRouter.get(
   "/:address/kyc",
   validateParams(addressParamSchema),
   validateQuery(kycQuerySchema),
   getUserKyc,
+);
+usersRouter.get(
+  "/:address/yield-history",
+  validateParams(addressParamSchema),
+  validateQuery(yieldHistoryQuerySchema),
+  getUserYieldHistory,
 );
 usersRouter.get("/:address", validateParams(addressParamSchema), getUser);
 usersRouter.get(

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -2,6 +2,8 @@ import type {
   User,
   UserVaultPosition,
   UserPortfolioResponse,
+  PaginatedResponse,
+  YieldHistoryEntry,
 } from "../types/index.js";
 import { query } from "../db/index.js";
 
@@ -118,5 +120,56 @@ export class UserService {
   async countUsers(): Promise<number> {
     const result = await query<{ count: string }>("SELECT COUNT(*) as count FROM users");
     return parseInt(result[0]?.count ?? "0", 10);
+  }
+
+  async getUserYieldHistory(
+    address: string,
+    page: number,
+    pageSize: number,
+  ): Promise<PaginatedResponse<YieldHistoryEntry>> {
+    const offset = (page - 1) * pageSize;
+
+    const rows = await query<{
+      contract_id: string;
+      event_type: string;
+      payload: Record<string, unknown>;
+      created_at: Date;
+    }>(
+      `SELECT contract_id, event_type, payload, created_at
+       FROM indexed_events
+       WHERE event_type IN ('yield_clm', 'prt_yld')
+         AND (payload->>'user' = $1 OR payload->>'address' = $1)
+       ORDER BY (payload->>'timestamp')::numeric DESC NULLS LAST, created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [address, pageSize, offset],
+    );
+
+    const countResult = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count
+       FROM indexed_events
+       WHERE event_type IN ('yield_clm', 'prt_yld')
+         AND (payload->>'user' = $1 OR payload->>'address' = $1)`,
+      [address],
+    );
+
+    const total = parseInt(countResult[0]?.count ?? "0", 10);
+
+    const data: YieldHistoryEntry[] = rows.map((row) => {
+      const ts = row.payload["timestamp"];
+      const timestamp = ts != null
+        ? new Date(Number(ts) * 1000).toISOString()
+        : row.created_at.toISOString();
+      const epoch = row.payload["epoch"] != null ? Number(row.payload["epoch"]) : null;
+
+      return {
+        vaultContractId: row.contract_id,
+        epoch,
+        amount: String(row.payload["amount"] ?? "0"),
+        timestamp,
+        eventType: row.event_type,
+      };
+    });
+
+    return { data, total, page, pageSize };
   }
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -91,3 +91,11 @@ export interface PaginatedResponse<T> {
   page: number;
   pageSize: number;
 }
+
+export interface YieldHistoryEntry {
+  vaultContractId: string;
+  epoch: number | null;
+  amount: string;
+  timestamp: string;
+  eventType: string;
+}


### PR DESCRIPTION
## Summary

- Implements `GET /api/v1/users/:address/yield-history` as specified in #587
- Queries `indexed_events` for `event_type IN ('yield_clm', 'prt_yld')` where the user address appears in `payload.user` or `payload.address`
- Returns entries ordered by `payload.timestamp DESC` (falls back to `created_at`), paginated via `page` + `pageSize` (max 50)
- Each entry includes `vaultContractId`, `epoch`, `amount`, `timestamp`, and `eventType`
- 4 new unit tests covering happy path, fallback timestamp, empty results, and offset calculation

## Closes

Closes #587
Closes #585
Closes #586
Closes #584

## Test plan

- [ ] `GET /api/v1/users/:address/yield-history` returns `{ data, total, page, pageSize }` with claim events in reverse chronological order
- [ ] Claims from multiple vaults are included
- [ ] `pageSize` is capped at 50; `page` defaults to 1
- [ ] Invalid Stellar address returns 400
- [ ] All new unit tests pass: `npx vitest run src/api/controllers/users.test.ts`