### PR TITLE
feat: implement stellar wave issues #572, #573, #574, #575

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@stellar/stellar-sdk": "^14.0.0",
         "@stellaryield/sdk": "file:../sdk",
+        "@types/swagger-ui-express": "^4.1.8",
         "cors": "^2.8.5",
         "dotenv": "^16.4.0",
         "express": "^4.21.0",
@@ -19,6 +21,8 @@
         "pg": "^8.13.0",
         "pino": "^9.5.0",
         "pino-http": "^10.3.0",
+        "prom-client": "^15.1.3",
+        "swagger-ui-express": "^5.0.1",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -1946,6 +1950,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
+      "integrity": "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
@@ -2594,6 +2610,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -2954,6 +2979,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
       "license": "Apache-2.0"
@@ -3000,7 +3032,6 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -3009,7 +3040,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3039,7 +3069,6 @@
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -3049,7 +3078,6 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "5.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3060,7 +3088,6 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3077,7 +3104,6 @@
     },
     "node_modules/@types/node": {
       "version": "22.19.19",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3095,17 +3121,14 @@
     },
     "node_modules/@types/qs": {
       "version": "6.15.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3113,7 +3136,6 @@
     },
     "node_modules/@types/serve-static": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -3142,6 +3164,16 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3658,6 +3690,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.5",
@@ -5184,6 +5222,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.0.tgz",
+      "integrity": "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -5543,6 +5590,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -6027,6 +6087,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "license": "MIT",
@@ -6204,7 +6297,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6877,6 +6969,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,8 +19,10 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@stellar/stellar-sdk": "^14.0.0",
     "@stellaryield/sdk": "file:../sdk",
+    "@types/swagger-ui-express": "^4.1.8",
     "cors": "^2.8.5",
     "dotenv": "^16.4.0",
     "express": "^4.21.0",
@@ -29,6 +31,8 @@
     "pg": "^8.13.0",
     "pino": "^9.5.0",
     "pino-http": "^10.3.0",
+    "prom-client": "^15.1.3",
+    "swagger-ui-express": "^5.0.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,8 @@ import { webhooksRouter } from "./api/routes/webhooks.js";
 import { errorHandler } from "./api/middleware/errors.js";
 import { requestId } from "./api/middleware/requestId.js";
 import { publicLimiter, authLimiter } from "./api/middleware/rateLimit.js";
+import { httpRequestsTotal, getMetrics } from "./services/metrics.js";
+import { setupOpenApiRoutes } from "./services/openapi.js";
 
 export function createApp(): Express {
   const app = express();
@@ -29,12 +31,26 @@ export function createApp(): Express {
 
   app.use(requestId);
 
+  app.use((req, res, next) => {
+    res.on("finish", () => {
+      const route = req.route?.path ?? req.path;
+      httpRequestsTotal.inc({ method: req.method, route, status: res.statusCode });
+    });
+    next();
+  });
+
   app.use("/health", publicLimiter, healthRouter);
   app.use("/api/v1/vaults", publicLimiter, vaultsRouter);
   app.use("/api/v1/users", publicLimiter, usersRouter);
   app.use("/api/v1/yields", publicLimiter, yieldsRouter);
   app.use("/api/v1/admin", authLimiter, adminRouter);
   app.use("/api/v1/webhooks", authLimiter, webhooksRouter);
+  app.get("/metrics", async (_req, res) => {
+    res.set("Content-Type", "text/plain");
+    res.send(await getMetrics());
+  });
+
+  setupOpenApiRoutes(app);
 
   app.use(errorHandler);
 

--- a/backend/src/db/migrations/011_redemption_request_id.sql
+++ b/backend/src/db/migrations/011_redemption_request_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE redemption_requests ADD COLUMN IF NOT EXISTS request_id INTEGER;
+CREATE INDEX IF NOT EXISTS idx_redemption_requests_vault_request ON redemption_requests(vault_id, request_id);

--- a/backend/src/db/migrations/012_webhook_deliveries.sql
+++ b/backend/src/db/migrations/012_webhook_deliveries.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id              SERIAL PRIMARY KEY,
+  webhook_id      INT NOT NULL REFERENCES webhooks(id),
+  payload         JSONB NOT NULL,
+  attempt         INT NOT NULL DEFAULT 1,
+  next_retry_at   TIMESTAMPTZ,
+  delivered_at    TIMESTAMPTZ,
+  last_error      TEXT,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_retry ON webhook_deliveries(next_retry_at) WHERE delivered_at IS NULL AND attempt < 6;

--- a/backend/src/services/indexer.test.ts
+++ b/backend/src/services/indexer.test.ts
@@ -9,7 +9,7 @@ vi.mock("./vault.js", () => ({ VaultService: vi.fn().mockImplementation(() => ({
 vi.mock("./notifications.js", () => ({ NotificationService: vi.fn().mockImplementation(() => ({})) }));
 
 import { rpc, xdr, nativeToScVal } from "@stellar/stellar-sdk";
-import { Indexer, parseDepositEvent, parseYieldDistributedEvent, parseCancelFundingEvent } from "./indexer.js";
+import { Indexer, parseDepositEvent, parseYieldDistributedEvent, parseCancelFundingEvent, parseEarlyRedemptionProcessedEvent, parseEarlyRedemptionCancelledEvent } from "./indexer.js";
 import { getSorobanRpc } from "./stellar.js";
 
 const VAULT_CONTRACT = "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3B";
@@ -243,6 +243,105 @@ describe("Indexer tick", () => {
 
     expect(parseCancelFundingEvent(event1)).not.toBeNull();
     expect(parseCancelFundingEvent(event2)).not.toBeNull();
+  });
+
+  describe("parseEarlyRedemptionProcessedEvent", () => {
+    it("parses a valid early_redemption_processed event", () => {
+      const data = xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(42),
+        xdr.ScVal.scvI128(new xdr.Int128Parts({
+          lo: xdr.Uint64.fromString("5000"),
+          hi: xdr.Uint64.fromString("0"),
+        })),
+      ]);
+      const accountId = Buffer.alloc(32, 42);
+      const pubKey = new xdr.PublicKey.publicKeyTypeEd25519(accountId);
+      const scAddress = new xdr.ScAddress(xdr.ScAddressType.scAddressTypeAccount(), pubKey);
+      const topics = [
+        xdr.ScVal.scvSymbol("erq_done"),
+        xdr.ScVal.scvAddress(scAddress),
+      ];
+      const event = { topics, value: data };
+
+      const result = parseEarlyRedemptionProcessedEvent(event);
+      expect(result).not.toBeNull();
+      expect(result?.requestId).toBe(42);
+      expect(result?.netAssets).toBe(5000n);
+      expect(result?.user).toBeDefined();
+    });
+
+    it("returns null for non-matching event name", () => {
+      const topics = [xdr.ScVal.scvSymbol("deposit")];
+      const event = { topics, value: xdr.ScVal.scvVoid() };
+      expect(parseEarlyRedemptionProcessedEvent(event)).toBeNull();
+    });
+
+    it("returns null for malformed input", () => {
+      expect(parseEarlyRedemptionProcessedEvent(null)).toBeNull();
+      expect(parseEarlyRedemptionProcessedEvent({})).toBeNull();
+    });
+  });
+
+  describe("parseEarlyRedemptionCancelledEvent", () => {
+    function makeScAddress(seed: number): xdr.ScVal {
+      const accountId = Buffer.alloc(32, seed);
+      const pubKey = new xdr.PublicKey.publicKeyTypeEd25519(accountId);
+      const scAddress = new xdr.ScAddress(xdr.ScAddressType.scAddressTypeAccount(), pubKey);
+      return xdr.ScVal.scvAddress(scAddress);
+    }
+
+    it("parses a valid early_redemption_cancelled event (erq_can)", () => {
+      const data = xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(7),
+        xdr.ScVal.scvI128(new xdr.Int128Parts({
+          lo: xdr.Uint64.fromString("3000"),
+          hi: xdr.Uint64.fromString("0"),
+        })),
+      ]);
+      const topics = [
+        xdr.ScVal.scvSymbol("erq_can"),
+        makeScAddress(99),
+      ];
+      const event = { topics, value: data };
+
+      const result = parseEarlyRedemptionCancelledEvent(event);
+      expect(result).not.toBeNull();
+      expect(result?.requestId).toBe(7);
+      expect(result?.shares).toBe(3000n);
+      expect(result?.user).toBeDefined();
+    });
+
+    it("parses a v2 cancelled event (erq_can2)", () => {
+      const data = xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(10),
+        xdr.ScVal.scvI128(new xdr.Int128Parts({
+          lo: xdr.Uint64.fromString("1000"),
+          hi: xdr.Uint64.fromString("0"),
+        })),
+        xdr.ScVal.scvU32(1),
+      ]);
+      const topics = [
+        xdr.ScVal.scvSymbol("erq_can2"),
+        makeScAddress(55),
+      ];
+      const event = { topics, value: data };
+
+      const result = parseEarlyRedemptionCancelledEvent(event);
+      expect(result).not.toBeNull();
+      expect(result?.requestId).toBe(10);
+      expect(result?.shares).toBe(1000n);
+    });
+
+    it("returns null for non-matching event name", () => {
+      const topics = [xdr.ScVal.scvSymbol("withdraw")];
+      const event = { topics, value: xdr.ScVal.scvVoid() };
+      expect(parseEarlyRedemptionCancelledEvent(event)).toBeNull();
+    });
+
+    it("returns null for malformed input", () => {
+      expect(parseEarlyRedemptionCancelledEvent(null)).toBeNull();
+      expect(parseEarlyRedemptionCancelledEvent({})).toBeNull();
+    });
   });
 
 });

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -5,6 +5,7 @@ import { query } from "../db/index.js";
 import { getSorobanRpc } from "./stellar.js";
 import { VaultService } from "./vault.js";
 import { NotificationService } from "./notifications.js";
+import { indexerEventsProcessedTotal, indexerLastLedger } from "./metrics.js";
 
 // ── Upstream helpers ───────────────────────────────────────────────────────────
 
@@ -236,6 +237,8 @@ export class Indexer {
       await this.processEvent(event);
     }
 
+    await this.notificationService?.processRetries();
+
     this.lastLedger = latestLedger;
     await this.persistLastLedger();
     this.lastTickAt = new Date();
@@ -372,6 +375,20 @@ export class Indexer {
       }
       return;
     }
+
+    const earlyProcessed = parseEarlyRedemptionProcessedEvent(event);
+    if (earlyProcessed) {
+      await this.handleEarlyRedemptionProcessed(event.contractId ?? "", earlyProcessed);
+      await this.recordEvent(event, "early_redemption_processed");
+      return;
+    }
+
+    const earlyCancelled = parseEarlyRedemptionCancelledEvent(event);
+    if (earlyCancelled) {
+      await this.handleEarlyRedemptionCancelled(event.contractId ?? "", earlyCancelled);
+      await this.recordEvent(event, "early_redemption_cancelled");
+      return;
+    }
   }
 
   isRunning(): boolean {
@@ -494,9 +511,59 @@ export class Indexer {
     });
   }
 
+  private async handleEarlyRedemptionProcessed(
+    contractId: string,
+    event: ParsedEarlyRedemptionProcessedEvent,
+  ): Promise<void> {
+    const vaultRow = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRow.length === 0) {
+      logger.warn({ contractId }, "early_redemption_processed for unknown vault — skipping");
+      return;
+    }
+    const vaultId = vaultRow[0].id;
+
+    await query(
+      `UPDATE redemption_requests SET processed = TRUE
+       WHERE vault_id = $1 AND request_id = $2 AND processed = FALSE`,
+      [vaultId, event.requestId],
+    );
+    logger.info(
+      { contractId, user: event.user, requestId: event.requestId },
+      "Processed early_redemption_processed event",
+    );
+  }
+
+  private async handleEarlyRedemptionCancelled(
+    contractId: string,
+    event: ParsedEarlyRedemptionCancelledEvent,
+  ): Promise<void> {
+    const vaultRow = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRow.length === 0) {
+      logger.warn({ contractId }, "early_redemption_cancelled for unknown vault — skipping");
+      return;
+    }
+    const vaultId = vaultRow[0].id;
+
+    await query(
+      `UPDATE redemption_requests SET processed = TRUE
+       WHERE vault_id = $1 AND request_id = $2 AND processed = FALSE`,
+      [vaultId, event.requestId],
+    );
+    logger.info(
+      { contractId, user: event.user, requestId: event.requestId },
+      "Processed early_redemption_cancelled event",
+    );
+  }
+
   private async handleRequestEarlyRedemption(
     contractId: string,
-    redemptionRequest: { userAddress: string; shares: bigint; timestamp: bigint },
+    redemptionRequest: { userAddress: string; requestId: number; shares: bigint; timestamp: bigint },
   ): Promise<void> {
     const vaultRow = await query<{ id: number }>(
       "SELECT id FROM vaults WHERE contract_id = $1",
@@ -512,13 +579,13 @@ export class Indexer {
     const requestTime = new Date(Number(redemptionRequest.timestamp) * 1000);
 
     await query(
-      `INSERT INTO redemption_requests (vault_id, user_address, shares, request_time, processed)
-       VALUES ($1, $2, $3, $4, FALSE)
-       ON CONFLICT (vault_id, user_address, request_time) DO NOTHING`,
-      [vaultId, redemptionRequest.userAddress, redemptionRequest.shares.toString(), requestTime],
+      `INSERT INTO redemption_requests (vault_id, user_address, shares, request_id, request_time, processed)
+       VALUES ($1, $2, $3, $4, $5, FALSE)
+       ON CONFLICT (vault_id, user_address, request_time) DO UPDATE SET request_id = EXCLUDED.request_id`,
+      [vaultId, redemptionRequest.userAddress, redemptionRequest.shares.toString(), redemptionRequest.requestId, requestTime],
     );
     logger.info(
-      { contractId, userAddress: redemptionRequest.userAddress, shares: redemptionRequest.shares.toString() },
+      { contractId, userAddress: redemptionRequest.userAddress, shares: redemptionRequest.shares.toString(), requestId: redemptionRequest.requestId },
       "Processed request_early_redemption event",
     );
   }
@@ -536,10 +603,12 @@ export class Indexer {
         JSON.stringify(event),
       ],
     );
+    indexerEventsProcessedTotal.inc();
   }
 
   private async persistLastLedger(): Promise<void> {
     await this.saveLastIndexedLedger(this.lastLedger);
+    indexerLastLedger.set(this.lastLedger);
   }
 
   async getLastIndexedLedger(): Promise<number> {
@@ -840,6 +909,7 @@ export function parseVaultCreatedEvent(rawEvent: any): {
 }
 export interface ParsedRequestEarlyRedemptionEvent {
   userAddress: string;
+  requestId: number;
   shares: bigint;
   timestamp: bigint;
 }
@@ -866,16 +936,103 @@ export function parseRequestEarlyRedemptionEvent(rawEvent: unknown): ParsedReque
     } catch {
       return null;
     }
-    if (eventName !== "request_early_redemption") return null;
+    if (eventName !== "erq_req" && eventName !== "request_early_redemption") return null;
 
     const userAddress = String(scValToNative(parsedTopics[1]) ?? "");
 
     const data = scValToNative(parsedValue as xdr.ScVal);
     const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
-    const shares = decodeBigInt(arr[0]);
-    const timestamp = decodeBigInt(arr[1]);
+    const requestId = Number(decodeBigInt(arr[0]));
+    const shares = decodeBigInt(arr[1]);
+    const timestamp = decodeBigInt(arr[2] ?? 0n);
 
-    return { userAddress, shares, timestamp };
+    return { userAddress, requestId, shares, timestamp };
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedEarlyRedemptionProcessedEvent {
+  user: string;
+  requestId: number;
+  netAssets: bigint;
+}
+
+export function parseEarlyRedemptionProcessedEvent(rawEvent: unknown): ParsedEarlyRedemptionProcessedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "erq_done" && eventName !== "early_redemption_processed") return null;
+
+    const user = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const data = scValToNative(parsedValue as xdr.ScVal);
+    const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
+    const requestId = Number(decodeBigInt(arr[0]));
+    const netAssets = decodeBigInt(arr[1]);
+
+    return { user, requestId, netAssets };
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedEarlyRedemptionCancelledEvent {
+  user: string;
+  requestId: number;
+  shares: bigint;
+}
+
+export function parseEarlyRedemptionCancelledEvent(rawEvent: unknown): ParsedEarlyRedemptionCancelledEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "erq_can" && eventName !== "erq_can2" && eventName !== "early_redemption_cancelled") return null;
+
+    const user = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const data = scValToNative(parsedValue as xdr.ScVal);
+    const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
+    const requestId = Number(decodeBigInt(arr[0]));
+    const shares = decodeBigInt(arr[1]);
+
+    return { user, requestId, shares };
   } catch {
     return null;
   }

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -1,0 +1,36 @@
+import client from "prom-client";
+
+const register = new client.Registry();
+
+client.collectDefaultMetrics({ register });
+
+export const httpRequestsTotal = new client.Counter({
+  name: "http_requests_total",
+  help: "Total number of HTTP requests",
+  labelNames: ["method", "route", "status"] as const,
+  registers: [register],
+});
+
+export const indexerEventsProcessedTotal = new client.Counter({
+  name: "indexer_events_processed_total",
+  help: "Total number of on-chain events processed by the indexer",
+  registers: [register],
+});
+
+export const indexerLastLedger = new client.Gauge({
+  name: "indexer_last_ledger",
+  help: "Last indexed ledger sequence number",
+  registers: [register],
+});
+
+export const dbQueryDurationSeconds = new client.Histogram({
+  name: "db_query_duration_seconds",
+  help: "Database query duration in seconds",
+  labelNames: ["query"] as const,
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+  registers: [register],
+});
+
+export async function getMetrics(): Promise<string> {
+  return register.metrics();
+}

--- a/backend/src/services/notifications.ts
+++ b/backend/src/services/notifications.ts
@@ -68,10 +68,86 @@ export class NotificationService {
 
     const payload = JSON.stringify({ event, data, timestamp: new Date().toISOString() });
 
-    await Promise.allSettled(webhooks.map((webhook) => this.deliver(webhook, payload)));
+    const results = await Promise.allSettled(
+      webhooks.map((webhook) => this.deliver(webhook, payload)),
+    );
+
+    for (let i = 0; i < webhooks.length; i++) {
+      const result = results[i];
+      if (result.status === "rejected" || (result.status === "fulfilled" && !result.value)) {
+        await query(
+          `INSERT INTO webhook_deliveries (webhook_id, payload, attempt, next_retry_at, last_error)
+           VALUES ($1, $2, 1, NOW() + INTERVAL '5 seconds', $3)`,
+          [webhooks[i].id, payload, result.status === "rejected" ? String(result.reason) : "non-2xx response"],
+        );
+      }
+    }
   }
 
-  private async deliver(webhook: WebhookRow, payload: string): Promise<void> {
+  /**
+   * Process due webhook retries. Selects entries that are due for retry,
+   * re-delivers, and updates the delivery status.
+   */
+  async processRetries(): Promise<void> {
+    const dueRows = await query<{
+      id: number;
+      webhook_id: number;
+      payload: string;
+      attempt: number;
+    }>(
+      `SELECT wd.id, wd.webhook_id, wd.payload, wd.attempt
+       FROM webhook_deliveries wd
+       JOIN webhooks w ON w.id = wd.webhook_id AND w.active = TRUE
+       WHERE wd.next_retry_at <= NOW()
+         AND wd.delivered_at IS NULL
+         AND wd.attempt < 6
+       ORDER BY wd.next_retry_at ASC
+       LIMIT 50`,
+    );
+
+    for (const row of dueRows) {
+      try {
+        const webhookRows = await query<WebhookRow>(
+          "SELECT id, url, events, secret FROM webhooks WHERE id = $1",
+          [row.webhook_id],
+        );
+        if (webhookRows.length === 0) continue;
+        const webhook = webhookRows[0];
+
+        const ok = await this.deliver(webhook, row.payload);
+        if (ok) {
+          await query(
+            "UPDATE webhook_deliveries SET delivered_at = NOW() WHERE id = $1",
+            [row.id],
+          );
+        } else {
+          const nextAttempt = row.attempt + 1;
+          const delaySeconds = Math.min(Math.pow(2, row.attempt) * 5, 3600);
+          await query(
+            `UPDATE webhook_deliveries
+             SET attempt = $1, next_retry_at = NOW() + INTERVAL '1 second' * $2, last_error = $3
+             WHERE id = $4`,
+            [nextAttempt, delaySeconds, "non-2xx response", row.id],
+          );
+        }
+      } catch (err) {
+        const nextAttempt = row.attempt + 1;
+        const delaySeconds = Math.min(Math.pow(2, row.attempt) * 5, 3600);
+        await query(
+          `UPDATE webhook_deliveries
+           SET attempt = $1, next_retry_at = NOW() + INTERVAL '1 second' * $2, last_error = $3
+           WHERE id = $4`,
+          [nextAttempt, delaySeconds, String(err), row.id],
+        );
+      }
+    }
+  }
+
+  /**
+   * Deliver a webhook payload. Returns true on success, false on failure.
+   * Throws on network/SSRF errors.
+   */
+  private async deliver(webhook: WebhookRow, payload: string): Promise<boolean> {
     // Re-validate at delivery time to defend against DNS rebinding.
     try {
       await validateWebhookUrl(webhook.url);
@@ -80,7 +156,7 @@ export class NotificationService {
         { webhookId: webhook.id, url: webhook.url, err },
         "Webhook URL failed SSRF check at delivery; skipping",
       );
-      return;
+      return false;
     }
 
     const headers: Record<string, string> = {
@@ -106,7 +182,7 @@ export class NotificationService {
           { webhookId: webhook.id, url: webhook.url, status: response.status },
           "Webhook delivery returned redirect; rejected for SSRF protection",
         );
-        return;
+        return false;
       }
 
       if (!response.ok) {
@@ -114,9 +190,13 @@ export class NotificationService {
           { webhookId: webhook.id, url: webhook.url, status: response.status },
           "Webhook delivery returned non-2xx status",
         );
+        return false;
       }
+
+      return true;
     } catch (err) {
       logger.warn({ webhookId: webhook.id, url: webhook.url, err }, "Webhook delivery failed");
+      throw err;
     }
   }
 

--- a/backend/src/services/openapi.ts
+++ b/backend/src/services/openapi.ts
@@ -1,0 +1,381 @@
+import { OpenApiGeneratorV3, OpenAPIRegistry, extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import type { Express } from "express";
+
+extendZodWithOpenApi(z);
+
+const registry = new OpenAPIRegistry();
+
+const vaultStateSchema = z.enum(["Funding", "Active", "Matured", "Closed", "Cancelled"]);
+
+const vaultSchema = z.object({
+  id: z.number(),
+  contractId: z.string(),
+  factoryId: z.string().nullable(),
+  asset: z.string(),
+  name: z.string().nullable(),
+  symbol: z.string().nullable(),
+  state: vaultStateSchema,
+  totalAssets: z.string(),
+  totalSupply: z.string(),
+  depositorCount: z.number(),
+  fundingTarget: z.string().nullable(),
+  fundingDeadline: z.string().nullable(),
+  fundingProgress: z.number().nullable(),
+  minDeposit: z.string().nullable(),
+  maxDepositPerUser: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const paginatedVaultsSchema = z.object({
+  data: z.array(vaultSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+
+const userSchema = z.object({
+  id: z.number(),
+  address: z.string(),
+  kycVerified: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const userPortfolioSchema = z.object({
+  positions: z.array(z.object({
+    id: z.number(),
+    userAddress: z.string(),
+    vaultId: z.number(),
+    shares: z.string(),
+    deposited: z.string(),
+    lastClaimedEpoch: z.number(),
+    updatedAt: z.string(),
+  })),
+  totalDeposited: z.string(),
+});
+
+const epochSchema = z.object({
+  id: z.number(),
+  vaultId: z.number(),
+  epoch: z.number(),
+  yieldAmount: z.string(),
+  totalShares: z.string(),
+  distributedAt: z.string().nullable(),
+});
+
+const redemptionRequestSchema = z.object({
+  id: z.number(),
+  userAddress: z.string(),
+  shares: z.string(),
+  requestTime: z.string(),
+});
+
+const adminStatsSchema = z.object({
+  vaultCount: z.number(),
+  userCount: z.number(),
+  totalValueLocked: z.string(),
+  epochCount: z.number(),
+});
+
+const indexerStatusSchema = z.object({
+  running: z.boolean(),
+  lastLedger: z.number(),
+  lastTickAt: z.string().nullable(),
+  eventsIndexed: z.number(),
+});
+
+const errorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+});
+
+function registerPaths(): void {
+  registry.registerPath({
+    method: "get",
+    path: "/health",
+    summary: "Health check",
+    tags: ["Health"],
+    responses: {
+      200: {
+        description: "Server is healthy",
+        content: { "application/json": { schema: z.object({ version: z.string(), status: z.string() }) } },
+      },
+      503: {
+        description: "Service unavailable",
+        content: { "application/json": { schema: errorResponseSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults",
+    summary: "List vaults",
+    tags: ["Vaults"],
+    request: {
+      query: z.object({
+        page: z.coerce.number().optional(),
+        pageSize: z.coerce.number().optional(),
+        state: z.string().optional(),
+        sort: z.enum(["created_at", "total_assets"]).optional(),
+        order: z.enum(["asc", "desc"]).optional(),
+      }),
+    },
+    responses: {
+      200: { description: "Paginated list of vaults", content: { "application/json": { schema: paginatedVaultsSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/count",
+    summary: "Get vault count",
+    tags: ["Vaults"],
+    responses: {
+      200: { description: "Total vault count", content: { "application/json": { schema: z.object({ total: z.number() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}",
+    summary: "Get vault by contract ID",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "Vault details", content: { "application/json": { schema: vaultSchema } } },
+      404: { description: "Vault not found", content: { "application/json": { schema: errorResponseSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/factory/{factoryId}",
+    summary: "List vaults by factory",
+    tags: ["Vaults"],
+    parameters: [{ name: "factoryId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "List of vaults for factory", content: { "application/json": { schema: z.array(vaultSchema) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}/state/live",
+    summary: "Get live vault state from chain",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "Live vault state", content: { "application/json": { schema: z.object({ state: z.string() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}/total-assets/live",
+    summary: "Get live total assets from chain",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "Live total assets", content: { "application/json": { schema: z.object({ totalAssets: z.string() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}/redemption-queue",
+    summary: "Get redemption queue",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "Redemption queue", content: { "application/json": { schema: z.array(redemptionRequestSchema) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}/snapshot",
+    summary: "Get vault snapshot",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "Vault snapshot", content: { "application/json": { schema: z.object({ state: z.string(), totalAssets: z.string(), totalSupply: z.string(), depositorCount: z.number(), epochCount: z.number(), lastIndexedAt: z.string().nullable() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}/tvl-history",
+    summary: "Get vault TVL history",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "TVL history", content: { "application/json": { schema: z.array(z.object({ totalAssets: z.string(), totalSupply: z.string(), recordedAt: z.string() })) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/users/{address}",
+    summary: "Get user by address",
+    tags: ["Users"],
+    parameters: [{ name: "address", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "User details", content: { "application/json": { schema: userSchema } } },
+      404: { description: "User not found", content: { "application/json": { schema: errorResponseSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/users/{address}/portfolio",
+    summary: "Get user portfolio",
+    tags: ["Users"],
+    parameters: [{ name: "address", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "User portfolio", content: { "application/json": { schema: userPortfolioSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/users/{address}/positions",
+    summary: "Get user vault positions",
+    tags: ["Users"],
+    parameters: [{ name: "address", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "User vault positions", content: { "application/json": { schema: z.array(z.object({ id: z.number(), userAddress: z.string(), vaultId: z.number(), shares: z.string(), deposited: z.string(), lastClaimedEpoch: z.number(), updatedAt: z.string() })) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/yields",
+    summary: "List yields",
+    tags: ["Yields"],
+    request: { query: z.object({ vaultId: z.coerce.number().optional(), epoch: z.coerce.number().optional() }) },
+    responses: {
+      200: { description: "List of yield distributions", content: { "application/json": { schema: z.array(epochSchema) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/admin/stats",
+    summary: "Get admin stats (requires API key)",
+    tags: ["Admin"],
+    responses: {
+      200: { description: "Admin statistics", content: { "application/json": { schema: adminStatsSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/admin/indexer",
+    summary: "Get indexer status (requires API key)",
+    tags: ["Admin"],
+    responses: {
+      200: { description: "Indexer status", content: { "application/json": { schema: indexerStatusSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/v1/admin/indexer/backfill",
+    summary: "Trigger indexer backfill (requires API key)",
+    tags: ["Admin"],
+    request: { body: { content: { "application/json": { schema: z.object({ fromLedger: z.number(), toLedger: z.number() }) } } } },
+    responses: {
+      202: { description: "Backfill queued", content: { "application/json": { schema: z.object({ queued: z.boolean(), fromLedger: z.number(), toLedger: z.number() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/admin/events",
+    summary: "Get indexed events (requires API key)",
+    tags: ["Admin"],
+    responses: {
+      200: { description: "Indexed events", content: { "application/json": { schema: z.array(z.object({ id: z.number(), ledger: z.number(), txHash: z.string(), contractId: z.string(), eventType: z.string(), createdAt: z.string() })) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/admin/vaults/{contractId}/audit",
+    summary: "Get vault audit trail (requires API key)",
+    tags: ["Admin"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: { description: "Vault audit trail", content: { "application/json": { schema: z.object({ data: z.array(z.any()), total: z.number(), limit: z.number(), offset: z.number() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/v1/webhooks",
+    summary: "Create webhook (requires API key)",
+    tags: ["Webhooks"],
+    request: { body: { content: { "application/json": { schema: z.object({ url: z.string(), events: z.array(z.string()), secret: z.string().optional() }) } } } },
+    responses: {
+      201: { description: "Webhook created", content: { "application/json": { schema: z.object({ id: z.number(), url: z.string(), events: z.array(z.string()), active: z.boolean(), createdAt: z.string() }) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/webhooks",
+    summary: "List webhooks (requires API key)",
+    tags: ["Webhooks"],
+    responses: {
+      200: { description: "List of webhooks", content: { "application/json": { schema: z.array(z.object({ id: z.number(), url: z.string(), events: z.array(z.string()), active: z.boolean(), createdAt: z.string() })) } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/v1/webhooks/{id}",
+    summary: "Delete webhook (requires API key)",
+    tags: ["Webhooks"],
+    parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      204: { description: "Webhook deleted" },
+      404: { description: "Webhook not found", content: { "application/json": { schema: errorResponseSchema } } },
+    },
+  });
+}
+
+registerPaths();
+
+const generator = new OpenApiGeneratorV3(registry.definitions);
+
+export function getOpenApiSpec(): ReturnType<typeof generator.generateDocument> {
+  return generator.generateDocument({
+    openapi: "3.1.0",
+    info: {
+      title: "StellarYield API",
+      version: "0.1.0",
+      description: "REST API for StellarYield — indexes on-chain events and exposes vault, user, and yield data.",
+    },
+    servers: [{ url: "/", description: "Base URL" }],
+  });
+}
+
+export function setupOpenApiRoutes(app: Express): void {
+  const spec = getOpenApiSpec();
+
+  app.get("/api/v1/docs/openapi.json", (_req, res) => {
+    res.json(spec);
+  });
+
+  import("swagger-ui-express").then((swaggerUi) => {
+    app.use("/api/v1/docs", swaggerUi.serve, swaggerUi.setup(spec, {
+      explorer: true,
+      customSiteTitle: "StellarYield API Docs",
+    }));
+  }).catch(() => {
+    // swagger-ui-express not available; skip UI setup
+  });
+}

--- a/backend/src/services/redemption-queue.test.ts
+++ b/backend/src/services/redemption-queue.test.ts
@@ -117,10 +117,11 @@ describe("parseRequestEarlyRedemptionEvent", () => {
   it("parses a valid request_early_redemption event", () => {
     const mockEvent = {
       topic: [
-        xdr.ScVal.scvSymbol("request_early_redemption"),
+        xdr.ScVal.scvSymbol("erq_req"),
         xdr.ScVal.scvAddress(xdr.Address.typeAccount(new xdr.PublicKey.publicKeyTypeEd25519(Buffer.alloc(32, 42)))),
       ],
       value: xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(1),
         xdr.ScVal.scvU128(xdr.Uint128Parts.fromXDRObject({
           lo: xdr.Uint64.fromString("1000"),
           hi: xdr.Uint64.fromString("0"),
@@ -132,6 +133,7 @@ describe("parseRequestEarlyRedemptionEvent", () => {
     const result = parseRequestEarlyRedemptionEvent(mockEvent);
     expect(result).not.toBeNull();
     if (result) {
+      expect(result.requestId).toBe(1);
       expect(result.shares).toBe(1000n);
       expect(result.timestamp).toBe(1609459200n);
       expect(result.userAddress).toBeDefined();
@@ -199,6 +201,7 @@ describe("Indexer - request_early_redemption handler", () => {
         xdr.ScVal.scvAddress(xdr.Address.typeAccount(new xdr.PublicKey.publicKeyTypeEd25519(Buffer.alloc(32, 99)))),
       ],
       value: xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(1),
         xdr.ScVal.scvU128(xdr.Uint128Parts.fromXDRObject({
           lo: xdr.Uint64.fromString("500"),
           hi: xdr.Uint64.fromString("0"),
@@ -233,6 +236,7 @@ describe("Indexer - request_early_redemption handler", () => {
         xdr.ScVal.scvAddress(xdr.Address.typeAccount(new xdr.PublicKey.publicKeyTypeEd25519(Buffer.alloc(32, 88)))),
       ],
       value: xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(2),
         xdr.ScVal.scvU128(xdr.Uint128Parts.fromXDRObject({
           lo: xdr.Uint64.fromString("100"),
           hi: xdr.Uint64.fromString("0"),
@@ -268,6 +272,7 @@ describe("Indexer - request_early_redemption handler", () => {
         xdr.ScVal.scvAddress(xdr.Address.typeAccount(new xdr.PublicKey.publicKeyTypeEd25519(Buffer.alloc(32, 77)))),
       ],
       value: xdr.ScVal.scvVec([
+        xdr.ScVal.scvU32(3),
         xdr.ScVal.scvU128(xdr.Uint128Parts.fromXDRObject({
           lo: xdr.Uint64.fromString("250"),
           hi: xdr.Uint64.fromString("0"),


### PR DESCRIPTION


## #572 — Parse `early_redemption_processed` and `early_redemption_cancelled` events
- Added `parseEarlyRedemptionProcessedEvent` and `parseEarlyRedemptionCancelledEvent` parsers
- Added DB migration for `request_id` column on `redemption_requests`
- Updated `processEvent` to mark requests as processed on these events
- Updated `parseRequestEarlyRedemptionEvent` to include `requestId`
- Unit tests for both new parsers

## #573 — Implement webhook retry queue with exponential backoff
- Created `webhook_deliveries` table (migration #012)
- Modified `NotificationService.deliver()` to insert retry rows on failure
- Added `processRetries()` method with exponential backoff (2^attempt × 5s, max 1h, 5 attempts)
- Retry processing runs in the indexer tick loop

## #574 — Add Prometheus metrics endpoint
- Installed `prom-client` and created `metrics.ts` service
- Tracks: `http_requests_total` (method, route, status), `indexer_events_processed_total`, `indexer_last_ledger`
- Exposed `GET /metrics` endpoint (Prometheus text format)

## #575 — Generate OpenAPI documentation with `zod-to-openapi`
- Installed `@asteasolutions/zod-to-openapi` and `swagger-ui-express`
- Created `openapi.ts` service registering all API paths with Zod schemas
- `GET /api/v1/docs/openapi.json` serves the generated OpenAPI 3.1 spec
- `GET /api/v1/docs` serves Swagger UI

closes #572
closes #573 
closes #574 
closes #575