### PR TITLE
feat: sync KYC status from indexed kyc_set events

### DIFF
--- a/backend/src/services/indexer.test.ts
+++ b/backend/src/services/indexer.test.ts
@@ -6,6 +6,11 @@ vi.mock("../logger.js", () => ({
 }));
 vi.mock("./stellar.js", () => ({ getSorobanRpc: vi.fn() }));
 vi.mock("./vault.js", () => ({ VaultService: vi.fn().mockImplementation(() => ({})) }));
+vi.mock("./user.js", () => ({
+  UserService: vi.fn().mockImplementation(() => ({
+    upsertUser: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 vi.mock("./notifications.js", () => ({ NotificationService: vi.fn().mockImplementation(() => ({})) }));
 
 import { rpc, xdr, nativeToScVal } from "@stellar/stellar-sdk";
@@ -396,6 +401,7 @@ import {
   parseYieldClaimedEvent,
   parseYieldClaimedPartialEvent,
   parseEarlyRedemptionRequestedEvent,
+  parseKycVerifiedEvent,
 } from "./indexer.js";
 
 describe("parseYieldClaimedEvent", () => {
@@ -457,5 +463,39 @@ describe("parseEarlyRedemptionRequestedEvent", () => {
   it("returns null for malformed events", () => {
     expect(parseEarlyRedemptionRequestedEvent(null)).toBeNull();
     expect(parseEarlyRedemptionRequestedEvent({})).toBeNull();
+  });
+});
+
+// ── Issue #611: parseKycVerifiedEvent ─────────────────────────────────────────
+
+describe("parseKycVerifiedEvent", () => {
+  it("parses a kyc_set event with verified=true", () => {
+    const topics = [nativeToScVal("kyc_set"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal(true);
+    const result = parseKycVerifiedEvent({ topics, data });
+    expect(result).not.toBeNull();
+    expect(result?.user).toBe(ACCOUNT);
+    expect(result?.verified).toBe(true);
+  });
+
+  it("parses a kyc_set event with verified=false", () => {
+    const topics = [nativeToScVal("kyc_set"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal(false);
+    const result = parseKycVerifiedEvent({ topics, data });
+    expect(result).not.toBeNull();
+    expect(result?.user).toBe(ACCOUNT);
+    expect(result?.verified).toBe(false);
+  });
+
+  it("returns null for an unrecognised topic", () => {
+    const topics = [nativeToScVal("deposit"), nativeToScVal(ACCOUNT)];
+    const data = nativeToScVal(true);
+    expect(parseKycVerifiedEvent({ topics, data })).toBeNull();
+  });
+
+  it("returns null for malformed events", () => {
+    expect(parseKycVerifiedEvent(null)).toBeNull();
+    expect(parseKycVerifiedEvent({})).toBeNull();
+    expect(parseKycVerifiedEvent({ topics: [], data: null })).toBeNull();
   });
 });

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -4,6 +4,7 @@ import { logger } from "../logger.js";
 import { query } from "../db/index.js";
 import { getSorobanRpc } from "./stellar.js";
 import { VaultService } from "./vault.js";
+import { UserService } from "./user.js";
 import { NotificationService } from "./notifications.js";
 import { indexerEventsProcessedTotal, indexerLastLedger } from "./metrics.js";
 
@@ -115,12 +116,14 @@ export class Indexer {
   private lastTickAt: Date | null = null;
   private readonly vaultFactoryContractId: string;
   private vaultService: VaultService;
+  private userService: UserService;
   private notificationService?: NotificationService;
 
   constructor(notificationService?: NotificationService) {
     this.lastLedger = config.indexer.startLedger;
     this.vaultFactoryContractId = config.stellar.vaultFactoryContractId;
     this.vaultService = new VaultService();
+    this.userService = new UserService();
     this.notificationService = notificationService;
 
     if (!this.vaultFactoryContractId) {
@@ -418,6 +421,17 @@ export class Indexer {
     if (earlyCancelled) {
       await this.handleEarlyRedemptionCancelled(event.contractId ?? "", earlyCancelled);
       await this.recordEvent(event, "early_redemption_cancelled");
+      return;
+    }
+
+    const kycUpdate = parseKycVerifiedEvent(event);
+    if (kycUpdate) {
+      await this.userService.upsertUser(kycUpdate.user, kycUpdate.verified);
+      await this.recordEvent(event, "kyc_set");
+      logger.info(
+        { user: kycUpdate.user, verified: kycUpdate.verified },
+        "Processed kyc_set event",
+      );
       return;
     }
   }
@@ -1183,6 +1197,55 @@ export function parseEarlyRedemptionRequestedEvent(rawEvent: unknown): ParsedEar
     const queuePosition = Number(arr[2] ?? 0);
 
     return { user, requestId, shares, queuePosition };
+  } catch {
+    return null;
+  }
+}
+
+// ── Issue #611: parseKycVerifiedEvent ─────────────────────────────────────────
+
+export interface ParsedKycVerifiedEvent {
+  user: string;
+  verified: boolean;
+}
+
+/**
+ * Parses a `kyc_set` on-chain event emitted when an operator updates a user's
+ * KYC status.
+ *
+ * Expected event shape:
+ *   topics[0]: symbol "kyc_set"
+ *   topics[1]: account address of the user
+ *   value:     bool — true = verified, false = revoked
+ */
+export function parseKycVerifiedEvent(rawEvent: unknown): ParsedKycVerifiedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "kyc_set") return null;
+
+    const user = String(scValToNative(parsedTopics[1]) ?? "");
+    const verified = Boolean(scValToNative(parsedValue as xdr.ScVal));
+
+    return { user, verified };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Adds `parseKycVerifiedEvent` to the indexer, parsing on-chain `kyc_set` events that carry a user address (topic[1]) and a verified boolean (value).
- Wires the parser into `processEvent`: when a `kyc_set` event is detected, `UserService.upsertUser` is called with the updated `kycVerified` flag, keeping `users.kyc_verified` in sync with chain state automatically.
- Adds `UserService` instance to `Indexer` and mocks it in the test suite.
- Adds 4 unit tests covering `verified=true`, `verified=false`, wrong topic, and malformed input.

## Test plan

- [ ] `parseKycVerifiedEvent` returns `{ user, verified: true }` for a `kyc_set` event with `scvBool(true)`
- [ ] `parseKycVerifiedEvent` returns `{ user, verified: false }` for a `kyc_set` event with `scvBool(false)`
- [ ] `parseKycVerifiedEvent` returns `null` for non-matching topic
- [ ] `parseKycVerifiedEvent` returns `null` for `null` / `{}` / `{ topics: [], data: null }`
- [ ] After a `kyc_set` event is indexed, `GET /api/v1/users/:address` reflects the updated `kycVerified` value

Closes #611
Closes #608
Closes #610
Closes #614