### PR TITLE
feat: add batch KYC status endpoint and event parsers

### DIFF
--- a/backend/src/api/controllers/users.ts
+++ b/backend/src/api/controllers/users.ts
@@ -83,3 +83,22 @@ export async function getUserYieldHistory(
     next(err);
   }
 }
+
+export async function getKycBatch(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { addresses, vaultId } = req.body as { addresses: string[]; vaultId: string };
+    const results = await Promise.all(
+      addresses.map(async (address) => {
+        try {
+          const verified = await readKycVerified(vaultId, address);
+          return [address, verified] as const;
+        } catch {
+          return [address, false] as const;
+        }
+      }),
+    );
+    res.json(Object.fromEntries(results));
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import {
+  getKycBatch,
   getPortfoliosBatch,
   getUser,
   getUserKyc,
@@ -36,6 +37,14 @@ const kycQuerySchema = z.object({
   vaultId: z.string().length(56).regex(/^C[A-Z2-7]{55}$/),
 });
 
+const kycBatchBodySchema = z.object({
+  addresses: z
+    .array(stellarAddressSchema)
+    .min(1, "At least one address is required")
+    .max(50, "A maximum of 50 addresses is allowed"),
+  vaultId: z.string().length(56).regex(/^C[A-Z2-7]{55}$/, "Invalid vault contract ID"),
+});
+
 const yieldHistoryQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).default(20).transform((v) => Math.min(v, 50)),
@@ -46,6 +55,11 @@ usersRouter.post(
   "/portfolios/batch",
   validateBody(batchPortfoliosBodySchema),
   getPortfoliosBatch,
+);
+usersRouter.post(
+  "/kyc/batch",
+  validateBody(kycBatchBodySchema),
+  getKycBatch,
 );
 usersRouter.get(
   "/:address/kyc",


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/users/kyc/batch` accepting `{ addresses: string[], vaultId: string }` (max 50 G-addresses)
- Returns a `{ [address]: boolean }` map; all addresses are checked in parallel via `Promise.all`
- Addresses with no on-chain KYC record return `false`; on-chain errors default to `false` instead of surfacing 500s
- Full Zod validation: Stellar G-address format, Stellar C-address vault ID format, 1–50 length bounds

Closes #613
Closes #615
Closes #617
Closes #618

## Test plan

- [ ] `POST /api/v1/users/kyc/batch` with 1–50 valid addresses returns `{ address: true/false }` map
- [ ] More than 50 addresses returns HTTP 400 `ValidationError`
- [ ] Non-G-address in `addresses` array returns HTTP 400
- [ ] Non-C-address `vaultId` returns HTTP 400
- [ ] Empty `addresses` array returns HTTP 400