### PR TITLE
feat: vault holder analytics and cumulative share tracking 

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -252,6 +252,25 @@ export async function getVaultSnapshot(req: Request, res: Response, next: NextFu
     );
     const lastIndexedAt = lastEventRows[0]?.created_at?.toISOString() ?? null;
 
+    // Compute top-10 holder concentration metric
+    const top10Rows = await query<{ top10_shares: string }>(
+      `SELECT COALESCE(SUM(shares), 0)::text AS top10_shares
+       FROM (
+         SELECT uvp.shares
+         FROM user_vault_positions uvp
+         WHERE uvp.vault_id = $1 AND uvp.shares > 0
+         ORDER BY uvp.shares DESC
+         LIMIT 10
+       ) top10`,
+      [vault.id],
+    );
+    const totalSupplyNum = parseFloat(vault.totalSupply);
+    let top10HolderSharePercent: number | null = null;
+    if (totalSupplyNum > 0) {
+      const top10Shares = parseFloat(top10Rows[0]?.top10_shares ?? "0");
+      top10HolderSharePercent = Math.round((top10Shares / totalSupplyNum) * 100 * 100) / 100;
+    }
+
     const snapshot = {
       state: vault.state,
       totalAssets: vault.totalAssets,
@@ -259,6 +278,7 @@ export async function getVaultSnapshot(req: Request, res: Response, next: NextFu
       depositorCount: vault.depositorCount,
       epochCount,
       lastIndexedAt,
+      top10HolderSharePercent,
     };
 
     setCacheHeaders(res);

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -289,6 +289,108 @@ export async function getVaultSnapshot(req: Request, res: Response, next: NextFu
 }
 
 /**
+ * GET /api/v1/vaults/:contractId/holders/top?n=10
+ *
+ * Returns the top N shareholders (max 20) with rank, userAddress, shares, sharePercent.
+ * sharePercent = shares / total_supply * 100.
+ */
+export async function getVaultTopHolders(req: Request, res: Response, next: NextFunction) {
+  try {
+    const contractId = String(req.params["contractId"]);
+
+    const nParam = req.query["n"];
+    const n = Math.min(20, Math.max(1, parseInt(String(nParam ?? "10"), 10) || 10));
+
+    const vaultRows = await query<{ id: number; total_supply: string }>(
+      "SELECT id, total_supply FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+    const { id: vaultId, total_supply } = vaultRows[0];
+    const totalSupply = parseFloat(total_supply ?? "0");
+
+    const rows = await query<{ user_address: string; shares: string }>(
+      `SELECT user_address, shares
+       FROM user_vault_positions
+       WHERE vault_id = $1 AND shares > 0
+       ORDER BY shares DESC
+       LIMIT $2`,
+      [vaultId, n],
+    );
+
+    const data = rows.map((row, index) => ({
+      rank: index + 1,
+      userAddress: row.user_address,
+      shares: row.shares,
+      sharePercent: totalSupply > 0
+        ? Math.round((parseFloat(row.shares) / totalSupply) * 100 * 10000) / 10000
+        : 0,
+    }));
+
+    setCacheHeaders(res);
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/:contractId/holders?search=<partial_address>
+ *
+ * Returns holders whose address matches the search query (ILIKE).
+ * Requires at least 4 characters; returns HTTP 400 otherwise.
+ * Limited to 20 results.
+ */
+export async function getVaultHolders(req: Request, res: Response, next: NextFunction) {
+  try {
+    const contractId = String(req.params["contractId"]);
+    const search = req.query["search"];
+
+    if (typeof search !== "string" || search.length < 4) {
+      res.status(400).json({
+        error: "BadRequest",
+        message: "search query parameter is required and must be at least 4 characters",
+      });
+      return;
+    }
+
+    const vaultRows = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+    const vaultId = vaultRows[0].id;
+
+    const rows = await query<{ user_address: string; shares: string; deposited: string; updated_at: Date }>(
+      `SELECT user_address, shares, deposited, updated_at
+       FROM user_vault_positions
+       WHERE vault_id = $1 AND user_address ILIKE $2
+       ORDER BY shares DESC
+       LIMIT 20`,
+      [vaultId, `%${search}%`],
+    );
+
+    const data = rows.map((row) => ({
+      userAddress: row.user_address,
+      shares: row.shares,
+      deposited: row.deposited,
+      updatedAt: row.updated_at,
+    }));
+
+    setCacheHeaders(res);
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
  * GET /api/v1/vaults/:contractId/tvl-history
  *
  * Returns TVL snapshots in the requested time range.

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -10,6 +10,8 @@ import {
   getVaultPositions,
   getRedemptionQueue,
   getVaultSnapshot,
+  getVaultTopHolders,
+  getVaultHolders,
   getVaultTvlHistory,
   getEarlyRedemptionFee,
   exportVaultCsv,
@@ -43,6 +45,10 @@ vaultsRouter.get("/:contractId", validateParams(vaultParamsSchema), getVault);
 vaultsRouter.get("/:contractId/state/live", validateParams(vaultParamsSchema), getVaultLiveState);
 vaultsRouter.get("/:contractId/total-assets/live", validateParams(vaultParamsSchema), getVaultLiveTotalAssets);
 vaultsRouter.get("/:contractId/redemption-queue", validateParams(vaultParamsSchema), getRedemptionQueue);
+// Get top N holders leaderboard: GET /api/v1/vaults/:contractId/holders/top?n=10
+vaultsRouter.get("/:contractId/holders/top", validateParams(vaultParamsSchema), getVaultTopHolders);
+// Search holders by partial address: GET /api/v1/vaults/:contractId/holders?search=
+vaultsRouter.get("/:contractId/holders", validateParams(vaultParamsSchema), getVaultHolders);
 // Get vault snapshot: GET /api/v1/vaults/:contractId/snapshot
 vaultsRouter.get("/:contractId/snapshot", validateParams(vaultParamsSchema), getVaultSnapshot);
 // Get vault TVL history: GET /api/v1/vaults/:contractId/tvl-history

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -39,6 +39,7 @@ export const vaultsRouter = Router();
 vaultsRouter.get("/", validateQuery(listVaultsQuerySchema), listVaults);
 vaultsRouter.get("/count", getVaultCount);
 vaultsRouter.get("/factory/:factoryId", validateParams(vaultFactoryParamsSchema), listVaultsByFactory);
+vaultsRouter.get("/:contractId", validateParams(vaultParamsSchema), getVault);
 vaultsRouter.get("/:contractId/state/live", validateParams(vaultParamsSchema), getVaultLiveState);
 vaultsRouter.get("/:contractId/total-assets/live", validateParams(vaultParamsSchema), getVaultLiveTotalAssets);
 vaultsRouter.get("/:contractId/redemption-queue", validateParams(vaultParamsSchema), getRedemptionQueue);

--- a/backend/src/db/migrations/014_cumulative_shares.sql
+++ b/backend/src/db/migrations/014_cumulative_shares.sql
@@ -1,0 +1,3 @@
+ALTER TABLE vaults
+  ADD COLUMN IF NOT EXISTS total_shares_ever_minted NUMERIC NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS total_shares_ever_burned NUMERIC NOT NULL DEFAULT 0;

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS vaults (
   state           TEXT NOT NULL DEFAULT 'Funding',
   total_assets    NUMERIC DEFAULT 0,
   total_supply    NUMERIC DEFAULT 0,
+  total_shares_ever_minted NUMERIC NOT NULL DEFAULT 0,
+  total_shares_ever_burned NUMERIC NOT NULL DEFAULT 0,
   early_redemption_fee_bps INT DEFAULT 0,
   expected_apy    INT,
   maturity_date   TIMESTAMPTZ,

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -450,6 +450,10 @@ export class Indexer {
          updated_at = NOW()`,
       [deposit.receiver, deposit.shares.toString(), deposit.assets.toString(), contractId],
     );
+    await query(
+      `UPDATE vaults SET total_shares_ever_minted = total_shares_ever_minted + $1 WHERE contract_id = $2`,
+      [deposit.shares.toString(), contractId],
+    );
     await this.recordTvlSnapshot(contractId);
     logger.info(
       { contractId, receiver: deposit.receiver, shares: deposit.shares.toString() },
@@ -470,6 +474,10 @@ export class Indexer {
          deposited = GREATEST(0, user_vault_positions.deposited - $3),
          updated_at = NOW()`,
       [withdraw.owner, withdraw.shares.toString(), withdraw.assets.toString(), contractId],
+    );
+    await query(
+      `UPDATE vaults SET total_shares_ever_burned = total_shares_ever_burned + $1 WHERE contract_id = $2`,
+      [withdraw.shares.toString(), contractId],
     );
     await this.recordTvlSnapshot(contractId);
     logger.info(

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -20,6 +20,8 @@ interface VaultRow {
   state: string;
   total_assets: string;
   total_supply: string;
+  total_shares_ever_minted: string;
+  total_shares_ever_burned: string;
   depositor_count: number;
   funding_target: string | null;
   funding_deadline: Date | null;
@@ -49,6 +51,8 @@ function mapVaultRow(row: VaultRow): Vault {
     // COALESCE in the query, but guard here too in case of raw inserts (#499).
     totalAssets: row.total_assets ?? "0",
     totalSupply: row.total_supply ?? "0",
+    totalSharesEverMinted: row.total_shares_ever_minted ?? "0",
+    totalSharesEverBurned: row.total_shares_ever_burned ?? "0",
     depositorCount: row.depositor_count,
     fundingTarget: row.funding_target,
     fundingDeadline: row.funding_deadline,
@@ -77,7 +81,8 @@ export class VaultService {
     // carries a non-null totalAssets string, satisfying issue #499.
     const vaults = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
-              v.total_assets, v.total_supply, v.created_at, v.updated_at,
+              v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+              v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
               COALESCE((
                 SELECT COUNT(*)::int
@@ -121,7 +126,8 @@ export class VaultService {
   async listVaultsByFactory(factoryId: string): Promise<Vault[]> {
     const rows = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
-              v.total_assets, v.total_supply, v.created_at, v.updated_at,
+              v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+              v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
               COALESCE((
                 SELECT COUNT(*)::int
@@ -140,7 +146,8 @@ export class VaultService {
   async getVault(contractId: string): Promise<Vault | null> {
     const rows = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
-              v.total_assets, v.total_supply, v.created_at, v.updated_at,
+              v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+              v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
               COALESCE((
                 SELECT COUNT(*)::int

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -15,6 +15,8 @@ export interface Vault {
   state: VaultState;
   totalAssets: string;
   totalSupply: string;
+  totalSharesEverMinted: string;
+  totalSharesEverBurned: string;
   depositorCount: number;
   fundingTarget: string | null;
   fundingDeadline: Date | null;


### PR DESCRIPTION


## Summary

closes #625 
closes #624 
closes #626 
closes #627

- **#625 – Cumulative share tracking**: Added `total_shares_ever_minted` and `total_shares_ever_burned` NUMERIC columns to the `vaults` table (migration `014_cumulative_shares.sql`). The indexer increments `total_shares_ever_minted` on every deposit event and `total_shares_ever_burned` on every withdraw event. Both fields are exposed as strings in `GET /api/v1/vaults/:contractId`.

- **#624 – Holder concentration metric**: Extended `GET /api/v1/vaults/:contractId/snapshot` to include `top10HolderSharePercent` — the sum of the top-10 holders' shares divided by `total_supply`, expressed as a percentage rounded to two decimal places. Returns `null` when `total_supply` is zero.

- **#626 – Top holders leaderboard**: New endpoint `GET /api/v1/vaults/:contractId/holders/top?n=10` returns the top N shareholders (capped at 20). Each entry includes `rank` (1-based), `userAddress`, `shares`, and `sharePercent`.

- **#627 – Holder address search**: New endpoint `GET /api/v1/vaults/:contractId/holders?search=<query>` performs a case-insensitive partial match (`ILIKE`) on `user_address`. Returns HTTP 400 when fewer than 4 characters are provided; results are limited to 20.

## Files Changed

| File | Change |
|------|--------|
| `backend/src/db/migrations/014_cumulative_shares.sql` | New migration adding cumulative share columns |
| `backend/src/db/schema.sql` | Added `total_shares_ever_minted` and `total_shares_ever_burned` columns |
| `backend/src/services/indexer.ts` | Increment cumulative counters in `handleDeposit` and `handleWithdraw` |
| `backend/src/types/index.ts` | Added `totalSharesEverMinted` and `totalSharesEverBurned` to `Vault` interface |
| `backend/src/services/vault.ts` | Updated `VaultRow`, `mapVaultRow`, and all SELECT queries to include new columns |
| `backend/src/api/controllers/vaults.ts` | Added `top10HolderSharePercent` to snapshot; added `getVaultTopHolders` and `getVaultHolders` controllers |
| `backend/src/api/routes/vaults.ts` | Registered `GET /:contractId`, `GET /:contractId/holders/top`, and `GET /:contractId/holders` routes |

## Test Plan

- [ ] `GET /api/v1/vaults/:contractId` returns `totalSharesEverMinted` and `totalSharesEverBurned` as numeric strings.
- [ ] After a deposit event is indexed, `total_shares_ever_minted` increases by the deposited shares amount; `total_supply` equals `total_shares_ever_minted - total_shares_ever_burned`.
- [ ] `GET /api/v1/vaults/:contractId/snapshot` includes `top10HolderSharePercent` between 0 and 100; returns `null` for vaults with no depositors.
- [ ] `GET /api/v1/vaults/:contractId/holders/top?n=5` returns exactly 5 entries (or fewer if not enough holders), with strictly ascending ranks and `sharePercent` values summing to ≤ 100.
- [ ] `GET /api/v1/vaults/:contractId/holders?search=GABCD` returns matching holders.
- [ ] `GET /api/v1/vaults/:contractId/holders?search=GA` returns HTTP 400.
