### PR TITLE
feat: add yield-per-share endpoints and compound projection

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -391,6 +391,77 @@ export async function getVaultHolders(req: Request, res: Response, next: NextFun
 }
 
 /**
+ * GET /api/v1/vaults/:contractId/compound-projection?shares=<amount>&epochs=<n>
+ *
+ * Returns a compounded yield projection assuming reinvestment of yield.
+ * Query params:
+ *   - shares: number of shares (required, must be positive)
+ *   - epochs: number of epochs to project (required, must be positive)
+ *
+ * Response: { projectedValue: string; compoundedYield: string; epochsProjected: number }
+ * Returns 400 if shares or epochs are non-positive, 404 if vault has no epochs.
+ */
+export async function getCompoundProjection(req: Request, res: Response, next: NextFunction) {
+  try {
+    const sharesParam = req.query.shares;
+    const epochsParam = req.query.epochs;
+
+    if (typeof sharesParam !== "string" || !/^\d+$/.test(sharesParam)) {
+      res.status(400).json({
+        error: "BadRequest",
+        message: "shares query parameter is required and must be a positive integer",
+      });
+      return;
+    }
+
+    if (typeof epochsParam !== "string" || !/^\d+$/.test(epochsParam)) {
+      res.status(400).json({
+        error: "BadRequest",
+        message: "epochs query parameter is required and must be a positive integer",
+      });
+      return;
+    }
+
+    const shares = BigInt(sharesParam);
+    const epochs = parseInt(epochsParam, 10);
+
+    if (shares <= 0n) {
+      res.status(400).json({
+        error: "BadRequest",
+        message: "shares must be greater than zero",
+      });
+      return;
+    }
+
+    if (epochs <= 0) {
+      res.status(400).json({
+        error: "BadRequest",
+        message: "epochs must be greater than zero",
+      });
+      return;
+    }
+
+    const projection = await vaultService.getCompoundProjection(
+      String(req.params["contractId"]),
+      sharesParam,
+      epochs,
+    );
+
+    if (!projection) {
+      res.status(404).json({
+        error: "NotFound",
+        message: "Vault has no epoch history to project from",
+      });
+      return;
+    }
+
+    res.json(projection);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
  * GET /api/v1/vaults/:contractId/tvl-history
  *
  * Returns TVL snapshots in the requested time range.

--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -3,12 +3,26 @@ import { YieldService } from "../../services/yield.js";
 
 const yieldService = new YieldService();
 
+function formatYieldPerShare(yieldAmount: string, totalShares: string): string {
+  const yieldBig = BigInt(yieldAmount);
+  const sharesBig = BigInt(totalShares);
+  if (sharesBig === BigInt(0)) return "0";
+  const DECIMALS = BigInt(10) ** BigInt(18);
+  const result = (yieldBig * DECIMALS) / sharesBig;
+  const resultStr = result.toString();
+  const padded = resultStr.padStart(19, "0");
+  const integer = padded.slice(0, -18);
+  const fraction = padded.slice(-18);
+  return `${integer}.${fraction}`;
+}
+
 export async function getVaultEpochs(req: Request, res: Response, next: NextFunction) {
   try {
     const epochs = await yieldService.getVaultEpochs(String(req.params["contractId"]));
     res.json(
       epochs.map((e) => ({
         ...e,
+        yieldPerShare: formatYieldPerShare(e.yieldAmount, e.totalShares),
         distributedAt: e.distributedAt ? e.distributedAt.toISOString() : null,
       })),
     );
@@ -33,6 +47,55 @@ export async function getYieldSummary(req: Request, res: Response, next: NextFun
   try {
     const summary = await yieldService.getYieldSummary(String(req.params["contractId"]));
     res.json(summary);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getYieldPerShareHistory(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const fromParam = req.query.from as string | undefined;
+    const toParam = req.query.to as string | undefined;
+    const page = Math.max(1, parseInt(String(req.query.page ?? "1"), 10) || 1);
+    const pageSize = Math.min(200, Math.max(1, parseInt(String(req.query.pageSize ?? "20"), 10) || 20));
+
+    let fromDate: Date | undefined;
+    let toDate: Date | undefined;
+
+    if (fromParam) {
+      fromDate = new Date(fromParam);
+      if (isNaN(fromDate.getTime())) {
+        res.status(400).json({ error: "BadRequest", message: "Invalid from date format" });
+        return;
+      }
+    }
+
+    if (toParam) {
+      toDate = new Date(toParam);
+      if (isNaN(toDate.getTime())) {
+        res.status(400).json({ error: "BadRequest", message: "Invalid to date format" });
+        return;
+      }
+    }
+
+    const result = await yieldService.getYieldPerShareHistory(
+      String(req.params["contractId"]),
+      fromDate,
+      toDate,
+      page,
+      pageSize,
+    );
+
+    res.json({
+      data: result.data,
+      total: result.total,
+      page,
+      pageSize,
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -15,6 +15,7 @@ import {
   getVaultTvlHistory,
   getEarlyRedemptionFee,
   exportVaultCsv,
+  getCompoundProjection,
 } from "../controllers/vaults.js";
 import { validateParams, validateQuery } from "../middleware/validate.js";
 
@@ -53,6 +54,8 @@ vaultsRouter.get("/:contractId/holders", validateParams(vaultParamsSchema), getV
 vaultsRouter.get("/:contractId/snapshot", validateParams(vaultParamsSchema), getVaultSnapshot);
 // Get vault TVL history: GET /api/v1/vaults/:contractId/tvl-history
 vaultsRouter.get("/:contractId/tvl-history", validateParams(vaultParamsSchema), getVaultTvlHistory);
+// Get compound projection: GET /api/v1/vaults/:contractId/compound-projection?shares=<amount>&epochs=<n>
+vaultsRouter.get("/:contractId/compound-projection", validateParams(vaultParamsSchema), getCompoundProjection);
 // Early redemption fee preview: GET /api/v1/vaults/:contractId/early-redemption-fee?shares=
 vaultsRouter.get(
   "/:contractId/early-redemption-fee",

--- a/backend/src/api/routes/yields.ts
+++ b/backend/src/api/routes/yields.ts
@@ -4,6 +4,7 @@ import {
   getVaultEpochs,
   getUserPendingYield,
   getYieldSummary,
+  getYieldPerShareHistory,
 } from "../controllers/yields.js";
 import { validateQuery } from "../middleware/validate.js";
 
@@ -11,8 +12,16 @@ const epochQuerySchema = z.object({
   epoch: z.coerce.number().int().positive().optional(),
 });
 
+const yieldHistoryQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).default(20).transform((v) => Math.min(v, 200)),
+});
+
 export const yieldsRouter = Router();
 
 yieldsRouter.get("/:contractId/summary", getYieldSummary);
 yieldsRouter.get("/:contractId/epochs", validateQuery(epochQuerySchema), getVaultEpochs);
+yieldsRouter.get("/:contractId/yield-per-share-history", validateQuery(yieldHistoryQuerySchema), getYieldPerShareHistory);
 yieldsRouter.get("/:contractId/pending/:userAddress", getUserPendingYield);

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -6,6 +6,7 @@ import type {
   YieldHistoryEntry,
 } from "../types/index.js";
 import { query } from "../db/index.js";
+import { YieldService } from "./yield.js";
 
 export class UserService {
   async getUser(address: string): Promise<User | null> {
@@ -70,6 +71,8 @@ export class UserService {
     );
 
     let totalDeposited = "0";
+    let totalPendingYield = BigInt(0);
+    const yieldService = new YieldService();
     const transformedPositions: UserVaultPosition[] = positions.map((row) => {
       const deposited = row.deposited || "0";
       totalDeposited = (BigInt(totalDeposited) + BigInt(deposited)).toString();
@@ -87,9 +90,23 @@ export class UserService {
       };
     });
 
+    for (const position of transformedPositions) {
+      if (position.contractId) {
+        const yieldData = await yieldService.getUserPendingYield(
+          position.contractId,
+          address,
+        );
+        totalPendingYield += BigInt(yieldData.pendingYield);
+      }
+    }
+
+    const totalValue = (BigInt(totalDeposited) + totalPendingYield).toString();
+
     return {
       positions: transformedPositions,
       totalDeposited,
+      totalPendingYield: totalPendingYield.toString(),
+      totalValue,
     };
   }
 

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -370,5 +370,68 @@ export class VaultService {
       requestTime: row.request_time,
     }));
   }
+
+  async getCompoundProjection(
+    contractId: string,
+    shares: string,
+    epochs: number,
+  ): Promise<{ projectedValue: string; compoundedYield: string; epochsProjected: number } | null> {
+    const epochRows = await query<{
+      id: number;
+      yield_amount: string;
+      total_shares: string;
+    }>(
+      `SELECT e.id, e.yield_amount, e.total_shares
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE v.contract_id = $1
+       ORDER BY e.epoch ASC`,
+      [contractId],
+    );
+
+    if (epochRows.length === 0) {
+      return null;
+    }
+
+    let sumYieldPerShare = BigInt(0);
+    const DECIMALS = BigInt(10) ** BigInt(18);
+
+    for (const row of epochRows) {
+      const yieldBig = BigInt(row.yield_amount);
+      const sharesBig = BigInt(row.total_shares);
+      if (sharesBig > BigInt(0)) {
+        const yieldPerShare = (yieldBig * DECIMALS) / sharesBig;
+        sumYieldPerShare += yieldPerShare;
+      }
+    }
+
+    const avgYieldPerShare = sumYieldPerShare / BigInt(epochRows.length);
+    const principal = BigInt(shares);
+
+    let projectedValue = principal;
+    for (let i = 0; i < epochs; i++) {
+      projectedValue = (projectedValue * (DECIMALS + avgYieldPerShare)) / DECIMALS;
+    }
+
+    const compoundedYield = projectedValue - principal;
+
+    const projectedStr = projectedValue.toString();
+    const projectedPadded = projectedStr.padStart(19, "0");
+    const projectedInt = projectedPadded.slice(0, -18);
+    const projectedFrac = projectedPadded.slice(-18);
+    const projectedFormatted = `${projectedInt}.${projectedFrac}`;
+
+    const yieldStr = compoundedYield.toString();
+    const yieldPadded = yieldStr.padStart(19, "0");
+    const yieldInt = yieldPadded.slice(0, -18);
+    const yieldFrac = yieldPadded.slice(-18);
+    const yieldFormatted = `${yieldInt}.${yieldFrac}`;
+
+    return {
+      projectedValue: projectedFormatted,
+      compoundedYield: yieldFormatted,
+      epochsProjected: epochs,
+    };
+  }
 }
 

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -2,6 +2,19 @@ import type { Epoch } from "../types/index.js";
 import { query } from "../db/index.js";
 
 export class YieldService {
+  private formatYieldPerShare(yieldAmount: string, totalShares: string): string {
+    const yieldBig = BigInt(yieldAmount);
+    const sharesBig = BigInt(totalShares);
+    if (sharesBig === BigInt(0)) return "0";
+    const DECIMALS = BigInt(10) ** BigInt(18);
+    const result = (yieldBig * DECIMALS) / sharesBig;
+    const resultStr = result.toString();
+    const padded = resultStr.padStart(19, "0");
+    const integer = padded.slice(0, -18);
+    const fraction = padded.slice(-18);
+    return `${integer}.${fraction}`;
+  }
+
   async getVaultEpochs(contractId: string): Promise<Epoch[]> {
     const rows = await query<{
       id: number;
@@ -154,5 +167,63 @@ export class YieldService {
        ON CONFLICT (vault_id, epoch) DO NOTHING`,
       [vaultId, epoch, yieldAmount, totalShares],
     );
+  }
+
+  async getYieldPerShareHistory(
+    contractId: string,
+    from?: Date,
+    to?: Date,
+    page: number = 1,
+    pageSize: number = 20,
+  ): Promise<{
+    data: Array<{ epoch: number; yieldPerShare: string; distributedAt: string | null }>;
+    total: number;
+  }> {
+    const offset = (page - 1) * pageSize;
+    const whereConditions: string[] = ["v.contract_id = $1"];
+    const params: any[] = [contractId];
+
+    if (from) {
+      whereConditions.push(`e.distributed_at >= $${params.length + 1}`);
+      params.push(from);
+    }
+    if (to) {
+      whereConditions.push(`e.distributed_at <= $${params.length + 1}`);
+      params.push(to);
+    }
+
+    const whereClause = whereConditions.join(" AND ");
+
+    const rows = await query<{
+      epoch: number;
+      yield_amount: string;
+      total_shares: string;
+      distributed_at: Date | null;
+    }>(
+      `SELECT e.epoch, e.yield_amount, e.total_shares, e.distributed_at
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE ${whereClause}
+       ORDER BY e.epoch ASC
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, pageSize, offset],
+    );
+
+    const countResult = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE ${whereClause}`,
+      params,
+    );
+
+    const total = parseInt(countResult[0]?.count ?? "0", 10);
+
+    const data = rows.map((row) => ({
+      epoch: row.epoch,
+      yieldPerShare: this.formatYieldPerShare(row.yield_amount, row.total_shares),
+      distributedAt: row.distributed_at ? row.distributed_at.toISOString() : null,
+    }));
+
+    return { data, total };
   }
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -60,6 +60,8 @@ export interface RedemptionRequest {
 export interface UserPortfolioResponse {
   positions: UserVaultPosition[];
   totalDeposited: string;
+  totalPendingYield: string;
+  totalValue: string;
 }
 
 export interface Epoch {


### PR DESCRIPTION
## What

Added four new API endpoints for yield analytics and projections: yield-per-share history with date filtering, yield-per-share field to epoch responses, total value in portfolio responses, and compound yield projections.

## Issues Resolved

Closes #635
Closes #634
Closes #633
Closes #632

## Changes

### #635 - Add yield-per-share-history endpoint

Added `GET /api/v1/vaults/:contractId/yield-per-share-history` endpoint that returns an array of `{ epoch, yieldPerShare, distributedAt }` with optional date range filtering and pagination. Results are ordered by epoch ASC with max 200 results per page.

### #634 - Add yieldPerShare field to epochs response

Added `yieldPerShare` field to each epoch in `GET /api/v1/yields/:contractId/epochs`. Computed as `yield_amount / total_shares` using BigInt arithmetic, expressed as a decimal string to 18 decimal places. Returns "0" if total_shares is zero.

### #633 - Add totalValue to portfolio response

Added `totalPendingYield` and `totalValue` fields to `GET /api/v1/users/:address/portfolio`. `totalValue = totalDeposited + totalPendingYield` across all user positions. All values are BigInt-safe strings.

### #632 - Add compound projection endpoint

Added `GET /api/v1/vaults/:contractId/compound-projection?shares=<amount>&epochs=<n>` endpoint that returns compound yield projections using the formula `V = principal * (1 + r)^n` where r is the average historical yield-per-share. Returns `{ projectedValue, compoundedYield, epochsProjected }`. Returns 400 if shares or epochs are non-positive.