### PR TITLE
feat: DB pool config, RWA fields, operators, and roles endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,10 @@ ZKME_VERIFIER_CONTRACT_ID=
 
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stellaryield
+DB_POOL_MIN=2
+DB_POOL_MAX=10
+DB_IDLE_TIMEOUT_MS=10000
+DB_QUERY_TIMEOUT_MS=30000
 
 # Indexer
 INDEXER_START_LEDGER=0

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -369,6 +369,46 @@ export async function getVaultHolders(req: Request, res: Response, next: NextFun
 }
 
 /**
+ * GET /api/v1/vaults/:contractId/operators
+ *
+ * Returns the current active operators for a vault.
+ */
+export async function getVaultOperators(req: Request, res: Response, next: NextFunction) {
+  try {
+    const vault = await vaultService.getVault(String(req.params["contractId"]));
+    if (!vault) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+    const operators = await vaultService.listVaultOperators(String(req.params["contractId"]));
+    setCacheHeaders(res);
+    res.json(operators);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/:contractId/roles
+ *
+ * Returns the current active roles for a vault.
+ */
+export async function getVaultRoles(req: Request, res: Response, next: NextFunction) {
+  try {
+    const vault = await vaultService.getVault(String(req.params["contractId"]));
+    if (!vault) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+    const roles = await vaultService.listVaultRoles(String(req.params["contractId"]));
+    setCacheHeaders(res);
+    res.json(roles);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
  * GET /api/v1/vaults/:contractId/holders/count
  *
  * Returns the active shareholder count for a vault.

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -18,6 +18,8 @@ import {
   getEarlyRedemptionFee,
   exportVaultCsv,
   getCompoundProjection,
+  getVaultOperators,
+  getVaultRoles,
 } from "../controllers/vaults.js";
 import { validateParams, validateQuery } from "../middleware/validate.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -87,3 +89,7 @@ vaultsRouter.get(
 );
 // Export vault data as CSV: GET /api/v1/vaults/:contractId/export.csv
 vaultsRouter.get("/:contractId/export.csv", validateParams(vaultParamsSchema), exportVaultCsv);
+// Get vault operators: GET /api/v1/vaults/:contractId/operators
+vaultsRouter.get("/:contractId/operators", validateParams(vaultParamsSchema), getVaultOperators);
+// Get vault roles: GET /api/v1/vaults/:contractId/roles
+vaultsRouter.get("/:contractId/roles", validateParams(vaultParamsSchema), getVaultRoles);

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -63,6 +63,26 @@ const envSchema = z.object({
     .default("300")
     .transform((v) => parseInt(v, 10))
     .pipe(z.number().int().min(1)),
+  DB_POOL_MIN: z
+    .string()
+    .default("2")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(0)),
+  DB_POOL_MAX: z
+    .string()
+    .default("10")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(1)),
+  DB_IDLE_TIMEOUT_MS: z
+    .string()
+    .default("10000")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(0)),
+  DB_QUERY_TIMEOUT_MS: z
+    .string()
+    .default("30000")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(1)),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -89,6 +109,10 @@ export const config = {
 
   db: {
     url: parsed.data.DATABASE_URL,
+    poolMin: parsed.data.DB_POOL_MIN,
+    poolMax: parsed.data.DB_POOL_MAX,
+    idleTimeoutMs: parsed.data.DB_IDLE_TIMEOUT_MS,
+    queryTimeoutMs: parsed.data.DB_QUERY_TIMEOUT_MS,
   },
 
   indexer: {

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -4,7 +4,13 @@ import { logger } from "../logger.js";
 
 const { Pool } = pg;
 
-export const pool = new Pool({ connectionString: config.db.url });
+export const pool = new Pool({
+  connectionString: config.db.url,
+  min: config.db.poolMin,
+  max: config.db.poolMax,
+  idleTimeoutMillis: config.db.idleTimeoutMs,
+  query_timeout: config.db.queryTimeoutMs,
+});
 
 export async function query<T = Record<string, unknown>>(
   sql: string,

--- a/backend/src/db/migrations/016_vault_rwa_fields.sql
+++ b/backend/src/db/migrations/016_vault_rwa_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE vaults
+  ADD COLUMN IF NOT EXISTS rwa_name         TEXT,
+  ADD COLUMN IF NOT EXISTS rwa_symbol        TEXT,
+  ADD COLUMN IF NOT EXISTS rwa_document_uri  TEXT;

--- a/backend/src/db/migrations/017_vault_operators.sql
+++ b/backend/src/db/migrations/017_vault_operators.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS vault_operators (
+  id              SERIAL PRIMARY KEY,
+  vault_id        INT NOT NULL REFERENCES vaults(id),
+  operator        TEXT NOT NULL,
+  added_by        TEXT NOT NULL,
+  added_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  removed_at      TIMESTAMPTZ,
+  removed_by      TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (vault_id, operator)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vault_operators_vault_id
+  ON vault_operators (vault_id);
+
+CREATE INDEX IF NOT EXISTS idx_vault_operators_vault_operator
+  ON vault_operators (vault_id, operator);

--- a/backend/src/db/migrations/018_vault_roles.sql
+++ b/backend/src/db/migrations/018_vault_roles.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS vault_roles (
+  id              SERIAL PRIMARY KEY,
+  vault_id        INT NOT NULL REFERENCES vaults(id),
+  user_address    TEXT NOT NULL,
+  role            TEXT NOT NULL,
+  granted_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at      TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (vault_id, user_address, role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vault_roles_vault_id
+  ON vault_roles (vault_id);
+
+CREATE INDEX IF NOT EXISTS idx_vault_roles_vault_user
+  ON vault_roles (vault_id, user_address);

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -2,7 +2,12 @@ import { xdr, scValToNative } from "@stellar/stellar-sdk";
 import { config } from "../config.js";
 import { logger } from "../logger.js";
 import { query } from "../db/index.js";
-import { getSorobanRpc } from "./stellar.js";
+import {
+  getSorobanRpc,
+  readRwaName,
+  readRwaSymbol,
+  readRwaDocumentUri,
+} from "./stellar.js";
 import { VaultService } from "./vault.js";
 import { NotificationService } from "./notifications.js";
 import { indexerEventsProcessedTotal, indexerLastLedger } from "./metrics.js";
@@ -114,12 +119,17 @@ export class Indexer {
   private running = false;
   private lastTickAt: Date | null = null;
   private readonly vaultFactoryContractId: string;
+  private watchedContractIds: Set<string>;
   private vaultService: VaultService;
   private notificationService?: NotificationService;
 
   constructor(notificationService?: NotificationService) {
     this.lastLedger = config.indexer.startLedger;
     this.vaultFactoryContractId = config.stellar.vaultFactoryContractId;
+    this.watchedContractIds = new Set<string>();
+    if (this.vaultFactoryContractId) {
+      this.watchedContractIds.add(this.vaultFactoryContractId);
+    }
     this.vaultService = new VaultService();
     this.notificationService = notificationService;
 
@@ -209,8 +219,9 @@ export class Indexer {
     if (latestLedger <= this.lastLedger) return;
 
     const from = this.lastLedger + 1;
-    const filters = this.vaultFactoryContractId
-      ? [{ contractIds: [this.vaultFactoryContractId] }]
+    const contractIds = Array.from(this.watchedContractIds);
+    const filters = contractIds.length > 0
+      ? contractIds.map((id) => ({ contractIds: [id] }))
       : [];
 
     let events: any[];
@@ -249,8 +260,9 @@ export class Indexer {
     const server = getSorobanRpc();
     let cursor = this.lastLedger;
 
-    const filters = this.vaultFactoryContractId
-      ? [{ contractIds: [this.vaultFactoryContractId] }]
+    const contractIds = Array.from(this.watchedContractIds);
+    const filters = contractIds.length > 0
+      ? contractIds.map((id) => ({ contractIds: [id] }))
       : [];
 
     while (cursor < tipLedger) {
@@ -378,6 +390,34 @@ export class Indexer {
       } catch (e) {
         logger.warn({ err: e }, "NotificationService.notify failed for vault_created");
       }
+      return;
+    }
+
+    const opAdded = parseOperatorAddedEvent(event);
+    if (opAdded) {
+      await this.handleOperatorAdded(event.contractId ?? "", opAdded);
+      await this.recordEvent(event, "operator_added");
+      return;
+    }
+
+    const opRemoved = parseOperatorRemovedEvent(event);
+    if (opRemoved) {
+      await this.handleOperatorRemoved(event.contractId ?? "", opRemoved);
+      await this.recordEvent(event, "operator_removed");
+      return;
+    }
+
+    const roleGranted = parseRoleGrantedEvent(event);
+    if (roleGranted) {
+      await this.handleRoleGranted(event.contractId ?? "", roleGranted);
+      await this.recordEvent(event, "role_granted");
+      return;
+    }
+
+    const roleRevoked = parseRoleRevokedEvent(event);
+    if (roleRevoked) {
+      await this.handleRoleRevoked(event.contractId ?? "", roleRevoked);
+      await this.recordEvent(event, "role_revoked");
       return;
     }
 
@@ -536,6 +576,13 @@ export class Indexer {
       { vault: vaultCreated.contractId, factoryId, name: vaultCreated.name },
       "Processing vault_created event",
     );
+
+    const [rwaName, rwaSymbol, rwaDocumentUri] = await Promise.all([
+      readRwaName(vaultCreated.contractId),
+      readRwaSymbol(vaultCreated.contractId),
+      readRwaDocumentUri(vaultCreated.contractId),
+    ]).catch(() => [null, null, null] as const);
+
     await this.vaultService.upsertVault({
       contractId: vaultCreated.contractId,
       factoryId,
@@ -547,7 +594,12 @@ export class Indexer {
       fundingDeadline: vaultCreated.fundingDeadline,
       minDeposit: vaultCreated.minDeposit,
       maxDepositPerUser: vaultCreated.maxDepositPerUser,
+      rwaName,
+      rwaSymbol,
+      rwaDocumentUri,
     });
+
+    this.watchedContractIds.add(vaultCreated.contractId);
   }
 
   private async handleCancelFunding(contractId: string): Promise<void> {
@@ -639,6 +691,121 @@ export class Indexer {
     logger.info(
       { contractId, user: event.user, requestId: event.requestId },
       "Processed early_redemption_cancelled event",
+    );
+  }
+
+  private async handleOperatorAdded(
+    contractId: string,
+    event: ParsedOperatorAddedEvent,
+  ): Promise<void> {
+    const vaultRow = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRow.length === 0) {
+      logger.warn({ contractId }, "op_add for unknown vault — skipping");
+      return;
+    }
+    const vaultId = vaultRow[0].id;
+
+    await query(
+      `INSERT INTO vault_operators (vault_id, operator, added_by, added_at)
+       VALUES ($1, $2, $3, to_timestamp($4))
+       ON CONFLICT (vault_id, operator)
+       DO UPDATE SET
+         removed_at = NULL,
+         removed_by = NULL,
+         added_by = EXCLUDED.added_by,
+         added_at = EXCLUDED.added_at`,
+      [vaultId, event.operator, event.caller, Number(event.timestamp)],
+    );
+    logger.info(
+      { contractId, operator: event.operator },
+      "Processed operator_added event",
+    );
+  }
+
+  private async handleOperatorRemoved(
+    contractId: string,
+    event: ParsedOperatorRemovedEvent,
+  ): Promise<void> {
+    const vaultRow = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRow.length === 0) {
+      logger.warn({ contractId }, "op_rem for unknown vault — skipping");
+      return;
+    }
+    const vaultId = vaultRow[0].id;
+
+    await query(
+      `INSERT INTO vault_operators (vault_id, operator, added_by, added_at, removed_at, removed_by)
+       VALUES ($1, $2, $3, NOW(), NOW(), $4)
+       ON CONFLICT (vault_id, operator)
+       DO UPDATE SET
+         removed_at = NOW(),
+         removed_by = EXCLUDED.removed_by`,
+      [vaultId, event.operator, event.caller, event.caller],
+    );
+    logger.info(
+      { contractId, operator: event.operator },
+      "Processed operator_removed event",
+    );
+  }
+
+  private async handleRoleGranted(
+    contractId: string,
+    event: ParsedRoleGrantedEvent,
+  ): Promise<void> {
+    const vaultRow = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRow.length === 0) {
+      logger.warn({ contractId }, "role_grt for unknown vault — skipping");
+      return;
+    }
+    const vaultId = vaultRow[0].id;
+
+    await query(
+      `INSERT INTO vault_roles (vault_id, user_address, role, granted_at)
+       VALUES ($1, $2, $3, NOW())
+       ON CONFLICT (vault_id, user_address, role)
+       DO UPDATE SET
+         revoked_at = NULL,
+         granted_at = NOW()`,
+      [vaultId, event.userAddress, event.role],
+    );
+    logger.info(
+      { contractId, user: event.userAddress, role: event.role },
+      "Processed role_granted event",
+    );
+  }
+
+  private async handleRoleRevoked(
+    contractId: string,
+    event: ParsedRoleRevokedEvent,
+  ): Promise<void> {
+    const vaultRow = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRow.length === 0) {
+      logger.warn({ contractId }, "role_rvk for unknown vault — skipping");
+      return;
+    }
+    const vaultId = vaultRow[0].id;
+
+    await query(
+      `UPDATE vault_roles
+       SET revoked_at = NOW()
+       WHERE vault_id = $1 AND user_address = $2 AND role = $3 AND revoked_at IS NULL`,
+      [vaultId, event.userAddress, event.role],
+    );
+    logger.info(
+      { contractId, user: event.userAddress, role: event.role },
+      "Processed role_revoked event",
     );
   }
 
@@ -1281,6 +1448,179 @@ export function parseYieldClaimedPartialEvent(rawEvent: unknown): ParsedYieldCla
     const epoch = Number(arr[2] ?? 0);
 
     return { user, claimed, shortfall, epoch };
+  } catch {
+    return null;
+  }
+}
+
+// ── Issue #593: operator events ─────────────────────────────────────────────
+
+export interface ParsedOperatorAddedEvent {
+  caller: string;
+  operator: string;
+  timestamp: bigint;
+}
+
+export function parseOperatorAddedEvent(rawEvent: unknown): ParsedOperatorAddedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 3 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "op_add") return null;
+
+    const caller = String(scValToNative(parsedTopics[1]) ?? "");
+    const operator = String(scValToNative(parsedTopics[2]) ?? "");
+    const timestamp = decodeBigInt(scValToNative(parsedValue as xdr.ScVal));
+
+    return { caller, operator, timestamp };
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedOperatorRemovedEvent {
+  caller: string;
+  operator: string;
+  timestamp: bigint;
+  reason: string | null;
+}
+
+export function parseOperatorRemovedEvent(rawEvent: unknown): ParsedOperatorRemovedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 3 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "op_rem") return null;
+
+    const caller = String(scValToNative(parsedTopics[1]) ?? "");
+    const operator = String(scValToNative(parsedTopics[2]) ?? "");
+
+    const data = scValToNative(parsedValue as xdr.ScVal);
+    const arr = Array.isArray(data) ? data : Object.values((data as Record<string, unknown>) ?? {});
+    const timestamp = decodeBigInt(arr[0] ?? 0n);
+    const reason = arr[1] != null ? String(arr[1]) : null;
+
+    return { caller, operator, timestamp, reason };
+  } catch {
+    return null;
+  }
+}
+
+// ── Issue #594: role events ─────────────────────────────────────────────────
+
+export interface ParsedRoleGrantedEvent {
+  userAddress: string;
+  role: string;
+}
+
+export function parseRoleGrantedEvent(rawEvent: unknown): ParsedRoleGrantedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "role_grt") return null;
+
+    const userAddress = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const nativeRole = scValToNative(parsedValue as xdr.ScVal);
+    const role = typeof nativeRole === "string"
+      ? nativeRole
+      : String(Object.keys(nativeRole as Record<string, unknown>)[0] ?? "");
+
+    return { userAddress, role };
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedRoleRevokedEvent {
+  userAddress: string;
+  role: string;
+}
+
+export function parseRoleRevokedEvent(rawEvent: unknown): ParsedRoleRevokedEvent | null {
+  try {
+    if (!rawEvent || typeof rawEvent !== "object") return null;
+    const ev = rawEvent as Record<string, unknown>;
+    const topics = (ev["topic"] ?? ev["topics"]) as unknown[] | undefined;
+    const value = ev["value"] ?? ev["data"];
+
+    if (!Array.isArray(topics) || topics.length < 2 || value == null) return null;
+
+    const parsedTopics = topics.map((t) =>
+      typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : (t as xdr.ScVal),
+    );
+    const parsedValue = typeof value === "string"
+      ? xdr.ScVal.fromXDR(value, "base64")
+      : value;
+
+    let eventName: string;
+    try {
+      eventName = String(scValToNative(parsedTopics[0]) ?? "");
+    } catch {
+      return null;
+    }
+    if (eventName !== "role_rvk") return null;
+
+    const userAddress = String(scValToNative(parsedTopics[1]) ?? "");
+
+    const nativeRole = scValToNative(parsedValue as xdr.ScVal);
+    const role = typeof nativeRole === "string"
+      ? nativeRole
+      : String(Object.keys(nativeRole as Record<string, unknown>)[0] ?? "");
+
+    return { userAddress, role };
   } catch {
     return null;
   }

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -157,6 +157,45 @@ export async function readCurrentEpoch(
  *
  * Closes #430
  */
+/**
+ * Read the RWA name from a vault contract.
+ * Returns null on simulation error.
+ */
+export async function readRwaName(contractId: string): Promise<string | null> {
+  try {
+    const raw = await simulateRead<string | Record<string, unknown>>(contractId, "rwa_name");
+    return typeof raw === "string" ? raw : String(Object.values(raw)[0] ?? "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the RWA symbol from a vault contract.
+ * Returns null on simulation error.
+ */
+export async function readRwaSymbol(contractId: string): Promise<string | null> {
+  try {
+    const raw = await simulateRead<string | Record<string, unknown>>(contractId, "rwa_symbol");
+    return typeof raw === "string" ? raw : String(Object.values(raw)[0] ?? "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the RWA document URI from a vault contract.
+ * Returns null on simulation error.
+ */
+export async function readRwaDocumentUri(contractId: string): Promise<string | null> {
+  try {
+    const raw = await simulateRead<string | Record<string, unknown>>(contractId, "rwa_document_uri");
+    return typeof raw === "string" ? raw : String(Object.values(raw)[0] ?? "");
+  } catch {
+    return null;
+  }
+}
+
 export async function readEpochData(
   contractId: string,
   epoch: number,

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -33,6 +33,9 @@ interface VaultRow {
   funding_deadline: Date | null;
   min_deposit: string | null;
   max_deposit_per_user: string | null;
+  rwa_name: string | null;
+  rwa_symbol: string | null;
+  rwa_document_uri: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -65,6 +68,9 @@ function mapVaultRow(row: VaultRow): Vault {
     fundingProgress: computeFundingProgress(row.total_assets, row.funding_target),
     minDeposit: row.min_deposit,
     maxDepositPerUser: row.max_deposit_per_user,
+    rwaName: row.rwa_name,
+    rwaSymbol: row.rwa_symbol,
+    rwaDocumentUri: row.rwa_document_uri,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -90,6 +96,7 @@ export class VaultService {
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -135,6 +142,7 @@ export class VaultService {
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -155,6 +163,7 @@ export class VaultService {
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -309,6 +318,9 @@ export class VaultService {
       fundingDeadline = null,
       minDeposit = null,
       maxDepositPerUser = null,
+      rwaName = null,
+      rwaSymbol = null,
+      rwaDocumentUri = null,
     } = vault;
 
     logger.info(
@@ -321,9 +333,10 @@ export class VaultService {
          contract_id, factory_id, asset, name, symbol, state,
          total_assets, total_supply,
          funding_target, funding_deadline, min_deposit, max_deposit_per_user,
+         rwa_name, rwa_symbol, rwa_document_uri,
          created_at, updated_at
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW(), NOW())
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NOW(), NOW())
        ON CONFLICT (contract_id)
        DO UPDATE SET
          state = EXCLUDED.state,
@@ -333,12 +346,73 @@ export class VaultService {
          funding_deadline = COALESCE(EXCLUDED.funding_deadline, vaults.funding_deadline),
          min_deposit = COALESCE(EXCLUDED.min_deposit, vaults.min_deposit),
          max_deposit_per_user = COALESCE(EXCLUDED.max_deposit_per_user, vaults.max_deposit_per_user),
+         rwa_name = COALESCE(EXCLUDED.rwa_name, vaults.rwa_name),
+         rwa_symbol = COALESCE(EXCLUDED.rwa_symbol, vaults.rwa_symbol),
+         rwa_document_uri = COALESCE(EXCLUDED.rwa_document_uri, vaults.rwa_document_uri),
          updated_at = NOW()`,
       [contractId, factoryId, asset, name, symbol, state, totalAssets, totalSupply,
-       fundingTarget, fundingDeadline, minDeposit, maxDepositPerUser],
+       fundingTarget, fundingDeadline, minDeposit, maxDepositPerUser,
+       rwaName, rwaSymbol, rwaDocumentUri],
     );
 
     logger.info({ contractId }, "Vault upserted successfully");
+  }
+
+  async listVaultOperators(contractId: string): Promise<{
+    operator: string;
+    addedBy: string;
+    addedAt: Date;
+    removedAt: Date | null;
+    removedBy: string | null;
+  }[]> {
+    const rows = await query<{
+      operator: string;
+      added_by: string;
+      added_at: Date;
+      removed_at: Date | null;
+      removed_by: string | null;
+    }>(
+      `SELECT vo.operator, vo.added_by, vo.added_at, vo.removed_at, vo.removed_by
+       FROM vault_operators vo
+       JOIN vaults v ON vo.vault_id = v.id
+       WHERE v.contract_id = $1 AND vo.removed_at IS NULL
+       ORDER BY vo.added_at DESC`,
+      [contractId],
+    );
+    return rows.map((r) => ({
+      operator: r.operator,
+      addedBy: r.added_by,
+      addedAt: r.added_at,
+      removedAt: r.removed_at,
+      removedBy: r.removed_by,
+    }));
+  }
+
+  async listVaultRoles(contractId: string): Promise<{
+    userAddress: string;
+    role: string;
+    grantedAt: Date;
+    revokedAt: Date | null;
+  }[]> {
+    const rows = await query<{
+      user_address: string;
+      role: string;
+      granted_at: Date;
+      revoked_at: Date | null;
+    }>(
+      `SELECT vr.user_address, vr.role, vr.granted_at, vr.revoked_at
+       FROM vault_roles vr
+       JOIN vaults v ON vr.vault_id = v.id
+       WHERE v.contract_id = $1 AND vr.revoked_at IS NULL
+       ORDER BY vr.granted_at DESC`,
+      [contractId],
+    );
+    return rows.map((r) => ({
+      userAddress: r.user_address,
+      role: r.role,
+      grantedAt: r.granted_at,
+      revokedAt: r.revoked_at,
+    }));
   }
 
   /**

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -23,6 +23,9 @@ export interface Vault {
   fundingProgress: number | null;
   minDeposit: string | null;
   maxDepositPerUser: string | null;
+  rwaName: string | null;
+  rwaSymbol: string | null;
+  rwaDocumentUri: string | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION


**#592** — Make DB pool settings configurable via env vars
- Added DB_POOL_MIN, DB_POOL_MAX, DB_IDLE_TIMEOUT_MS, DB_QUERY_TIMEOUT_MS env vars with Zod validation and defaults
- Updated Pool constructor in db/index.ts to pass pool config

**#593** — Implement GET /api/v1/vaults/:contractId/operators
- Creates vault_operators table (migration 017)
- Parses op_add/op_rem events from vault contracts
- Exposes GET endpoint returning active operators

**#594** — Implement GET /api/v1/vaults/:contractId/roles
- Creates vault_roles table (migration 018)
- Parses role_grt/role_rvk events
- Exposes GET endpoint returning active roles/grants

**#595** — Add rwaName, rwaSymbol, rwaDocumentUri to vault response
- Adds rwa_name, rwa_symbol, rwa_document_uri columns (migration 016)
- Reads RWA details from chain on vault creation
- Returns fields in all vault GET endpoints

Also extends the indexer to watch individual vault contracts for operator/role events as they are discovered.

Closes #592
Closes #593 
Closes #594 
Closes #595