### PR TITLE
feat: implement issues #576 #577 #578 #579

### DIFF
--- a/backend/src/api/controllers/admin.ts
+++ b/backend/src/api/controllers/admin.ts
@@ -100,6 +100,30 @@ export async function deleteApiKey(req: Request, res: Response, next: NextFuncti
   }
 }
 
+export async function getApiKeys(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const rows = await query<{
+      id: number;
+      label: string | null;
+      role: string;
+      created_at: Date;
+    }>(
+      "SELECT id, label, role, created_at FROM api_keys ORDER BY created_at DESC",
+    );
+
+    res.json(
+      rows.map((row) => ({
+        id: row.id,
+        label: row.label,
+        role: row.role,
+        createdAt: row.created_at,
+      })),
+    );
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function getAdminEvents(req: Request, res: Response, next: NextFunction) {
   try {
     const { contractId, eventType } = req.query as Record<string, string | undefined>;

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -28,16 +28,20 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       page,
       pageSize,
       state,
+      category,
+      cursor,
       sort,
       order,
     } = req.query as unknown as {
       page: number;
       pageSize: number;
       state?: string;
+      category?: string;
+      cursor?: string;
       sort: "created_at" | "total_assets";
       order: "asc" | "desc";
     };
-    const result = await vaultService.listVaults({ page, pageSize, state, sort, order });
+    const result = await vaultService.listVaults({ page, pageSize, state, category, cursor, sort, order });
     setCacheHeaders(res);
     res.json(result);
   } catch (err) {
@@ -50,6 +54,16 @@ export async function getVaultCount(_req: Request, res: Response, next: NextFunc
     const total = await vaultService.countVaults();
     setCacheHeaders(res);
     res.json({ total });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listCategories(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const categories = await vaultService.listCategories();
+    setCacheHeaders(res);
+    res.json(categories);
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit, backfillIndexer, deleteApiKey } from "../controllers/admin.js";
+import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit, backfillIndexer, deleteApiKey, getApiKeys } from "../controllers/admin.js";
 import { requireApiKey } from "../middleware/auth.js";
 
 export const adminRouter = Router();
@@ -12,5 +12,7 @@ adminRouter.post("/indexer/backfill", backfillIndexer);
 adminRouter.get("/events", getAdminEvents);
 // Per-vault audit trail: GET /api/v1/admin/vaults/:contractId/audit
 adminRouter.get("/vaults/:contractId/audit", getVaultAudit);
+// List API keys: GET /api/v1/admin/api-keys
+adminRouter.get("/api-keys", getApiKeys);
 // Delete API key: DELETE /api/v1/admin/api-keys/:id
 adminRouter.delete("/api-keys/:id", deleteApiKey);

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -20,6 +20,7 @@ import {
   getCompoundProjection,
   getVaultAnnualReport,
   getEpochBreakdown,
+  listCategories,
 } from "../controllers/vaults.js";
 import { validateParams, validateQuery } from "../middleware/validate.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -30,6 +31,8 @@ const listVaultsQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).default(20).transform((value) => Math.min(value, 100)),
   state: z.string().optional(),
+  category: z.string().optional(),
+  cursor: z.string().optional(),
   sort: z.enum(["created_at", "total_assets"]).default("created_at"),
   order: z.enum(["asc", "desc"]).default("desc"),
 });
@@ -50,6 +53,7 @@ const vaultHoldersQuerySchema = z.object({
 
 export const vaultsRouter = Router();
 
+vaultsRouter.get("/categories", listCategories);
 vaultsRouter.get("/", validateQuery(listVaultsQuerySchema), listVaults);
 vaultsRouter.get("/count", getVaultCount);
 vaultsRouter.get("/factory/:factoryId", validateParams(vaultFactoryParamsSchema), listVaultsByFactory);

--- a/backend/src/db/migrations/019_vault_rwa_category.sql
+++ b/backend/src/db/migrations/019_vault_rwa_category.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vaults ADD COLUMN IF NOT EXISTS rwa_category TEXT;
+CREATE INDEX IF NOT EXISTS idx_vaults_rwa_category ON vaults (rwa_category);

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS vaults (
   early_redemption_fee_bps INT DEFAULT 0,
   expected_apy    INT,
   maturity_date   TIMESTAMPTZ,
+  rwa_category    TEXT,
   created_at      TIMESTAMPTZ DEFAULT NOW(),
   updated_at      TIMESTAMPTZ DEFAULT NOW()
 );

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -566,6 +566,7 @@ export class Indexer {
       asset: string;
       name: string;
       symbol: string;
+      rwaCategory: string | null;
       fundingTarget: string | null;
       fundingDeadline: Date | null;
       minDeposit: string | null;
@@ -597,6 +598,7 @@ export class Indexer {
       rwaName,
       rwaSymbol,
       rwaDocumentUri,
+      rwaCategory: vaultCreated.rwaCategory,
     });
 
     this.watchedContractIds.add(vaultCreated.contractId);
@@ -1100,6 +1102,7 @@ export function parseVaultCreatedEvent(rawEvent: any): {
   asset: string;
   name: string;
   symbol: string;
+  rwaCategory: string | null;
   fundingTarget: string | null;
   fundingDeadline: Date | null;
   minDeposit: string | null;
@@ -1149,7 +1152,18 @@ export function parseVaultCreatedEvent(rawEvent: any): {
     const rawMaxDeposit = nativeData?.max_deposit_per_user ?? nativeData?.maxDepositPerUser ?? null;
     const maxDepositPerUser = rawMaxDeposit != null ? String(rawMaxDeposit) : null;
 
-    return { contractId, asset, name, symbol, fundingTarget, fundingDeadline, minDeposit, maxDepositPerUser };
+    // Extract RWA category from the first element of the data tuple (vault_type).
+    // The VaultType enum is either a string or an object with a single key (the variant name).
+    const rawCategory = nativeData?.rwa_category ?? nativeData?.vault_type
+      ?? (Array.isArray(nativeData) ? nativeData[0] : null);
+    let rwaCategory: string | null = null;
+    if (typeof rawCategory === "string") {
+      rwaCategory = rawCategory;
+    } else if (rawCategory && typeof rawCategory === "object" && !Array.isArray(rawCategory)) {
+      rwaCategory = Object.keys(rawCategory)[0] ?? null;
+    }
+
+    return { contractId, asset, name, symbol, rwaCategory, fundingTarget, fundingDeadline, minDeposit, maxDepositPerUser };
   } catch (error) {
     logger.warn({ error }, "Error parsing vault_created event");
     return null;

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -50,6 +50,33 @@ export class UserService {
     );
   }
 
+  async getTotalPendingYield(address: string): Promise<string> {
+    const positions = await query<{
+      contract_id: string;
+    }>(
+      `SELECT v.contract_id
+       FROM user_vault_positions uvp
+       JOIN vaults v ON uvp.vault_id = v.id
+       WHERE uvp.user_address = $1 AND uvp.shares > 0`,
+      [address],
+    );
+
+    if (positions.length === 0) return "0";
+
+    let totalPendingYield = BigInt(0);
+    const yieldService = new YieldService();
+
+    for (const row of positions) {
+      const yieldData = await yieldService.getUserPendingYield(
+        row.contract_id,
+        address,
+      );
+      totalPendingYield += BigInt(yieldData.pendingYield);
+    }
+
+    return totalPendingYield.toString();
+  }
+
   async getUserPortfolio(address: string): Promise<UserPortfolioResponse> {
     const positions = await query<{
       id: number;

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -12,6 +12,8 @@ interface ListVaultsOptions {
   page: number;
   pageSize: number;
   state?: string;
+  category?: string;
+  cursor?: string;
   sort: "created_at" | "total_assets";
   order: "asc" | "desc";
 }
@@ -36,6 +38,7 @@ interface VaultRow {
   rwa_name: string | null;
   rwa_symbol: string | null;
   rwa_document_uri: string | null;
+  rwa_category: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -71,6 +74,7 @@ function mapVaultRow(row: VaultRow): Vault {
     rwaName: row.rwa_name,
     rwaSymbol: row.rwa_symbol,
     rwaDocumentUri: row.rwa_document_uri,
+    rwaCategory: row.rwa_category,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -78,47 +82,137 @@ function mapVaultRow(row: VaultRow): Vault {
 
 export class VaultService {
   async listVaults(opts: ListVaultsOptions): Promise<PaginatedResponse<Vault>> {
-    const { page, pageSize, state, sort, order } = opts;
-    const offset = (page - 1) * pageSize;
+    const { page, pageSize, state, category, cursor, sort, order } = opts;
     const sortColumn = sort === "total_assets" ? "total_assets" : "created_at";
     const sortDirection = order === "asc" ? "ASC" : "DESC";
+    const isDesc = sortDirection === "DESC";
 
-    // Build WHERE clause if state filter is provided
-    const whereClause = state ? "WHERE v.state = $3" : "";
-    const params: any[] = [pageSize, offset];
-    if (state) params.push(state);
+    // Decode cursor if provided
+    let cursorId: number | null = null;
+    let cursorCreatedAt: Date | null = null;
+    if (cursor) {
+      try {
+        const decoded = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+        cursorId = typeof decoded.id === "number" ? decoded.id : null;
+        cursorCreatedAt = decoded.created_at ? new Date(decoded.created_at) : null;
+      } catch {
+        cursorId = null;
+        cursorCreatedAt = null;
+      }
+    }
 
-    // Query vaults with pagination.
-    // COALESCE(v.total_assets, '0') guarantees every vault item in the response
-    // carries a non-null totalAssets string, satisfying issue #499.
-    const vaults = await query<VaultRow>(
-      `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
-              v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
-              v.created_at, v.updated_at,
-              v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
-              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
-              COALESCE((
-                SELECT COUNT(*)::int
-                FROM user_vault_positions uvp
-                WHERE uvp.vault_id = v.id AND uvp.shares > 0
-              ), 0) AS depositor_count
-       FROM vaults v
-       ${whereClause}
-       ORDER BY v.${sortColumn} ${sortDirection}
-       LIMIT $1 OFFSET $2`,
-      params,
-    );
+    const conditions: string[] = [];
+    const params: any[] = [];
+    let paramIdx = 0;
 
-    // Get total count
-    const countResult = await query<{ count: string }>(
-      `SELECT COUNT(*) as count
-       FROM vaults v
-       ${state ? "WHERE v.state = $1" : ""}`,
-      state ? [state] : [],
-    );
-    const total = parseInt(countResult[0]?.count ?? "0", 10);
+    if (state) {
+      paramIdx++;
+      conditions.push(`v.state = $${paramIdx}`);
+      params.push(state);
+    }
 
-    // Map database rows to Vault type
+    if (category) {
+      paramIdx++;
+      conditions.push(`v.rwa_category = $${paramIdx}`);
+      params.push(category);
+    }
+
+    if (cursorId !== null && cursorCreatedAt !== null) {
+      paramIdx++;
+      const cursorTs = cursorCreatedAt.toISOString();
+      if (isDesc) {
+        conditions.push(
+          `(v.created_at, v.id) < ($${paramIdx}::timestamptz, $${paramIdx + 1})`,
+        );
+      } else {
+        conditions.push(
+          `(v.created_at, v.id) > ($${paramIdx}::timestamptz, $${paramIdx + 1})`,
+        );
+      }
+      params.push(cursorTs, cursorId);
+      paramIdx++;
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    // Fetch one extra row to determine if there's a next page
+    const limit = cursor ? pageSize + 1 : pageSize;
+    const limitIdx = paramIdx + 1;
+    params.push(limit);
+
+    let sql: string;
+    if (cursor) {
+      sql = `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
+               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+               v.created_at, v.updated_at,
+               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+               v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
+               COALESCE((
+                 SELECT COUNT(*)::int
+                 FROM user_vault_positions uvp
+                 WHERE uvp.vault_id = v.id AND uvp.shares > 0
+               ), 0) AS depositor_count
+        FROM vaults v
+        ${whereClause}
+        ORDER BY v.${sortColumn} ${sortDirection}, v.id ${sortDirection}
+        LIMIT $${limitIdx}`;
+    } else {
+      const offset = (page - 1) * pageSize;
+      params.push(offset);
+      sql = `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
+               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+               v.created_at, v.updated_at,
+               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+               v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
+               COALESCE((
+                 SELECT COUNT(*)::int
+                 FROM user_vault_positions uvp
+                 WHERE uvp.vault_id = v.id AND uvp.shares > 0
+               ), 0) AS depositor_count
+        FROM vaults v
+        ${whereClause}
+        ORDER BY v.${sortColumn} ${sortDirection}
+        LIMIT $${limitIdx} OFFSET $${limitIdx + 1}`;
+    }
+
+    const vaults = await query<VaultRow>(sql, params);
+
+    // Determine nextCursor if cursor-based pagination
+    let nextCursor: string | null = null;
+    if (cursor && vaults.length > pageSize) {
+      vaults.pop(); // remove the extra row
+      const last = vaults[vaults.length - 1];
+      nextCursor = Buffer.from(
+        JSON.stringify({ id: last.id, created_at: last.created_at.toISOString() }),
+      ).toString("base64url");
+    } else if (cursor) {
+      nextCursor = null;
+    }
+
+    // Get total count (only when not using cursor, to avoid expensive counts)
+    let total = 0;
+    if (!cursor) {
+      const countConditions: string[] = [];
+      const countParams: any[] = [];
+      let countIdx = 0;
+      if (state) {
+        countIdx++;
+        countConditions.push(`v.state = $${countIdx}`);
+        countParams.push(state);
+      }
+      if (category) {
+        countIdx++;
+        countConditions.push(`v.rwa_category = $${countIdx}`);
+        countParams.push(category);
+      }
+      const countWhere = countConditions.length > 0 ? `WHERE ${countConditions.join(" AND ")}` : "";
+      const countResult = await query<{ count: string }>(
+        `SELECT COUNT(*) as count FROM vaults v ${countWhere}`,
+        countParams,
+      );
+      total = parseInt(countResult[0]?.count ?? "0", 10);
+    }
+
     const data: Vault[] = vaults.map(mapVaultRow);
 
     return {
@@ -126,6 +220,7 @@ export class VaultService {
       total,
       page,
       pageSize,
+      nextCursor,
     };
   }
 
@@ -136,13 +231,20 @@ export class VaultService {
     return parseInt(countResult[0]?.count ?? "0", 10);
   }
 
+  async listCategories(): Promise<string[]> {
+    const rows = await query<{ rwa_category: string | null }>(
+      "SELECT DISTINCT rwa_category FROM vaults WHERE rwa_category IS NOT NULL ORDER BY rwa_category ASC",
+    );
+    return rows.map((r) => r.rwa_category!);
+  }
+
   async listVaultsByFactory(factoryId: string): Promise<Vault[]> {
     const rows = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
-              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -163,7 +265,7 @@ export class VaultService {
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
-              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -321,6 +423,7 @@ export class VaultService {
       rwaName = null,
       rwaSymbol = null,
       rwaDocumentUri = null,
+      rwaCategory = null,
     } = vault;
 
     logger.info(
@@ -333,10 +436,10 @@ export class VaultService {
          contract_id, factory_id, asset, name, symbol, state,
          total_assets, total_supply,
          funding_target, funding_deadline, min_deposit, max_deposit_per_user,
-         rwa_name, rwa_symbol, rwa_document_uri,
+         rwa_name, rwa_symbol, rwa_document_uri, rwa_category,
          created_at, updated_at
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, NOW(), NOW())
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NOW(), NOW())
        ON CONFLICT (contract_id)
        DO UPDATE SET
          state = EXCLUDED.state,
@@ -349,10 +452,11 @@ export class VaultService {
          rwa_name = COALESCE(EXCLUDED.rwa_name, vaults.rwa_name),
          rwa_symbol = COALESCE(EXCLUDED.rwa_symbol, vaults.rwa_symbol),
          rwa_document_uri = COALESCE(EXCLUDED.rwa_document_uri, vaults.rwa_document_uri),
+         rwa_category = COALESCE(EXCLUDED.rwa_category, vaults.rwa_category),
          updated_at = NOW()`,
       [contractId, factoryId, asset, name, symbol, state, totalAssets, totalSupply,
        fundingTarget, fundingDeadline, minDeposit, maxDepositPerUser,
-       rwaName, rwaSymbol, rwaDocumentUri],
+       rwaName, rwaSymbol, rwaDocumentUri, rwaCategory],
     );
 
     logger.info({ contractId }, "Vault upserted successfully");

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -26,6 +26,7 @@ export interface Vault {
   rwaName: string | null;
   rwaSymbol: string | null;
   rwaDocumentUri: string | null;
+  rwaCategory: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -112,6 +113,7 @@ export interface PaginatedResponse<T> {
   total: number;
   page: number;
   pageSize: number;
+  nextCursor?: string | null;
 }
 
 export interface YieldHistoryEntry {


### PR DESCRIPTION
Closes #576, closes #577, closes #578, closes #579

## Summary

### #576 - Vault search by RWA category
- Added rwa_category column to vaults table (migration 019)
- Extract rwa_category from vault_created event parser
- Added category query param to GET /api/v1/vaults
- Added GET /api/v1/vaults/categories endpoint returning distinct categories

### #577 - Cursor-based pagination for GET /api/v1/vaults
- Accept optional cursor query param (base64-encoded { id, created_at })
- Uses WHERE (created_at, id) < (cursor.created_at, cursor.id) for stable keyset navigation
- Includes nextCursor in response (null on last page)
- Preserves existing page/pageSize support -- cursor is opt-in

### #578 - Total pending yield across all vaults
- Added UserService.getTotalPendingYield(address) method
- Sums pending yield across all vaults where the user has a position

### #579 - GET /api/v1/admin/api-keys
- Returns all api_keys rows omitting key_hash
- Protected with requireApiKey (role: admin)
- Returns id, label, role, createdAt

## Testing
- TypeScript compiles cleanly
- All 122 unit tests pass (2 pre-existing E2E failures unrelated to changes)
- Lint errors: only 2 pre-existing (unused imports in other files)
