### PR TITLE
feat: vault search indexes, Redis caching, per-state TTLs, and ETag support

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "dotenv": "^16.4.0",
     "express": "^4.21.0",
     "express-rate-limit": "^8.5.2",
+    "ioredis": "^5.4.2",
     "helmet": "8.0.0",
     "pg": "^8.13.0",
     "pino": "^9.5.0",

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
+import { createHash } from "crypto";
 import { z } from "zod";
 import { VaultService } from "../../services/vault.js";
 import { readTotalAssets, readVaultState } from "../../services/stellar.js";
@@ -88,7 +89,13 @@ export async function getVault(req: Request, res: Response, next: NextFunction) 
       res.status(404).json({ error: "NotFound", message: "Vault not found" });
       return;
     }
+    const etag = `W/"${createHash("sha1").update(JSON.stringify(vault)).digest("hex")}"`;
+    if (req.headers["if-none-match"] === etag) {
+      res.status(304).end();
+      return;
+    }
     setCacheHeaders(res);
+    res.set("ETag", etag);
     res.json(vault);
   } catch (err) {
     next(err);

--- a/backend/src/cache/redis.ts
+++ b/backend/src/cache/redis.ts
@@ -1,0 +1,45 @@
+import Redis from "ioredis";
+import { logger } from "../logger.js";
+
+let client: Redis | null = null;
+
+function getClient(): Redis | null {
+  if (client) return client;
+  const url = process.env["REDIS_URL"];
+  if (!url) return null;
+  client = new Redis(url, { lazyConnect: true, maxRetriesPerRequest: 1 });
+  client.on("error", (err: Error) => logger.error({ err }, "redis error"));
+  return client;
+}
+
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  try {
+    const redis = getClient();
+    if (!redis) return null;
+    const val = await redis.get(key);
+    return val ? (JSON.parse(val) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheSet(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+  try {
+    const redis = getClient();
+    if (!redis) return;
+    await redis.set(key, JSON.stringify(value), "EX", ttlSeconds);
+  } catch {
+    // cache is best-effort
+  }
+}
+
+export async function cacheDel(pattern: string): Promise<void> {
+  try {
+    const redis = getClient();
+    if (!redis) return;
+    const keys = await redis.keys(pattern);
+    if (keys.length > 0) await redis.del(...keys);
+  } catch {
+    // cache is best-effort
+  }
+}

--- a/backend/src/db/migrations/020_vault_search_indexes.sql
+++ b/backend/src/db/migrations/020_vault_search_indexes.sql
@@ -1,0 +1,11 @@
+-- Enable trigram extension for ILIKE / similarity searches
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Trigram index on vault name for fast partial-match queries
+CREATE INDEX IF NOT EXISTS idx_vaults_name_trgm ON vaults USING GIN (name gin_trgm_ops);
+
+-- Trigram index on rwa_name for category-scoped text search
+CREATE INDEX IF NOT EXISTS idx_vaults_rwa_name_trgm ON vaults USING GIN (rwa_name gin_trgm_ops);
+
+-- Index on state for filter-heavy list queries
+CREATE INDEX IF NOT EXISTS idx_vaults_state ON vaults (state);

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -7,6 +7,15 @@ import type {
 } from "../types/index.js";
 import { query } from "../db/index.js";
 import { logger } from "../logger.js";
+import { cacheGet, cacheSet, cacheDel } from "../cache/redis.js";
+
+const TTL_BY_STATE: Record<string, number> = {
+  Active: 10,
+  Funding: 30,
+  Cancelled: 600,
+  Matured: 600,
+};
+const DEFAULT_TTL = 30;
 
 interface ListVaultsOptions {
   page: number;
@@ -83,6 +92,10 @@ function mapVaultRow(row: VaultRow): Vault {
 
 export class VaultService {
   async listVaults(opts: ListVaultsOptions): Promise<PaginatedResponse<Vault>> {
+    const cacheKey = `vaults:list:${JSON.stringify(opts)}`;
+    const cached = await cacheGet<PaginatedResponse<Vault>>(cacheKey);
+    if (cached) return cached;
+
     const { page, pageSize, state, category, cursor, sort, order } = opts;
     const sortColumn = sort === "total_assets" ? "total_assets" : "created_at";
     const sortDirection = order === "asc" ? "ASC" : "DESC";
@@ -216,13 +229,10 @@ export class VaultService {
 
     const data: Vault[] = vaults.map(mapVaultRow);
 
-    return {
-      data,
-      total,
-      page,
-      pageSize,
-      nextCursor,
-    };
+    const result: PaginatedResponse<Vault> = { data, total, page, pageSize, nextCursor };
+    const listTtl = TTL_BY_STATE[state ?? ""] ?? DEFAULT_TTL;
+    await cacheSet(cacheKey, result, listTtl);
+    return result;
   }
 
   async countVaults(): Promise<number> {
@@ -261,6 +271,10 @@ export class VaultService {
   }
 
   async getVault(contractId: string): Promise<Vault | null> {
+    const cacheKey = `vault:${contractId}`;
+    const cached = await cacheGet<Vault>(cacheKey);
+    if (cached) return cached;
+
     const rows = await query<VaultRow>(
       `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
@@ -279,7 +293,10 @@ export class VaultService {
 
     if (rows.length === 0) return null;
 
-    return mapVaultRow(rows[0]);
+    const vault = mapVaultRow(rows[0]);
+    const ttl = TTL_BY_STATE[vault.state] ?? DEFAULT_TTL;
+    await cacheSet(cacheKey, vault, ttl);
+    return vault;
   }
 
   async getVaultPositions(contractId: string): Promise<UserVaultPosition[]> {
@@ -461,6 +478,8 @@ export class VaultService {
     );
 
     logger.info({ contractId }, "Vault upserted successfully");
+    await cacheDel(`vault:${contractId}`);
+    await cacheDel("vaults:list:*");
   }
 
   async listVaultOperators(contractId: string): Promise<{


### PR DESCRIPTION
Closes #651

---

Closes #650

---

Closes #648

---

Closes #649

---

## Summary

- **Migration 020** (`020_vault_search_indexes.sql`): enables `pg_trgm` extension and adds trigram GIN indexes on `vaults.name` and `vaults.rwa_name` for fast partial-match queries, plus a B-tree index on `state` for filter-heavy list queries (#648)
- **Redis cache module** (`cache/redis.ts`): thin `ioredis` wrapper exposing `cacheGet<T>`, `cacheSet`, and `cacheDel`; all calls are best-effort — the module silently no-ops when `REDIS_URL` is unset (#649)
- **`VaultService` caching**: `getVault` and `listVaults` read from Redis before hitting the database; `upsertVault` evicts the affected vault key and all list keys; TTL is determined by vault state — Active 10 s, Funding 30 s, Cancelled/Matured 600 s (#649, #650)
- **ETag on vault detail**: `GET /api/v1/vaults/:contractId` computes a `W/`-prefixed SHA-1 fingerprint of the serialised vault, sets the `ETag` header, and returns `304 Not Modified` when `If-None-Match` matches (#651)

## Test plan

- [ ] Apply migration 020 and verify `pg_trgm` extension and new indexes appear in `\di`
- [ ] Set `REDIS_URL` and confirm `GET /api/v1/vaults/:contractId` hits Redis on the second call (check Redis `TTL` matches the vault state)
- [ ] Confirm service still works without `REDIS_URL` (no errors, just DB calls)
- [ ] Call `GET /api/v1/vaults/:contractId`, copy the `ETag` response header, re-send with `If-None-Match: <etag>` — expect `304`
- [ ] Upsert a vault and confirm Redis keys are evicted