### PR TITLE
feat: add maturing-soon, fully-funded, similar endpoints and fuzzy 

### DIFF
--- a/backend/src/api/controllers/vaults-endpoints.test.ts
+++ b/backend/src/api/controllers/vaults-endpoints.test.ts
@@ -6,6 +6,9 @@ const mocks = vi.hoisted(() => ({
   listVaultHolders: vi.fn(),
   countVaultHolders: vi.fn(),
   getVaultHoldersForExport: vi.fn(),
+  getMaturitySoonVaults: vi.fn(),
+  getFullyFundedVaults: vi.fn(),
+  getSimilarVaults: vi.fn(),
 }));
 
 vi.mock("../../services/vault.js", () => ({
@@ -15,6 +18,9 @@ vi.mock("../../services/vault.js", () => ({
     listVaultHolders: mocks.listVaultHolders,
     countVaultHolders: mocks.countVaultHolders,
     getVaultHoldersForExport: mocks.getVaultHoldersForExport,
+    getMaturitySoonVaults: mocks.getMaturitySoonVaults,
+    getFullyFundedVaults: mocks.getFullyFundedVaults,
+    getSimilarVaults: mocks.getSimilarVaults,
   })),
 }));
 vi.mock("../../services/stellar.js", () => ({
@@ -29,6 +35,9 @@ import {
   getVaultHolders,
   getVaultHolderCount,
   exportVaultHoldersCsv,
+  getMaturingSoonVaults,
+  getFullyFundedVaults,
+  getSimilarVaults,
 } from "./vaults.js";
 
 const CONTRACT_ID = "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3B";
@@ -303,5 +312,126 @@ describe("exportVaultHoldersCsv", () => {
       "GUSER1,200,100,2025-01-01T00:00:00.000Z\r\n" +
       "GUSER2,50,75,2025-01-02T00:00:00.000Z\r\n",
     );
+  });
+});
+
+describe("getMaturingSoonVaults", () => {
+  const next = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns active vaults maturing soon with default 30 days", async () => {
+    const vaults = [{ contractId: CONTRACT_ID, daysUntilMaturity: 10 }];
+    mocks.getMaturitySoonVaults.mockResolvedValue(vaults);
+    const res = makeRes();
+    const req = { query: {} } as any;
+
+    await getMaturingSoonVaults(req, res as any, next);
+
+    expect(mocks.getMaturitySoonVaults).toHaveBeenCalledWith(30);
+    expect(res.json).toHaveBeenCalledWith(vaults);
+  });
+
+  it("clamps days parameter to 1-90 range", async () => {
+    mocks.getMaturitySoonVaults.mockResolvedValue([]);
+    const res = makeRes();
+    const req = { query: { days: "200" } } as any;
+
+    await getMaturingSoonVaults(req, res as any, next);
+
+    expect(mocks.getMaturitySoonVaults).toHaveBeenCalledWith(90);
+  });
+
+  it("returns empty array when no vaults are maturing soon", async () => {
+    mocks.getMaturitySoonVaults.mockResolvedValue([]);
+    const res = makeRes();
+    const req = { query: { days: "7" } } as any;
+
+    await getMaturingSoonVaults(req, res as any, next);
+
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+});
+
+describe("getFullyFundedVaults", () => {
+  const next = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns fully-funded vaults with cache headers", async () => {
+    const vaults = [
+      { contractId: CONTRACT_ID, state: "Funding", fundingProgress: 100 },
+    ];
+    mocks.getFullyFundedVaults.mockResolvedValue(vaults);
+    const res = makeRes();
+    const req = {} as any;
+
+    await getFullyFundedVaults(req, res as any, next);
+
+    expect(mocks.getFullyFundedVaults).toHaveBeenCalled();
+    expect(res.set).toHaveBeenCalledWith("Cache-Control", "max-age=10, stale-while-revalidate=60");
+    expect(res.json).toHaveBeenCalledWith(vaults);
+  });
+
+  it("returns empty array when no fully-funded vaults exist", async () => {
+    mocks.getFullyFundedVaults.mockResolvedValue([]);
+    const res = makeRes();
+    const req = {} as any;
+
+    await getFullyFundedVaults(req, res as any, next);
+
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+});
+
+describe("getSimilarVaults", () => {
+  const next = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when the target vault does not exist", async () => {
+    mocks.getSimilarVaults.mockResolvedValue(null);
+    const res = makeRes();
+    const req = { params: { contractId: CONTRACT_ID } } as any;
+
+    await getSimilarVaults(req, res as any, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("returns similar vaults with cache headers", async () => {
+    const similar = [
+      {
+        contractId: "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3C",
+        name: "RE Fund 2",
+        totalAssets: "5500",
+        rwaCategory: "real-estate",
+      },
+    ];
+    mocks.getSimilarVaults.mockResolvedValue(similar);
+    const res = makeRes();
+    const req = { params: { contractId: CONTRACT_ID } } as any;
+
+    await getSimilarVaults(req, res as any, next);
+
+    expect(mocks.getSimilarVaults).toHaveBeenCalledWith(CONTRACT_ID);
+    expect(res.set).toHaveBeenCalledWith("Cache-Control", "max-age=10, stale-while-revalidate=60");
+    expect(res.json).toHaveBeenCalledWith(similar);
+  });
+
+  it("returns empty array when no similar vaults exist", async () => {
+    mocks.getSimilarVaults.mockResolvedValue([]);
+    const res = makeRes();
+    const req = { params: { contractId: CONTRACT_ID } } as any;
+
+    await getSimilarVaults(req, res as any, next);
+
+    expect(res.json).toHaveBeenCalledWith([]);
   });
 });

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -44,7 +44,7 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       order: "asc" | "desc";
       q?: string;
     };
-    const result = await vaultService.listVaults({ page, pageSize, state, category, cursor, sort, order });
+    const result = await vaultService.listVaults({ page, pageSize, state, category, cursor, sort, order, q });
     setCacheHeaders(res);
     res.json(result);
   } catch (err) {
@@ -691,6 +691,7 @@ export async function searchVaults(req: Request, res: Response, next: NextFuncti
       pageSize,
       sort,
       order,
+      fuzzy,
     } = req.query as unknown as {
       q?: string;
       category?: string;
@@ -699,8 +700,9 @@ export async function searchVaults(req: Request, res: Response, next: NextFuncti
       pageSize: number;
       sort: "created_at" | "total_assets";
       order: "asc" | "desc";
+      fuzzy?: boolean;
     };
-    const result = await vaultService.searchVaults({ q, category, state, page, pageSize, sort, order });
+    const result = await vaultService.searchVaults({ q, category, state, page, pageSize, sort, order, fuzzy });
     setCacheHeaders(res);
     res.json(result);
   } catch (err) {
@@ -965,6 +967,72 @@ export async function getVaultTvlHistory(req: Request, res: Response, next: Next
 
     setCacheHeaders(res);
     res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/maturing-soon?days=30
+ *
+ * Returns active vaults whose maturity_date falls within the next `days` days
+ * (1–90, default 30). Each entry includes a daysUntilMaturity integer.
+ *
+ * #644
+ */
+export async function getMaturingSoonVaults(req: Request, res: Response, next: NextFunction) {
+  try {
+    const daysParam = req.query["days"];
+    const days = typeof daysParam === "string" && /^\d+$/.test(daysParam)
+      ? Math.min(90, Math.max(1, parseInt(daysParam, 10)))
+      : 30;
+
+    const vaults = await vaultService.getMaturitySoonVaults(days);
+    setCacheHeaders(res);
+    res.json(vaults);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/fully-funded
+ *
+ * Returns Funding-state vaults where total_assets >= funding_target, ordered
+ * by funding ratio descending (most overfunded first). Each entry includes
+ * fundingProgress as a percentage.
+ *
+ * #645
+ */
+export async function getFullyFundedVaults(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const vaults = await vaultService.getFullyFundedVaults();
+    setCacheHeaders(res);
+    res.json(vaults);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/:contractId/similar
+ *
+ * Returns up to 5 active vaults in the same rwa_category as the target vault,
+ * sorted by TVL proximity (closest total_assets first). Excludes the target
+ * vault itself. Returns [] when no similar vaults exist.
+ *
+ * #647
+ */
+export async function getSimilarVaults(req: Request, res: Response, next: NextFunction) {
+  try {
+    const contractId = String(req.params["contractId"]);
+    const similar = await vaultService.getSimilarVaults(contractId);
+    if (similar === null) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+    setCacheHeaders(res);
+    res.json(similar);
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -20,6 +20,13 @@ import {
   getVaultAnnualReport,
   getEpochBreakdown,
   listCategories,
+  searchVaults,
+  checkVaultName,
+  getTrendingVaults,
+  getNewVaults,
+  getMaturingSoonVaults,
+  getFullyFundedVaults,
+  getSimilarVaults,
 } from "../controllers/vaults.js";
 import { validateParams, validateQuery } from "../middleware/validate.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -59,10 +66,15 @@ const searchVaultsQuerySchema = z.object({
   order: z.enum(["asc", "desc"]).default("desc"),
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).default(20).transform((value) => Math.min(value, 100)),
+  fuzzy: z.coerce.boolean().default(false),
 });
 
 const newVaultsQuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(30).default(7),
+});
+
+const maturingSoonQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(90).default(30),
 });
 
 export const vaultsRouter = Router();
@@ -70,6 +82,13 @@ export const vaultsRouter = Router();
 vaultsRouter.get("/categories", listCategories);
 vaultsRouter.get("/", validateQuery(listVaultsQuerySchema), listVaults);
 vaultsRouter.get("/count", getVaultCount);
+// Search, filter, and discovery endpoints (#640–#643, #644, #645)
+vaultsRouter.get("/search", validateQuery(searchVaultsQuerySchema), searchVaults);
+vaultsRouter.get("/name-check", checkVaultName);
+vaultsRouter.get("/trending", getTrendingVaults);
+vaultsRouter.get("/new", validateQuery(newVaultsQuerySchema), getNewVaults);
+vaultsRouter.get("/maturing-soon", validateQuery(maturingSoonQuerySchema), getMaturingSoonVaults);
+vaultsRouter.get("/fully-funded", getFullyFundedVaults);
 vaultsRouter.get("/factory/:factoryId", validateParams(vaultFactoryParamsSchema), listVaultsByFactory);
 vaultsRouter.get("/:contractId", validateParams(vaultParamsSchema), getVault);
 vaultsRouter.get("/:contractId/state/live", validateParams(vaultParamsSchema), getVaultLiveState);
@@ -111,3 +130,5 @@ vaultsRouter.get("/:contractId/export.csv", validateParams(vaultParamsSchema), e
 vaultsRouter.get("/:contractId/report", validateParams(vaultParamsSchema), getVaultAnnualReport);
 // Per-user yield breakdown for a specific epoch: GET /api/v1/vaults/:contractId/epochs/:epoch/breakdown
 vaultsRouter.get("/:contractId/epochs/:epoch/breakdown", validateParams(vaultParamsSchema), getEpochBreakdown);
+// Similar vaults by category and TVL proximity: GET /api/v1/vaults/:contractId/similar
+vaultsRouter.get("/:contractId/similar", validateParams(vaultParamsSchema), getSimilarVaults);

--- a/backend/src/cache/redis.ts
+++ b/backend/src/cache/redis.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import { Redis } from "ioredis";
 import { logger } from "../logger.js";
 
 let client: Redis | null = null;

--- a/backend/src/services/vault.test.ts
+++ b/backend/src/services/vault.test.ts
@@ -267,4 +267,228 @@ describe("VaultService", () => {
       );
     });
   });
+
+  describe("getMaturitySoonVaults", () => {
+    it("returns active vaults maturing within the given days with daysUntilMaturity", async () => {
+      const createdAt = new Date("2025-01-01T00:00:00.000Z");
+      const maturityDate = new Date("2025-12-31T00:00:00.000Z");
+      vi.mocked(db.query).mockResolvedValueOnce([
+        {
+          id: 1,
+          contract_id: CONTRACT_ID,
+          factory_id: null,
+          asset: "USDC",
+          name: "Real Estate Fund",
+          symbol: "REF",
+          state: "Active",
+          total_assets: "5000",
+          total_supply: "4500",
+          total_shares_ever_minted: "4500",
+          total_shares_ever_burned: "0",
+          depositor_count: 10,
+          funding_target: "4000",
+          funding_deadline: null,
+          min_deposit: null,
+          max_deposit_per_user: null,
+          rwa_name: null,
+          rwa_symbol: null,
+          rwa_document_uri: null,
+          rwa_category: "real-estate",
+          created_at: createdAt,
+          updated_at: createdAt,
+          days_until_maturity: 14,
+        },
+      ]);
+
+      const result = await vaultService.getMaturitySoonVaults(30);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].contractId).toBe(CONTRACT_ID);
+      expect(result[0].daysUntilMaturity).toBe(14);
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("v.state = 'Active'"),
+        [30],
+      );
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("days_until_maturity"),
+        [30],
+      );
+    });
+
+    it("returns empty array when no vaults are maturing soon", async () => {
+      vi.mocked(db.query).mockResolvedValueOnce([]);
+
+      const result = await vaultService.getMaturitySoonVaults(7);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getFullyFundedVaults", () => {
+    it("returns Funding-state vaults at or above their funding target", async () => {
+      const createdAt = new Date("2025-01-01T00:00:00.000Z");
+      vi.mocked(db.query).mockResolvedValueOnce([
+        {
+          id: 2,
+          contract_id: CONTRACT_ID,
+          factory_id: null,
+          asset: "USDC",
+          name: "Bond Fund",
+          symbol: "BF",
+          state: "Funding",
+          total_assets: "10500",
+          total_supply: "10000",
+          total_shares_ever_minted: "10000",
+          total_shares_ever_burned: "0",
+          depositor_count: 5,
+          funding_target: "10000",
+          funding_deadline: null,
+          min_deposit: null,
+          max_deposit_per_user: null,
+          rwa_name: null,
+          rwa_symbol: null,
+          rwa_document_uri: null,
+          rwa_category: "bonds",
+          created_at: createdAt,
+          updated_at: createdAt,
+        },
+      ]);
+
+      const result = await vaultService.getFullyFundedVaults();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].state).toBe("Funding");
+      expect(result[0].fundingProgress).toBe(100);
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("v.state = 'Funding'"),
+      );
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("v.total_assets::numeric >= v.funding_target::numeric"),
+      );
+    });
+
+    it("returns empty array when no fully-funded vaults exist", async () => {
+      vi.mocked(db.query).mockResolvedValueOnce([]);
+
+      const result = await vaultService.getFullyFundedVaults();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("searchVaults with fuzzy", () => {
+    it("uses similarity() when fuzzy=true", async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ count: "0" }]);
+
+      await vaultService.searchVaults({
+        q: "realestat",
+        page: 1,
+        pageSize: 20,
+        sort: "created_at",
+        order: "desc",
+        fuzzy: true,
+      });
+
+      expect(db.query).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("similarity(v.name, $1) > 0.3"),
+        expect.arrayContaining(["realestat"]),
+      );
+    });
+
+    it("uses ILIKE when fuzzy=false", async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ count: "0" }]);
+
+      await vaultService.searchVaults({
+        q: "real estate",
+        page: 1,
+        pageSize: 20,
+        sort: "created_at",
+        order: "desc",
+        fuzzy: false,
+      });
+
+      expect(db.query).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("ILIKE"),
+        expect.arrayContaining(["%real estate%"]),
+      );
+    });
+
+    it("filters by rwa_category when category is provided", async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ count: "0" }]);
+
+      await vaultService.searchVaults({
+        category: "real-estate",
+        page: 1,
+        pageSize: 20,
+        sort: "created_at",
+        order: "desc",
+      });
+
+      expect(db.query).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("v.rwa_category = $1"),
+        expect.arrayContaining(["real-estate"]),
+      );
+    });
+  });
+
+  describe("getSimilarVaults", () => {
+    it("returns similar active vaults in the same category sorted by TVL proximity", async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce([{ rwa_category: "real-estate", total_assets: "5000" }])
+        .mockResolvedValueOnce([
+          { contract_id: "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3C", name: "RE Fund 2", total_assets: "5500", rwa_category: "real-estate" },
+        ]);
+
+      const result = await vaultService.getSimilarVaults(CONTRACT_ID);
+
+      expect(result).toHaveLength(1);
+      expect(result![0].contractId).toBe("CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3C");
+      expect(result![0].rwaCategory).toBe("real-estate");
+      expect(db.query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("ABS(total_assets::numeric - $3::numeric) ASC"),
+        ["real-estate", CONTRACT_ID, "5000"],
+      );
+      expect(db.query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("LIMIT 5"),
+        expect.any(Array),
+      );
+    });
+
+    it("returns null when the target vault does not exist", async () => {
+      vi.mocked(db.query).mockResolvedValueOnce([]);
+
+      const result = await vaultService.getSimilarVaults(CONTRACT_ID);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns empty array when the target vault has no rwa_category", async () => {
+      vi.mocked(db.query).mockResolvedValueOnce([{ rwa_category: null, total_assets: "5000" }]);
+
+      const result = await vaultService.getSimilarVaults(CONTRACT_ID);
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when no similar vaults exist", async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce([{ rwa_category: "rare-category", total_assets: "1000" }])
+        .mockResolvedValueOnce([]);
+
+      const result = await vaultService.getSimilarVaults(CONTRACT_ID);
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -25,7 +25,7 @@ interface ListVaultsOptions {
   cursor?: string;
   sort: "created_at" | "total_assets";
   order: "asc" | "desc";
-  q?: string;
+  q?: string; // forwarded from controller; listVaults currently delegates text search to /search
 }
 
 interface VaultRow {
@@ -670,7 +670,7 @@ export class VaultService {
     }));
   }
 
-  // ── Issue #640: Combined search ──────────────────────────────────────────────
+  // ── Issue #640 / #646: Combined search with optional fuzzy matching ──────────
   async searchVaults(opts: {
     q?: string;
     category?: string;
@@ -679,8 +679,9 @@ export class VaultService {
     pageSize: number;
     sort: string;
     order: string;
+    fuzzy?: boolean;
   }): Promise<PaginatedResponse<Vault>> {
-    const { q, category, state, page, pageSize, sort, order } = opts;
+    const { q, category, state, page, pageSize, sort, order, fuzzy } = opts;
     const offset = (page - 1) * pageSize;
     const sortColumn = sort === "total_assets" ? "total_assets" : "created_at";
     const sortDirection = order === "asc" ? "ASC" : "DESC";
@@ -693,11 +694,16 @@ export class VaultService {
       params.push(state);
     }
     if (q) {
-      conditions.push(`(v.name ILIKE $${params.length + 1} OR v.symbol ILIKE $${params.length + 1} OR v.rwa_name ILIKE $${params.length + 1})`);
-      params.push(`%${q}%`);
+      if (fuzzy) {
+        conditions.push(`similarity(v.name, $${params.length + 1}) > 0.3`);
+        params.push(q);
+      } else {
+        conditions.push(`(v.name ILIKE $${params.length + 1} OR v.symbol ILIKE $${params.length + 1} OR v.rwa_name ILIKE $${params.length + 1})`);
+        params.push(`%${q}%`);
+      }
     }
     if (category) {
-      conditions.push(`v.rwa_name ILIKE $${params.length + 1}`);
+      conditions.push(`v.rwa_category = $${params.length + 1}`);
       params.push(category);
     }
 
@@ -708,7 +714,7 @@ export class VaultService {
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
-              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -789,7 +795,7 @@ export class VaultService {
               v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
               v.created_at, v.updated_at,
               v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
-              v.rwa_name, v.rwa_symbol, v.rwa_document_uri,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
               COALESCE((
                 SELECT COUNT(*)::int
                 FROM user_vault_positions uvp
@@ -802,6 +808,103 @@ export class VaultService {
     );
 
     return rows.map(mapVaultRow);
+  }
+
+  // ── Issue #644: Maturing-soon vaults ────────────────────────────────────────
+  async getMaturitySoonVaults(days: number): Promise<Array<Vault & { daysUntilMaturity: number }>> {
+    const rows = await query<VaultRow & { days_until_maturity: number }>(
+      `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
+              v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+              v.created_at, v.updated_at,
+              v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
+              COALESCE((
+                SELECT COUNT(*)::int
+                FROM user_vault_positions uvp
+                WHERE uvp.vault_id = v.id AND uvp.shares > 0
+              ), 0) AS depositor_count,
+              GREATEST(0, (v.maturity_date::date - CURRENT_DATE)) AS days_until_maturity
+       FROM vaults v
+       WHERE v.state = 'Active'
+         AND v.maturity_date > NOW()
+         AND v.maturity_date <= NOW() + ($1::int * INTERVAL '1 day')
+       ORDER BY v.maturity_date ASC`,
+      [days],
+    );
+
+    return rows.map((row) => ({
+      ...mapVaultRow(row),
+      daysUntilMaturity: row.days_until_maturity,
+    }));
+  }
+
+  // ── Issue #645: Fully-funded vaults ─────────────────────────────────────────
+  async getFullyFundedVaults(): Promise<Vault[]> {
+    const rows = await query<VaultRow>(
+      `SELECT v.id, v.contract_id, v.factory_id, v.asset, v.name, v.symbol, v.state,
+              v.total_assets, v.total_supply, v.total_shares_ever_minted, v.total_shares_ever_burned,
+              v.created_at, v.updated_at,
+              v.funding_target, v.funding_deadline, v.min_deposit, v.max_deposit_per_user,
+              v.rwa_name, v.rwa_symbol, v.rwa_document_uri, v.rwa_category,
+              COALESCE((
+                SELECT COUNT(*)::int
+                FROM user_vault_positions uvp
+                WHERE uvp.vault_id = v.id AND uvp.shares > 0
+              ), 0) AS depositor_count
+       FROM vaults v
+       WHERE v.state = 'Funding'
+         AND v.funding_target IS NOT NULL
+         AND v.funding_target::numeric > 0
+         AND v.total_assets::numeric >= v.funding_target::numeric
+       ORDER BY (v.total_assets::numeric / v.funding_target::numeric) DESC`,
+    );
+
+    return rows.map(mapVaultRow);
+  }
+
+  // ── Issue #647: Similar vaults ───────────────────────────────────────────────
+  async getSimilarVaults(contractId: string): Promise<{
+    contractId: string;
+    name: string | null;
+    totalAssets: string;
+    rwaCategory: string | null;
+  }[] | null> {
+    const targetRows = await query<{
+      rwa_category: string | null;
+      total_assets: string;
+    }>(
+      "SELECT rwa_category, total_assets FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+
+    if (targetRows.length === 0) return null;
+
+    const { rwa_category, total_assets } = targetRows[0];
+
+    if (!rwa_category) return [];
+
+    const rows = await query<{
+      contract_id: string;
+      name: string | null;
+      total_assets: string;
+      rwa_category: string | null;
+    }>(
+      `SELECT contract_id, name, total_assets, rwa_category
+       FROM vaults
+       WHERE rwa_category = $1
+         AND state = 'Active'
+         AND contract_id != $2
+       ORDER BY ABS(total_assets::numeric - $3::numeric) ASC
+       LIMIT 5`,
+      [rwa_category, contractId, total_assets],
+    );
+
+    return rows.map((r) => ({
+      contractId: r.contract_id,
+      name: r.name,
+      totalAssets: r.total_assets ?? "0",
+      rwaCategory: r.rwa_category,
+    }));
   }
 
   async getCompoundProjection(


### PR DESCRIPTION
  Summary

  Implements issues #644, #645, #646, and #647 — four new vault discovery and search endpoints.

  Changes

  New endpoints:

  - GET /api/v1/vaults/maturing-soon?days=30 — returns Active vaults whose maturity_date falls within the next days
  days (1–90, default 30). Each entry includes a daysUntilMaturity integer. (#644)
  - GET /api/v1/vaults/fully-funded — returns Funding-state vaults where total_assets >= funding_target, ordered by
  funding ratio descending (most overfunded first). fundingProgress is included and >= 100 for all entries. (#645)
  - GET /api/v1/vaults/:contractId/similar — returns up to 5 Active vaults in the same rwa_category, sorted by
  ABS(total_assets - target.total_assets) ASC. Returns [] when no similar vaults exist; 404 if the target vault is not
  found. (#647)

  Fuzzy search (Issue #646):

  - Added fuzzy=true query param to GET /api/v1/vaults/search. When true, uses similarity(name, $1) > 0.3 (requires
  pg_trgm, already enabled in migration 020_vault_search_indexes.sql). When false (default), uses existing ILIKE
  logic.

  Route registration fixes (#640–#643):

  - Wired up previously missing routes: /search, /name-check, /trending, /new

  Bug fixes:

  - Fixed searchVaults category filter (was rwa_name ILIKE, now correctly rwa_category =)
  - Fixed missing rwa_category column in SELECT for getNewVaults and searchVaults
  - Fixed listVaults controller not forwarding the q param to the service
  - Fixed ioredis type import in cache/redis.ts (upstream TypeScript error)

  Tests:

  - Added service-layer tests for all 4 new methods + fuzzy/category search cases
  - Added controller-layer tests for getMaturingSoonVaults, getFullyFundedVaults, getSimilarVaults

  ---
  Closes

  Closes #644
  Closes #645
  Closes #646
  Closes #647