### PR TITLE
feat(backend): holder index, /health pool stats, slow-query logging, vault.funded webhook

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,8 @@ DB_POOL_MIN=2
 DB_POOL_MAX=10
 DB_IDLE_TIMEOUT_MS=10000
 DB_QUERY_TIMEOUT_MS=30000
+# Queries slower than this many milliseconds are logged at warn level
+DB_SLOW_QUERY_MS=500
 
 # Indexer
 INDEXER_START_LEDGER=0

--- a/backend/src/api/routes/health.ts
+++ b/backend/src/api/routes/health.ts
@@ -9,10 +9,19 @@ const { version } = JSON.parse(
 export const healthRouter = Router();
 
 healthRouter.get("/", async (_req, res) => {
+  // Surface connection pool utilisation so operators can detect connection
+  // exhaustion before it causes query timeouts (#657). `waiting > 0` means
+  // requests are queued for a connection — a sign of pool pressure.
+  const dbPool = {
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
+  };
+
   try {
     await pool.query("SELECT 1");
-    res.json({ version, status: "ok" });
+    res.json({ version, status: "ok", dbPool });
   } catch {
-    res.status(503).json({ version, status: "error" });
+    res.status(503).json({ version, status: "error", dbPool });
   }
 });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -83,6 +83,11 @@ const envSchema = z.object({
     .default("30000")
     .transform((v) => parseInt(v, 10))
     .pipe(z.number().int().min(1)),
+  DB_SLOW_QUERY_MS: z
+    .string()
+    .default("500")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(1)),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -113,6 +118,7 @@ export const config = {
     poolMax: parsed.data.DB_POOL_MAX,
     idleTimeoutMs: parsed.data.DB_IDLE_TIMEOUT_MS,
     queryTimeoutMs: parsed.data.DB_QUERY_TIMEOUT_MS,
+    slowQueryMs: parsed.data.DB_SLOW_QUERY_MS,
   },
 
   indexer: {

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -20,12 +20,20 @@ export async function query<T = Record<string, unknown>>(
   const start = performance.now();
   const result = await pool.query(sql, params);
   const durationMs = performance.now() - start;
+  const roundedMs = Math.round(durationMs * 100) / 100;
 
-  if (logger.level === "debug" || logger.level === "trace") {
+  if (durationMs > config.db.slowQueryMs) {
+    // Slow queries get higher-visibility logging so they are easy to filter.
+    // The full SQL is included regardless of environment to aid diagnosis (#658).
+    logger.warn(
+      { sql, paramsCount: params?.length ?? 0, durationMs: roundedMs, rowCount: result.rowCount },
+      "slow query",
+    );
+  } else if (logger.level === "debug" || logger.level === "trace") {
     const firstLine = config.nodeEnv === "production"
       ? sql.slice(0, 80)
       : sql;
-    logger.debug({ sql: firstLine, durationMs: Math.round(durationMs * 100) / 100, rowCount: result.rowCount }, "query");
+    logger.debug({ sql: firstLine, durationMs: roundedMs, rowCount: result.rowCount }, "query");
   }
 
   return result.rows;

--- a/backend/src/db/migrations/021_vault_sort_indexes.sql
+++ b/backend/src/db/migrations/021_vault_sort_indexes.sql
@@ -1,2 +1,7 @@
 -- Composite index on (state, total_assets DESC) for vault sort queries (#655)
 CREATE INDEX CONCURRENTLY IF NOT EXISTS vaults_state_assets_idx ON vaults (state, total_assets DESC);
+
+-- Composite index on (vault_id, shares DESC) for holder queries (#656)
+-- Backs GET /api/v1/vaults/:contractId/holders?sort=shares which sorts by
+-- shares DESC; without this the sort requires a full scan of user_vault_positions.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS uvp_vault_shares_idx ON user_vault_positions (vault_id, shares DESC);

--- a/backend/src/services/indexer.test.ts
+++ b/backend/src/services/indexer.test.ts
@@ -143,6 +143,66 @@ describe("Indexer", () => {
     const maturedCall = notify.mock.calls.find((c) => c[0] === "vault.matured");
     expect(maturedCall).toBeUndefined();
   });
+
+  it("notifies vault.funded when a deposit crosses the funding target", async () => {
+    const { query } = await import("../db/index.js");
+    // Vault was at 500 assets with a 1000 target before this deposit.
+    (query as any).mockImplementation((sql: string) =>
+      sql.includes("funding_target")
+        ? Promise.resolve([{ total_assets: "500", funding_target: "1000" }])
+        : Promise.resolve([]),
+    );
+
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const fundedIndexer = new Indexer({ notify } as any);
+
+    // Deposit of 600 assets pushes total to 1100, crossing the 1000 target.
+    const event = {
+      id: "evt-funded",
+      contractId: VAULT_CONTRACT,
+      type: "contract",
+      ledger: 3000,
+      txHash: "funded-tx",
+      topic: [nativeToScVal("deposit"), nativeToScVal(ACCOUNT), nativeToScVal(ACCOUNT)],
+      value: nativeToScVal([600n, 600n]),
+    };
+
+    await fundedIndexer.processEvent(event);
+
+    expect(notify).toHaveBeenCalledWith("vault.funded", {
+      contractId: VAULT_CONTRACT,
+      totalAssets: "1100",
+      fundingTarget: "1000",
+    });
+  });
+
+  it("does not notify vault.funded on a deposit that keeps the vault above target", async () => {
+    const { query } = await import("../db/index.js");
+    // Vault is already funded (1200 >= 1000 target) before this deposit.
+    (query as any).mockImplementation((sql: string) =>
+      sql.includes("funding_target")
+        ? Promise.resolve([{ total_assets: "1200", funding_target: "1000" }])
+        : Promise.resolve([]),
+    );
+
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const fundedIndexer = new Indexer({ notify } as any);
+
+    const event = {
+      id: "evt-already-funded",
+      contractId: VAULT_CONTRACT,
+      type: "contract",
+      ledger: 3001,
+      txHash: "already-funded-tx",
+      topic: [nativeToScVal("deposit"), nativeToScVal(ACCOUNT), nativeToScVal(ACCOUNT)],
+      value: nativeToScVal([300n, 300n]),
+    };
+
+    await fundedIndexer.processEvent(event);
+
+    const fundedCall = notify.mock.calls.find((c) => c[0] === "vault.funded");
+    expect(fundedCall).toBeUndefined();
+  });
 });
 
 // ── Standalone event parser tests ──────────────────────────────────────────────

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -20,6 +20,19 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Parse a NUMERIC column (returned by pg as a string) into a bigint. Asset
+// amounts are stored as integers; any fractional part is truncated and
+// null/invalid values fall back to 0 so callers never throw.
+function toBigIntOrZero(value: string | null | undefined): bigint {
+  if (value == null) return 0n;
+  const integerPart = value.split(".")[0];
+  try {
+    return BigInt(integerPart || "0");
+  } catch {
+    return 0n;
+  }
+}
+
 function getEventTopics(rawEvent: any): unknown[] | null {
   const topics = rawEvent?.topic ?? rawEvent?.topics;
   return Array.isArray(topics) ? topics : null;
@@ -550,15 +563,51 @@ export class Indexer {
          updated_at = NOW()`,
       [deposit.receiver, deposit.shares.toString(), deposit.assets.toString(), contractId],
     );
+
+    // Read the funding target and the total assets prior to this deposit so we
+    // can detect when the deposit pushes the vault across its funding goal (#659).
+    const vaultRows = await query<{ total_assets: string | null; funding_target: string | null }>(
+      "SELECT total_assets, funding_target FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    const prevTotalAssets = toBigIntOrZero(vaultRows[0]?.total_assets);
+    const fundingTarget =
+      vaultRows[0]?.funding_target != null ? toBigIntOrZero(vaultRows[0].funding_target) : null;
+    const newTotalAssets = prevTotalAssets + deposit.assets;
+
     await query(
-      `UPDATE vaults SET total_shares_ever_minted = total_shares_ever_minted + $1 WHERE contract_id = $2`,
-      [deposit.shares.toString(), contractId],
+      `UPDATE vaults
+       SET total_assets = $1,
+           total_shares_ever_minted = total_shares_ever_minted + $2
+       WHERE contract_id = $3`,
+      [newTotalAssets.toString(), deposit.shares.toString(), contractId],
     );
     await this.recordTvlSnapshot(contractId);
     logger.info(
       { contractId, receiver: deposit.receiver, shares: deposit.shares.toString() },
       "Processed deposit event",
     );
+
+    // Fire vault.funded once, only on the deposit that crosses the threshold:
+    // previously below the target and now at or above it. Subsequent deposits
+    // that keep the vault above target leave prevTotalAssets >= target, so the
+    // event does not fire again (#659).
+    if (
+      fundingTarget != null &&
+      fundingTarget > 0n &&
+      prevTotalAssets < fundingTarget &&
+      newTotalAssets >= fundingTarget
+    ) {
+      try {
+        await this.notificationService?.notify("vault.funded", {
+          contractId,
+          totalAssets: newTotalAssets.toString(),
+          fundingTarget: fundingTarget.toString(),
+        });
+      } catch (e) {
+        logger.warn({ err: e }, "NotificationService.notify failed for vault.funded");
+      }
+    }
   }
 
   private async handleWithdraw(


### PR DESCRIPTION
## Description

This PR bundles four small backend observability / data-layer improvements:

- **#656 — Composite index for holder queries.** Adds `uvp_vault_shares_idx` on `user_vault_positions (vault_id, shares DESC)` to migration `021_vault_sort_indexes.sql`. This backs `GET /api/v1/vaults/:contractId/holders?sort=shares`, which previously required a full scan of `user_vault_positions` to satisfy the `shares DESC` sort.
- **#657 — Pool stats in `/health`.** Adds a `dbPool` object `{ total, idle, waiting }` to the `GET /health` response, sourced from the node-postgres `pool.totalCount` / `pool.idleCount` / `pool.waitingCount` counters. `dbPool.total` reflects `DB_POOL_MAX`; `dbPool.waiting > 0` signals pool pressure. The object is returned on both the healthy and unhealthy (503) paths.
- **#658 — Slow query logging.** Adds a `DB_SLOW_QUERY_MS` env var (default `500`). In the `query()` wrapper, queries whose duration exceeds the threshold are logged at `warn` level with the full SQL, params count, and duration; faster queries keep their existing `debug`-level logging.
- **#659 — `vault.funded` webhook.** When the indexer applies a deposit, it compares the vault's total assets before and after the deposit against `funding_target` and fires `notify("vault.funded", { contractId, totalAssets, fundingTarget })` only on the deposit that crosses the threshold. Subsequent deposits that keep the vault above target do not re-fire the event.

Closes #656
Closes #657
Closes #658
Closes #659

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Performance improvement

## Testing

- Added unit tests for the `vault.funded` crossing behaviour in `indexer.test.ts`: one asserting the event fires when a deposit crosses the funding target, and one asserting it does not fire when a deposit keeps an already-funded vault above target.
- ESLint passes on the changed files (`config.ts`, `db/index.ts`, `health.ts`).

> Note: `main` currently contains several pre-existing truncated/corrupted source and test files (e.g. unbalanced braces in `services/indexer.ts`, `api/controllers/users.ts`, `api/routes/users.ts`, and `services/indexer.test.ts`) that prevent a full `tsc`/`vitest` run repo-wide. These are unrelated to this PR and were left untouched. The changes here are scoped and self-consistent, and will be exercised by the test suite once that pre-existing breakage is resolved.

## Security Considerations

No access-control or fund-flow changes. `DB_SLOW_QUERY_MS` slow-query logging includes full SQL at `warn` level; parameter *values* are not logged (only the params count), consistent with the existing query logger.

## Reviewer Focus Areas

- The `vault.funded` crossing logic in `handleDeposit` (threshold detection using before/after totals; ensuring single-fire semantics).
- Whether incrementing `total_assets` on deposit in the indexer is acceptable alongside the absolute value set by `upsertVault` (the absolute chain sync corrects any drift).
