### PR TITLE
feat: add operator activity log endpoint

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -999,6 +999,26 @@ export async function getVaultOperators(req: Request, res: Response, next: NextF
     next(err);
   }
 }
+
+/**
+ * GET /api/v1/vaults/:contractId/operators/log
+ *
+ * Returns a chronological history of operator additions and removals
+ * for a vault, sourced from indexed_events. Empty logs return [].
+ */
+export async function getOperatorLog(req: Request, res: Response, next: NextFunction) {
+  try {
+    const contractId = String(req.params["contractId"]);
+    const page = Math.max(1, parseInt(String(req.query["page"] ?? "1"), 10) || 1);
+    const pageSize = Math.min(100, Math.max(1, parseInt(String(req.query["pageSize"] ?? "20"), 10) || 20));
+
+    const result = await vaultService.getOperatorLog(contractId, page, pageSize);
+    setCacheHeaders(res);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
 /**
  * GET /api/v1/vaults/maturing-soon?days=30
  *

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -17,6 +17,7 @@ import {
   getEarlyRedemptionFee,
   exportVaultCsv,
   getVaultOperators,
+  getOperatorLog,
   getCompoundProjection,
   getVaultAnnualReport,
   getEpochBreakdown,
@@ -129,6 +130,8 @@ vaultsRouter.get(
 vaultsRouter.get("/:contractId/export.csv", validateParams(vaultParamsSchema), exportVaultCsv);
 // Operators list: GET /api/v1/vaults/:contractId/operators
 vaultsRouter.get("/:contractId/operators", validateParams(vaultParamsSchema), getVaultOperators);
+// Operator activity log: GET /api/v1/vaults/:contractId/operators/log
+vaultsRouter.get("/:contractId/operators/log", validateParams(vaultParamsSchema), getOperatorLog);
 // Vault detail: GET /api/v1/vaults/:contractId
 vaultsRouter.get("/:contractId", validateParams(vaultParamsSchema), getVault);
 // Annual vault performance report: GET /api/v1/vaults/:contractId/report?year=2025

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -1,14 +1,8 @@
-import type { Vault, VaultOperator, UserVaultPosition, PaginatedResponse } from "../types/index.js";
-import type {
-  Vault,
-  UserVaultPosition,
-  PaginatedResponse,
-  VaultHolder,
-  VaultHolderSort,
-} from "../types/index.js";
+import type { Vault, VaultOperator, UserVaultPosition, PaginatedResponse, VaultHolder, VaultHolderSort, OperatorLogEntry } from "../types/index.js";
 import { query } from "../db/index.js";
 import { logger } from "../logger.js";
 import { cacheGet, cacheSet, cacheDel } from "../cache/redis.js";
+import { xdr, scValToNative } from "@stellar/stellar-sdk";
 
 const TTL_BY_STATE: Record<string, number> = {
   Active: 10,
@@ -730,6 +724,76 @@ export class VaultService {
       assignedAt: row.assigned_at.toISOString(),
     }));
   }
+
+  async getOperatorLog(
+    contractId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<PaginatedResponse<OperatorLogEntry>> {
+    const offset = (page - 1) * pageSize;
+
+    const countResult = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count
+       FROM indexed_events
+       WHERE contract_id = $1 AND event_type IN ('op_add', 'op_rem')`,
+      [contractId],
+    );
+    const total = parseInt(countResult[0]?.count ?? "0", 10);
+
+    const rows = await query<{
+      ledger: number;
+      event_type: string;
+      payload: Record<string, unknown>;
+      created_at: Date;
+    }>(
+      `SELECT ledger, event_type, payload, created_at
+       FROM indexed_events
+       WHERE contract_id = $1 AND event_type IN ('op_add', 'op_rem')
+       ORDER BY created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [contractId, pageSize, offset],
+    );
+
+    const data: OperatorLogEntry[] = rows.map((row) => {
+      const payload = row.payload;
+      const topics = (payload["topic"] ?? payload["topics"]) as unknown[] | undefined;
+      const callerAddress = Array.isArray(topics) && topics.length >= 2
+        ? extractAddressFromScVal(topics[1])
+        : "";
+      const operatorAddress = Array.isArray(topics) && topics.length >= 3
+        ? extractAddressFromScVal(topics[2])
+        : "";
+
+      let timestamp: string;
+      const ledgerClosedAt = payload["ledgerClosedAt"];
+      if (typeof ledgerClosedAt === "string") {
+        timestamp = ledgerClosedAt;
+      } else {
+        timestamp = row.created_at.toISOString();
+      }
+
+      return {
+        operatorAddress,
+        action: row.event_type === "op_add" ? "added" : "removed",
+        callerAddress,
+        ledger: row.ledger,
+        timestamp,
+      };
+    });
+
+    return { data, total, page, pageSize };
+  }
+}
+
+function extractAddressFromScVal(topic: unknown): string {
+  if (typeof topic === "string") {
+    try {
+      return String(scValToNative(xdr.ScVal.fromXDR(topic, "base64")));
+    } catch {
+      return "";
+    }
+  }
+  return "";
 }
 
   // ── Issue #640 / #646: Combined search with optional fuzzy matching ──────────

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -137,3 +137,11 @@ export interface KycHistoryEntry {
   ledger: number;
   timestamp: string;
 }
+
+export interface OperatorLogEntry {
+  operatorAddress: string;
+  action: "added" | "removed";
+  callerAddress: string;
+  ledger: number;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/vaults/:contractId/operators/log` to return a chronological history of operator additions and removals for a vault, sourced from `indexed_events`.

Closes #600
Closes #601 
Closes #602 
Closes #603 

## Changes

- **`backend/src/types/index.ts`** — Add `OperatorLogEntry` interface (`operatorAddress`, `action`, `callerAddress`, `ledger`, `timestamp`)
- **`backend/src/services/vault.ts`** — Add `getOperatorLog()` method to `VaultService` that queries `indexed_events` for `op_add`/`op_rem` events, parses XDR topics via `@stellar/stellar-sdk` to extract caller/operator addresses, and returns paginated results
- **`backend/src/api/controllers/vaults.ts`** — Add `getOperatorLog` controller with `page` + `pageSize` query params (max 100)
- **`backend/src/api/routes/vaults.ts`** — Wire up `GET /:contractId/operators/log` route with Zod param validation

## Acceptance criteria

- [x] Returns events in reverse chronological order (`ORDER BY created_at DESC`)
- [x] Empty log returns `{ data: [], total: 0, page, pageSize }`, not 404
- [x] Paginated with `page` + `pageSize` (default 20, max 100)
- [x] Each entry includes `operatorAddress`, `action` ("added" | "removed"), `callerAddress`, `ledger`, `timestamp`