### PR TITLE
feat(stellar): add read functions for vault metadata

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { VaultService } from "../../services/vault.js";
-import { readTotalAssets, readVaultState } from "../../services/stellar.js";
+import { readTotalAssets, readVaultState, readPaused } from "../../services/stellar.js";
 import { query } from "../../db/index.js";
 
 const vaultService = new VaultService();
@@ -113,8 +113,10 @@ export async function getVault(req: Request, res: Response, next: NextFunction) 
 
 export async function getVaultLiveState(req: Request, res: Response) {
   try {
-    const state = await readVaultState(String(req.params["contractId"]));
-    res.json({ state });
+    const contractId = String(req.params["contractId"]);
+    const state = await readVaultState(contractId);
+    const paused = await readPaused(contractId);
+    res.json({ state, paused });
   } catch (_err) {
     res.status(500).json({
       error: "RpcError",

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -227,3 +227,47 @@ export async function readEpochData(
     timestamp: BigInt(raw.timestamp ?? raw[2] ?? 0n),
   };
 }
+
+/**
+ * Read the paused state of the vault.
+ * Returns true if the vault is paused, false if it is active.
+ *
+ * Closes #685
+ */
+export async function readPaused(contractId: string): Promise<boolean> {
+  const value = await simulateRead<boolean>(contractId, "is_paused");
+  return Boolean(value);
+}
+
+/**
+ * Read the cooperator address for the vault.
+ * Returns a Stellar address string.
+ *
+ * Closes #686
+ */
+export async function readCooperator(contractId: string): Promise<string> {
+  const raw = await simulateRead<string | Record<string, unknown>>(contractId, "cooperator");
+  return typeof raw === "string" ? raw : String(Object.values(raw)[0] ?? "");
+}
+
+/**
+ * Read the minimum deposit amount for the vault.
+ * Returns 0n if no minimum is set, or the minimum amount as a bigint.
+ *
+ * Closes #687
+ */
+export async function readMinDeposit(contractId: string): Promise<bigint> {
+  const value = await simulateRead<bigint>(contractId, "min_deposit");
+  return BigInt(value ?? 0n);
+}
+
+/**
+ * Read the operator approval threshold for multi-sig operations.
+ * Returns the current threshold as a number.
+ *
+ * Closes #684
+ */
+export async function readOperatorThreshold(contractId: string): Promise<number> {
+  const value = await simulateRead<number>(contractId, "operator_threshold");
+  return Number(value ?? 0);
+}


### PR DESCRIPTION
## What
Add four new read functions to stellar.ts for reading vault metadata from the Soroban contract, and wire the paused state into the live state API endpoint.

## Issues Resolved
Closes #684
Closes #685
Closes #686
Closes #687

## Changes

### #684 - Add `readOperatorThreshold` to `stellar.ts`
Added readOperatorThreshold function that returns the current operator approval threshold integer for multi-sig operations.

### #685 - Add `readPaused` to `stellar.ts`
Added readPaused function that returns true if vault is paused, false if active. Wired into GET /api/v1/vaults/:contractId/state/live endpoint response as paused field.

### #686 - Add `readCooperator` to `stellar.ts`
Added readCooperator function that returns the Stellar address string of the current cooperator.

### #687 - Add `readMinDeposit` to `stellar.ts`
Added readMinDeposit function that returns the minimum deposit amount as bigint, or 0n if no minimum is set.