### PR TITLE
Add readVaultName to stellar.ts

### DIFF
--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -298,3 +298,25 @@ export async function readEarlyRedemptionFeeBps(contractId: string): Promise<num
   const value = await simulateRead<number>(contractId, "early_redemption_fee_bps");
   return Number(value ?? 0);
 }
+
+/**
+ * Read the funding deadline timestamp (unix seconds) from the contract.
+ * Returns 0n when no deadline is configured.
+ */
+export async function readFundingDeadline(contractId: string): Promise<bigint> {
+  const value = await simulateRead<bigint | number>(contractId, "funding_deadline");
+  const result = BigInt(value ?? 0n);
+  if (result < 0n) {
+    throw new Error(`readFundingDeadline: unexpected negative value ${result}`);
+  }
+  return result;
+}
+
+/**
+ * Read the vault name (share token name) from the contract.
+ * Returns a string representing the share token name.
+ */
+export async function readVaultName(contractId: string): Promise<string> {
+  const raw = await simulateRead<string | Record<string, unknown>>(contractId, "name");
+  return typeof raw === "string" ? raw : String(Object.values(raw)[0] ?? "");
+}

--- a/soroban-contracts/contracts/vault_factory/src/tests.rs
+++ b/soroban-contracts/contracts/vault_factory/src/tests.rs
@@ -1360,3 +1360,18 @@ fn test_list_recent_vaults_returns_newest_first() {
     assert_eq!(all_recent.get(2).unwrap(), v3);
     assert_eq!(all_recent.get(3).unwrap(), v2);
 }
+
+#[test]
+fn test_default_operator_fee_bps_returns_constructor_default() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (factory_id, _) = setup_factory(&e);
+    let client = VaultFactoryClient::new(&e, &factory_id);
+
+    assert_eq!(
+        client.default_operator_fee_bps(),
+        200u32,
+        "default_operator_fee_bps must return 200 (2%) as set in the constructor"
+    );
+}


### PR DESCRIPTION

Added two new read functions to backend/src/services/stellar.ts:309-329:
- readFundingDeadline(contractId) — simulates funding_deadline (u64) and returns a bigint (0n when unset).
- readVaultName(contractId) — simulates name and returns the share-token name string.

Both follow the existing patterns: readFundingDeadline mirrors readFundingTarget (non-negative bigint guard), and readVaultName mirrors readVaultSymbol (string-or-enum-shaped decoding).


closes #680
closes #682