### PR TITLE
Document vault lifecycle

### DIFF
--- a/backend/docs/events.md
+++ b/backend/docs/events.md
@@ -1,0 +1,49 @@
+# Indexer Event Reference
+
+Reference for every on-chain event parser in [`services/indexer.ts`](../src/services/indexer.ts).
+`Indexer.processEvent()` tries each parser in order against the raw Soroban event; the first
+match wins, the event is persisted to `indexed_events`, and any associated DB writes / webhook
+notifications fire. Topic values are the `symbol` in `topics[0]` the parser matches on.
+
+| Topic | Parser Function | DB Effect | Webhook Fired |
+|---|---|---|---|
+| `deposit` | `parseDepositEvent` | Upserts `user_vault_positions` (shares/deposited +=), updates `vaults.total_assets`/`total_shares_ever_minted`, inserts `vault_tvl_snapshots` | `user.deposit`; `vault.funded` once when the deposit crosses `funding_target` |
+| `withdraw` | `parseWithdrawEvent` | Decrements `user_vault_positions` (floored at 0), updates `vaults.total_shares_ever_burned`, inserts `vault_tvl_snapshots` | `user.withdraw` |
+| `yield_dis` | `parseYieldDistributedEvent` | Inserts `epochs` row, `vault_tvl_snapshots`, and one `share_balance_snapshots` row per active shareholder | `yield_distributed` |
+| `st_chg` / `vault_state_changed` | `parseVaultStateChangedEvent` | Updates `vaults.state` | `vault_state_changed`; also `vault.matured` when `newState === "Matured"` |
+| `fund_cxl` / `funding_cancelled` / `cancel_funding` | `parseCancelFundingEvent` | `VaultService.upsertVault` sets `vaults.state = 'Cancelled'` | `cancel_funding`; `vault.cancelled` |
+| `v_create` / `vault_created` | `parseVaultCreatedEvent` | `VaultService.upsertVault` inserts the new `vaults` row (state `Funding`), fetches RWA metadata via RPC | `vault_created` |
+| `v_rem` / `vault_removed` | `parseVaultRemovedEvent` | Sets `vaults.archived = TRUE` (soft delete) | none |
+| `op_add` | `parseOperatorAddedEvent` (alias: `parseOpAddEvent`) | Upserts `vault_operators`, clearing `removed_at`/`removed_by` | none |
+| `op_rem` | `parseOperatorRemovedEvent` (alias: `parseOpRemEvent`) | Upserts `vault_operators` with `removed_at = NOW()` | none |
+| `role_grt` | `parseRoleGrantedEvent` | Upserts `vault_roles`, clearing `revoked_at` | none |
+| `role_rvk` | `parseRoleRevokedEvent` | Updates `vault_roles.revoked_at = NOW()` for the active grant | none |
+| `erq_req` / `request_early_redemption` | `parseRequestEarlyRedemptionEvent` | Inserts/updates `redemption_requests` | `user.early_redemption_requested` |
+| `yield_clm` | `parseYieldClaimedEvent` | Bumps `user_vault_positions.last_claimed_epoch`, invalidates `pending-yield:*` cache | none |
+| `prt_yld` | `parseYieldClaimedPartialEvent` | Same as `yield_clm` (shares the `handleYieldClaimed` handler) | none |
+| `erq_done` / `early_redemption_processed` | `parseEarlyRedemptionProcessedEvent` | Sets `redemption_requests.processed = TRUE` | none |
+| `erq_can` / `erq_can2` / `early_redemption_cancelled` | `parseEarlyRedemptionCancelledEvent` | Sets `redemption_requests.processed = TRUE` | none |
+| `zkme_upd` | `parseZkmeVerifierUpdatedEvent` | Updates `vaults.zkme_verifier_address` | none |
+| `kyc_set` | `parseKycSetEvent` | `UserService.upsertUser`, inserts an `indexed_events` row directly (bypasses `recordEvent`) | none |
+| `paused` / `v_pause` | `parsePausedEvent` | Sets `vaults.paused = TRUE` | none |
+| `unpaused` / `v_unpause` | `parseUnpausedEvent` | Sets `vaults.paused = FALSE` | none |
+| `kyc_set` | `parseKycVerifiedEvent` | `UserService.upsertUser` (dead branch in practice — `parseKycSetEvent` matches `kyc_set` first and returns) | none |
+
+## Parsers not wired into `processEvent`
+
+These are exported for unit testing / historical compatibility but are not called from
+`Indexer.processEvent()` directly:
+
+- `parseEarlyRedemptionRequestedEvent` (topic `erq_req`) — superseded by `parseRequestEarlyRedemptionEvent`.
+- `parseOpAddEvent` / `parseOpRemEvent` — thin aliases around `parseOperatorAddedEvent` / `parseOperatorRemovedEvent`.
+
+## Adding a new event parser
+
+1. Add a `parse<EventName>Event(rawEvent: unknown): Parsed<EventName>Event | null` function that
+   matches on `topics[0]` and returns `null` for any other event (parsers are tried in sequence
+   and must not throw).
+2. Add a `handle<EventName>` method on `Indexer` for the DB write, and call it — plus
+   `this.recordEvent(event, "<event_type>")` — from a new branch in `processEvent()`.
+3. If subscribers should be notified, call `this.notificationService?.notify("<webhook.name>", ...)`
+   and add the event to [`webhooks.md`](./webhooks.md).
+4. Add a row to the table above.

--- a/backend/docs/vault-states.md
+++ b/backend/docs/vault-states.md
@@ -1,0 +1,47 @@
+# Vault Lifecycle States
+
+A vault's on-chain `VaultState` (`get_vault()` / `state` field) gates which contract
+operations are permitted. The indexer mirrors this into `vaults.state` and re-emits it as
+the `vault_state_changed` webhook (see [`webhooks.md`](./webhooks.md)).
+
+## States
+
+| State | Meaning |
+|---|---|
+| `Funding` | Raising capital toward `funding_target`; deposits accepted. |
+| `Active` | Fully funded, RWA investment live, yield accrues. |
+| `Matured` | Investment period ended; full redemptions enabled. |
+| `Cancelled` | Funding deadline passed without meeting target; refunds available. |
+| `Emergency` | Emergency mode; users claim a pro-rata share of remaining assets. |
+| `Closed` | Terminal, admin-only archival state after `total_supply` reaches 0. |
+
+## Transitions
+
+| From | To | Trigger (contract fn) | Who | Webhook(s) fired |
+|---|---|---|---|---|
+| — | `Funding` | `__constructor` | — (vault deployment) | `vault_created` |
+| `Funding` | `Active` | `activate_vault` | operator/admin, once funded | `vault_state_changed` |
+| `Funding` | `Cancelled` | `cancel_funding` | LifecycleManager role, only after the funding deadline passes with target unmet | `vault_state_changed`, `cancel_funding`, `vault.cancelled` |
+| `Active` | `Matured` | `mature_vault` | operator/admin | `vault_state_changed`, `vault.matured` |
+| `Matured` | `Closed` | `close_vault` | admin, only when `total_supply == 0` | `vault_state_changed` |
+| any state | `Emergency` | `emergency_enable_pro_rata` | emergency multisig signers | `vault_state_changed` |
+
+`Cancelled`, `Emergency`, and `Closed` are terminal — no contract function transitions a
+vault back out of them.
+
+## Allowed operations per state
+
+| Operation | Funding | Active | Matured | Cancelled | Emergency | Closed |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| `deposit` / `mint` | ✅ (capped at `funding_target`) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `withdraw` / `redeem` | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| `redeem_at_maturity` | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `request_early_redemption` / `process_early_redemption` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `distribute_yield` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `refund` | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `emergency_claim` | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+
+So: **a deposit is only allowed while the vault is in `Funding` or `Active`** — any other
+state (including `Matured`, `Cancelled`, `Emergency`, `Closed`) rejects it via
+`require_active_or_funding`. Read-only API endpoints (`GET /vaults/:contractId`, etc.) are
+available regardless of state.

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -99,6 +99,28 @@ function mapVaultRow(row: VaultRow): Vault {
 }
 
 export class VaultService {
+  /**
+   * List non-archived vaults with optional filtering, sorting, and pagination.
+   * Results are cached (TTL depends on `state`, see `TTL_BY_STATE`) keyed by
+   * the full options object.
+   *
+   * Supports two mutually-driven pagination modes: page/offset (default) and
+   * cursor-based (when `opts.cursor` is set, `total` is not computed — cursor
+   * pagination is meant for cheap infinite-scroll, not page counts).
+   *
+   * @param opts.page - 1-indexed page number, used when `cursor` is not set.
+   * @param opts.pageSize - Number of vaults per page/batch.
+   * @param opts.state - Optional exact-match filter on vault state (e.g. "Active").
+   * @param opts.category - Optional exact-match filter on `rwa_category`.
+   * @param opts.cursor - Optional base64url-encoded `{ id, created_at }` cursor from a
+   *   previous response's `nextCursor`. When present, switches to cursor-based pagination.
+   * @param opts.sort - Column to sort by: "created_at" or "total_assets".
+   * @param opts.order - Sort direction: "asc" or "desc".
+   * @param opts.q - Forwarded from the controller but unused here; text search is
+   *   handled by `searchVaults` instead.
+   * @returns A page of vaults plus `total` (0 when cursor-paginated), `page`,
+   *   `pageSize`, and `nextCursor` (null when there is no further page).
+   */
   async listVaults(opts: ListVaultsOptions): Promise<PaginatedResponse<Vault>> {
     const cacheKey = `vaults:list:${JSON.stringify(opts)}`;
     const cached = await cacheGet<PaginatedResponse<Vault>>(cacheKey);
@@ -247,6 +269,11 @@ export class VaultService {
     return result;
   }
 
+  /**
+   * Count non-archived vaults.
+   *
+   * @returns The total number of vaults where `archived = FALSE`.
+   */
   async countVaults(): Promise<number> {
     const countResult = await query<{ count: string }>(
       "SELECT COUNT(*) as count FROM vaults WHERE archived = FALSE",
@@ -308,6 +335,16 @@ export class VaultService {
     return rows.map(mapVaultRow);
   }
 
+  /**
+   * Fetch a single vault by its on-chain contract address, including a live
+   * depositor count. Results are cached under `vault:{contractId}` with a
+   * TTL that depends on the vault's state (see `TTL_BY_STATE`).
+   *
+   * @param contractId - The vault's Stellar contract address (e.g. `CBQHN...`).
+   * @returns The matching `Vault`, or `null` if no vault exists with that
+   *   `contractId` (archived vaults are still returned — this method does not
+   *   filter on `archived`).
+   */
   async getVault(contractId: string): Promise<Vault | null> {
     const cacheKey = `vault:${contractId}`;
     const cached = await cacheGet<Vault>(cacheKey);
@@ -338,6 +375,16 @@ export class VaultService {
     return vault;
   }
 
+  /**
+   * List every user's share position in a vault, most shares first.
+   * Unlike `listVaultHolders`, this is not paginated and includes positions
+   * with zero shares (e.g. users who have fully withdrawn).
+   *
+   * @param contractId - The vault's Stellar contract address.
+   * @returns All `UserVaultPosition` rows for the vault, sorted by `shares`
+   *   descending. Returns an empty array if the vault does not exist or has
+   *   no recorded positions.
+   */
   async getVaultPositions(contractId: string): Promise<UserVaultPosition[]> {
     const rows = await query<{
       id: number;
@@ -463,6 +510,52 @@ export class VaultService {
     }));
   }
 
+  /**
+   * Insert a new vault or update an existing one (matched by `contractId`),
+   * then invalidate its cache entries. Called by the indexer when it observes
+   * `vault_created` (insert) or a subsequent state/asset-changing event
+   * (partial update).
+   *
+   * On conflict, `state`, `totalAssets`, and `totalSupply` are always
+   * overwritten with the given values, while the RWA/funding metadata fields
+   * (`fundingTarget`, `fundingDeadline`, `minDeposit`, `maxDepositPerUser`,
+   * `rwaName`, `rwaSymbol`, `rwaDocumentUri`, `rwaCategory`) are only
+   * overwritten when the incoming value is non-null — passing a partial
+   * update will not clear previously stored metadata for fields you omit.
+   * Any field not listed above (e.g. `name`, `symbol`, `asset`, `factoryId`)
+   * is only ever set on insert and defaults as noted below.
+   *
+   * @param vault.contractId - Required. The vault's Stellar contract address;
+   *   the conflict key for the upsert.
+   * @param vault.factoryId - Defaults to `null` on insert.
+   * @param vault.asset - Defaults to `""` on insert.
+   * @param vault.name - Defaults to `null` on insert.
+   * @param vault.symbol - Defaults to `null` on insert.
+   * @param vault.state - Vault lifecycle state; defaults to `"Funding"` on
+   *   insert and is always overwritten on update.
+   * @param vault.totalAssets - Defaults to `"0"` on insert and is always
+   *   overwritten on update.
+   * @param vault.totalSupply - Defaults to `"0"` on insert and is always
+   *   overwritten on update.
+   * @param vault.fundingTarget - Only applied if non-null; existing value is
+   *   preserved otherwise.
+   * @param vault.fundingDeadline - Only applied if non-null; existing value
+   *   is preserved otherwise.
+   * @param vault.minDeposit - Only applied if non-null; existing value is
+   *   preserved otherwise.
+   * @param vault.maxDepositPerUser - Only applied if non-null; existing value
+   *   is preserved otherwise.
+   * @param vault.rwaName - Only applied if non-null; existing value is
+   *   preserved otherwise.
+   * @param vault.rwaSymbol - Only applied if non-null; existing value is
+   *   preserved otherwise.
+   * @param vault.rwaDocumentUri - Only applied if non-null; existing value is
+   *   preserved otherwise.
+   * @param vault.rwaCategory - Only applied if non-null; existing value is
+   *   preserved otherwise.
+   * @returns Resolves once the row is written and the `vault:{contractId}`
+   *   and `vaults:list:*` cache entries have been invalidated.
+   */
   async upsertVault(vault: Partial<Vault> & { contractId: string }): Promise<void> {
     const {
       contractId,


### PR DESCRIPTION

- JSDoc: Added detailed @param/@returns/behavioral notes to listVaults, getVault, getVaultPositions, upsertVault, and countVaults in backend/src/services/vault.ts.
- backend/docs/events.md: New reference table covering all 20 event parsers in indexer.ts (topic → parser → DB effect → webhook), plus a note on the two parsers exported but not wired into processEvent, and a short guide for adding new ones.
- backend/docs/vault-states.md (47 lines): States table, transition table (trigger fn, caller, webhooks fired — cross-referenced against the Soroban contract's require_state checks), and an allowed-operations-per-state matrix answering the deposit question directly.|




closes #701
closes #700
closes #699
closes #698