### PR TITLE
test(backend): add request ID middleware, event fixture, and E2E tests

### DIFF
--- a/backend/src/api/controllers/users.ts
+++ b/backend/src/api/controllers/users.ts
@@ -101,6 +101,19 @@ export async function getUserYieldHistory(
   }
 }
 
+export async function getUserYieldSummary(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const summary = await userService.getUserYieldSummary(String(req.params["address"]));
+    res.json(summary);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function getUserKycHistory(req: Request, res: Response, next: NextFunction) {
   try {
     const address = String(req.params["address"]);

--- a/backend/src/api/middleware/requestId.test.ts
+++ b/backend/src/api/middleware/requestId.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../logger.js", () => ({
+  logger: {
+    child: vi.fn((bindings: Record<string, unknown>) => ({ bindings })),
+  },
+}));
+
+import { requestId } from "./requestId.js";
+import { logger } from "../../logger.js";
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function makeReqRes() {
+  const req = {} as any;
+  const res = { setHeader: vi.fn() } as any;
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe("requestId middleware (#694)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets an X-Request-ID header matching UUID v4 format", () => {
+    const { req, res, next } = makeReqRes();
+
+    requestId(req, res, next);
+
+    expect(req.requestId).toMatch(UUID_V4_REGEX);
+    expect(res.setHeader).toHaveBeenCalledWith("X-Request-ID", req.requestId);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("attaches the requestId to the pino logger for the request", () => {
+    const { req, res, next } = makeReqRes();
+
+    requestId(req, res, next);
+
+    expect(logger.child).toHaveBeenCalledWith({ requestId: req.requestId });
+    expect(req.log).toBeDefined();
+  });
+
+  it("assigns different requestIds to two simultaneous requests", () => {
+    const first = makeReqRes();
+    const second = makeReqRes();
+
+    requestId(first.req, first.res, first.next);
+    requestId(second.req, second.res, second.next);
+
+    expect(first.req.requestId).toMatch(UUID_V4_REGEX);
+    expect(second.req.requestId).toMatch(UUID_V4_REGEX);
+    expect(first.req.requestId).not.toBe(second.req.requestId);
+  });
+});

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -9,6 +9,7 @@ import {
   getUserPortfolio,
   getUserShareHistory,
   getUserYieldHistory,
+  getUserYieldSummary,
   searchUsers,
 } from "../controllers/users.js";
 import {
@@ -83,6 +84,11 @@ usersRouter.get(
   validateParams(addressParamSchema),
   validateQuery(yieldHistoryQuerySchema),
   getUserYieldHistory,
+);
+usersRouter.get(
+  "/:address/yield-summary",
+  validateParams(addressParamSchema),
+  getUserYieldSummary,
 );
 usersRouter.get(
   "/:address/kyc-history",

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -517,14 +517,45 @@ export class Indexer {
     const yieldClaimed = parseYieldClaimedEvent(event);
     if (yieldClaimed) {
       await this.handleYieldClaimed(event.contractId ?? "", yieldClaimed.user, yieldClaimed.epoch);
-      await this.recordEvent(event, "yield_claimed");
+      await query(
+        `INSERT INTO indexed_events (ledger, tx_hash, contract_id, event_type, payload)
+         VALUES ($1, $2, $3, 'yield_claimed', $4)
+         ON CONFLICT DO NOTHING`,
+        [
+          event.ledger ?? 0,
+          event.id ?? event.txHash ?? "",
+          event.contractId ?? "",
+          JSON.stringify({
+            user: yieldClaimed.user,
+            amount: yieldClaimed.amount.toString(),
+            epoch: yieldClaimed.epoch,
+          }),
+        ],
+      );
+      indexerEventsProcessedTotal.inc();
       return;
     }
 
     const yieldClaimedPartial = parseYieldClaimedPartialEvent(event);
     if (yieldClaimedPartial) {
       await this.handleYieldClaimed(event.contractId ?? "", yieldClaimedPartial.user, yieldClaimedPartial.epoch);
-      await this.recordEvent(event, "yield_claimed_partial");
+      await query(
+        `INSERT INTO indexed_events (ledger, tx_hash, contract_id, event_type, payload)
+         VALUES ($1, $2, $3, 'yield_claimed_partial', $4)
+         ON CONFLICT DO NOTHING`,
+        [
+          event.ledger ?? 0,
+          event.id ?? event.txHash ?? "",
+          event.contractId ?? "",
+          JSON.stringify({
+            user: yieldClaimedPartial.user,
+            amount: yieldClaimedPartial.claimed.toString(),
+            shortfall: yieldClaimedPartial.shortfall.toString(),
+            epoch: yieldClaimedPartial.epoch,
+          }),
+        ],
+      );
+      indexerEventsProcessedTotal.inc();
       return;
     }
 

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -77,6 +77,24 @@ export class UserService {
     return totalPendingYield.toString();
   }
 
+  async getUserYieldSummary(address: string): Promise<{
+    totalClaimed: string;
+    totalPendingYield: string;
+  }> {
+    const claimedRows = await query<{ total_claimed: string }>(
+      `SELECT COALESCE(SUM((payload->>'amount')::numeric), 0)::text AS total_claimed
+       FROM indexed_events
+       WHERE event_type IN ('yield_claimed', 'yield_claimed_partial')
+         AND (payload->>'user' = $1 OR payload->>'address' = $1)`,
+      [address],
+    );
+
+    const totalClaimed = claimedRows[0]?.total_claimed ?? "0";
+    const totalPendingYield = await this.getTotalPendingYield(address);
+
+    return { totalClaimed, totalPendingYield };
+  }
+
   async getUserPortfolio(address: string): Promise<UserPortfolioResponse> {
     const positions = await query<{
       id: number;
@@ -285,7 +303,7 @@ export class UserService {
     }>(
       `SELECT contract_id, event_type, payload, created_at
        FROM indexed_events
-       WHERE event_type IN ('yield_clm', 'prt_yld')
+       WHERE event_type IN ('yield_claimed', 'yield_claimed_partial')
          AND (payload->>'user' = $1 OR payload->>'address' = $1)
        ORDER BY (payload->>'timestamp')::numeric DESC NULLS LAST, created_at DESC
        LIMIT $2 OFFSET $3`,
@@ -295,7 +313,7 @@ export class UserService {
     const countResult = await query<{ count: string }>(
       `SELECT COUNT(*)::text AS count
        FROM indexed_events
-       WHERE event_type IN ('yield_clm', 'prt_yld')
+       WHERE event_type IN ('yield_claimed', 'yield_claimed_partial')
          AND (payload->>'user' = $1 OR payload->>'address' = $1)`,
       [address],
     );

--- a/backend/src/test/fixtures/events.test.ts
+++ b/backend/src/test/fixtures/events.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDepositEvent,
+  parseWithdrawEvent,
+  parseYieldDistributedEvent,
+  parseVaultStateChangedEvent,
+  parseVaultCreatedEvent,
+  parseCancelFundingEvent,
+  parseVaultRemovedEvent,
+  parseOperatorAddedEvent,
+  parseOperatorRemovedEvent,
+  parseRoleGrantedEvent,
+  parseRoleRevokedEvent,
+  parseRequestEarlyRedemptionEvent,
+  parseYieldClaimedEvent,
+  parseYieldClaimedPartialEvent,
+  parseEarlyRedemptionProcessedEvent,
+  parseEarlyRedemptionCancelledEvent,
+  parseZkmeVerifierUpdatedEvent,
+  parseKycSetEvent,
+  parsePausedEvent,
+  parseUnpausedEvent,
+} from "../../services/indexer.js";
+import {
+  VAULT_CONTRACT,
+  USER_ADDRESS,
+  makeDepositEvent,
+  makeWithdrawEvent,
+  makeYieldDistributedEvent,
+  makeVaultStateChangedEvent,
+  makeVaultCreatedEvent,
+  makeCancelFundingEvent,
+  makeVaultRemovedEvent,
+  makeOperatorAddedEvent,
+  makeOperatorRemovedEvent,
+  makeRoleGrantedEvent,
+  makeRoleRevokedEvent,
+  makeRequestEarlyRedemptionEvent,
+  makeYieldClaimedEvent,
+  makeYieldClaimedPartialEvent,
+  makeEarlyRedemptionProcessedEvent,
+  makeEarlyRedemptionCancelledEvent,
+  makeZkmeVerifierUpdatedEvent,
+  makeKycSetEvent,
+  makePausedEvent,
+  makeUnpausedEvent,
+} from "./events.js";
+
+describe("event fixture factory (#697)", () => {
+  it("makeDepositEvent parses to the expected fields", () => {
+    const parsed = parseDepositEvent(makeDepositEvent({ assets: 5n, shares: 5n }));
+    expect(parsed).toEqual({ caller: USER_ADDRESS, receiver: USER_ADDRESS, assets: 5n, shares: 5n });
+  });
+
+  it("makeWithdrawEvent parses to the expected fields", () => {
+    const parsed = parseWithdrawEvent(makeWithdrawEvent());
+    expect(parsed).not.toBeNull();
+    expect(parsed?.assets).toBe(500n);
+  });
+
+  it("makeYieldDistributedEvent parses to the expected fields", () => {
+    const parsed = parseYieldDistributedEvent(makeYieldDistributedEvent({ epoch: 3, amount: 42n }));
+    expect(parsed).toEqual({ epoch: 3, amount: 42n, timestamp: 1_700_000_000n });
+  });
+
+  it("makeVaultStateChangedEvent parses to the expected fields", () => {
+    const parsed = parseVaultStateChangedEvent(
+      makeVaultStateChangedEvent({ oldState: "Active", newState: "Matured" }),
+    );
+    expect(parsed).toEqual({ oldState: "Active", newState: "Matured" });
+  });
+
+  it("makeVaultCreatedEvent is recognized by the parser", () => {
+    const parsed = parseVaultCreatedEvent(makeVaultCreatedEvent({ name: "Test Vault" }));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.name).toBe("Test Vault");
+  });
+
+  it("makeCancelFundingEvent is recognized by the parser", () => {
+    const parsed = parseCancelFundingEvent(makeCancelFundingEvent({ contractId: VAULT_CONTRACT }));
+    expect(parsed).toEqual({ contractId: VAULT_CONTRACT });
+  });
+
+  it("makeVaultRemovedEvent is recognized by the parser", () => {
+    const parsed = parseVaultRemovedEvent(makeVaultRemovedEvent({ contractId: VAULT_CONTRACT }));
+    expect(parsed).toEqual({ contractId: VAULT_CONTRACT });
+  });
+
+  it("makeOperatorAddedEvent parses to the expected fields", () => {
+    const parsed = parseOperatorAddedEvent(makeOperatorAddedEvent());
+    expect(parsed?.caller).toBe(USER_ADDRESS);
+  });
+
+  it("makeOperatorRemovedEvent parses to the expected fields", () => {
+    const parsed = parseOperatorRemovedEvent(makeOperatorRemovedEvent({ reason: "policy" }));
+    expect(parsed?.reason).toBe("policy");
+  });
+
+  it("makeRoleGrantedEvent parses to the expected fields", () => {
+    const parsed = parseRoleGrantedEvent(makeRoleGrantedEvent({ role: "Admin" }));
+    expect(parsed).toEqual({ userAddress: USER_ADDRESS, role: "Admin" });
+  });
+
+  it("makeRoleRevokedEvent parses to the expected fields", () => {
+    const parsed = parseRoleRevokedEvent(makeRoleRevokedEvent({ role: "Admin" }));
+    expect(parsed).toEqual({ userAddress: USER_ADDRESS, role: "Admin" });
+  });
+
+  it("makeRequestEarlyRedemptionEvent parses to the expected fields", () => {
+    const parsed = parseRequestEarlyRedemptionEvent(makeRequestEarlyRedemptionEvent({ requestId: 7 }));
+    expect(parsed?.requestId).toBe(7);
+  });
+
+  it("makeYieldClaimedEvent parses to the expected fields", () => {
+    const parsed = parseYieldClaimedEvent(makeYieldClaimedEvent({ amount: 900n, epoch: 2 }));
+    expect(parsed).toEqual({ user: USER_ADDRESS, amount: 900n, epoch: 2 });
+  });
+
+  it("makeYieldClaimedPartialEvent parses to the expected fields", () => {
+    const parsed = parseYieldClaimedPartialEvent(
+      makeYieldClaimedPartialEvent({ claimed: 100n, shortfall: 50n, epoch: 4 }),
+    );
+    expect(parsed).toEqual({ user: USER_ADDRESS, claimed: 100n, shortfall: 50n, epoch: 4 });
+  });
+
+  it("makeEarlyRedemptionProcessedEvent parses to the expected fields", () => {
+    const parsed = parseEarlyRedemptionProcessedEvent(makeEarlyRedemptionProcessedEvent());
+    expect(parsed?.user).toBe(USER_ADDRESS);
+  });
+
+  it("makeEarlyRedemptionCancelledEvent parses to the expected fields", () => {
+    const parsed = parseEarlyRedemptionCancelledEvent(makeEarlyRedemptionCancelledEvent());
+    expect(parsed?.user).toBe(USER_ADDRESS);
+  });
+
+  it("makeZkmeVerifierUpdatedEvent parses to the expected fields", () => {
+    const parsed = parseZkmeVerifierUpdatedEvent(makeZkmeVerifierUpdatedEvent());
+    expect(parsed?.caller).toBe(USER_ADDRESS);
+  });
+
+  it("makeKycSetEvent parses to the expected fields", () => {
+    const parsed = parseKycSetEvent(makeKycSetEvent({ verified: false }));
+    expect(parsed).toEqual({ user: USER_ADDRESS, verified: false, timestamp: 1_700_000_000n });
+  });
+
+  it("makePausedEvent is recognized by the parser", () => {
+    const parsed = parsePausedEvent(makePausedEvent({ contractId: VAULT_CONTRACT }));
+    expect(parsed).toEqual({ contractId: VAULT_CONTRACT });
+  });
+
+  it("makeUnpausedEvent is recognized by the parser", () => {
+    const parsed = parseUnpausedEvent(makeUnpausedEvent({ contractId: VAULT_CONTRACT }));
+    expect(parsed).toEqual({ contractId: VAULT_CONTRACT });
+  });
+});

--- a/backend/src/test/fixtures/events.ts
+++ b/backend/src/test/fixtures/events.ts
@@ -1,0 +1,371 @@
+// Shared raw-event fixture builders for indexer/unit/integration tests (#697).
+//
+// Each `make*Event` builder returns a minimal, valid raw on-chain event object
+// that `Indexer.processEvent` (src/services/indexer.ts) and its standalone
+// `parse*Event` functions accept, matching the `{ topic, value, ... }` shape
+// used throughout the existing test suite (see src/services/indexer.test.ts
+// and src/deposit-indexing.e2e.test.ts).
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+
+export const VAULT_CONTRACT = "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3BMNOP";
+export const USER_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2A";
+export const OTHER_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA";
+
+interface BaseOverrides {
+  contractId?: string;
+  ledger?: number;
+  id?: string;
+  txHash?: string;
+  ledgerClosedAt?: string;
+}
+
+let eventCounter = 0;
+
+function baseEvent(overrides: BaseOverrides = {}) {
+  eventCounter += 1;
+  return {
+    type: "contract" as const,
+    contractId: overrides.contractId ?? VAULT_CONTRACT,
+    ledger: overrides.ledger ?? 1000,
+    id: overrides.id ?? `fixture-evt-${eventCounter}`,
+    txHash: overrides.txHash ?? `fixture-tx-${eventCounter}`,
+    ledgerClosedAt: overrides.ledgerClosedAt ?? "2025-01-01T00:00:00.000Z",
+    pagingToken: "",
+    transactionIndex: 0,
+    operationIndex: 0,
+    inSuccessfulContractCall: true,
+  };
+}
+
+export function makeDepositEvent(
+  overrides: Partial<BaseOverrides & {
+    caller: string;
+    receiver: string;
+    assets: bigint;
+    shares: bigint;
+  }> = {},
+) {
+  const caller = overrides.caller ?? USER_ADDRESS;
+  const receiver = overrides.receiver ?? USER_ADDRESS;
+  const assets = overrides.assets ?? 1_000n;
+  const shares = overrides.shares ?? 1_000n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("deposit"), nativeToScVal(caller), nativeToScVal(receiver)],
+    value: nativeToScVal([assets, shares]),
+  };
+}
+
+export function makeWithdrawEvent(
+  overrides: Partial<BaseOverrides & {
+    caller: string;
+    receiver: string;
+    owner: string;
+    assets: bigint;
+    shares: bigint;
+  }> = {},
+) {
+  const caller = overrides.caller ?? USER_ADDRESS;
+  const receiver = overrides.receiver ?? USER_ADDRESS;
+  const owner = overrides.owner ?? USER_ADDRESS;
+  const assets = overrides.assets ?? 500n;
+  const shares = overrides.shares ?? 500n;
+  return {
+    ...baseEvent(overrides),
+    topic: [
+      nativeToScVal("withdraw"),
+      nativeToScVal(caller),
+      nativeToScVal(receiver),
+      nativeToScVal(owner),
+    ],
+    value: nativeToScVal([assets, shares]),
+  };
+}
+
+export function makeYieldDistributedEvent(
+  overrides: Partial<BaseOverrides & {
+    epoch: number;
+    amount: bigint;
+    timestamp: bigint;
+  }> = {},
+) {
+  const epoch = overrides.epoch ?? 1;
+  const amount = overrides.amount ?? 10_000n;
+  const timestamp = overrides.timestamp ?? 1_700_000_000n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("yield_dis"), nativeToScVal(epoch)],
+    value: nativeToScVal([amount, timestamp]),
+  };
+}
+
+export function makeVaultStateChangedEvent(
+  overrides: Partial<BaseOverrides & {
+    oldState: string;
+    newState: string;
+  }> = {},
+) {
+  const oldState = overrides.oldState ?? "Funding";
+  const newState = overrides.newState ?? "Active";
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("st_chg")],
+    value: nativeToScVal({ oldState, newState }),
+  };
+}
+
+export function makeVaultCreatedEvent(
+  overrides: Partial<BaseOverrides & {
+    asset: string;
+    name: string;
+    symbol: string;
+    rwaCategory: string;
+    fundingTarget: bigint;
+    fundingDeadline: number;
+    minDeposit: bigint;
+    maxDepositPerUser: bigint;
+  }> = {},
+) {
+  const asset = overrides.asset ?? "XLM";
+  const name = overrides.name ?? "Stellar Lumens Vault";
+  const symbol = overrides.symbol ?? "SVXLM";
+  const rwaCategory = overrides.rwaCategory ?? "RealEstate";
+  const fundingTarget = overrides.fundingTarget ?? 1_000_000n;
+  const fundingDeadline = overrides.fundingDeadline ?? 1_800_000_000;
+  const minDeposit = overrides.minDeposit ?? 100n;
+  const maxDepositPerUser = overrides.maxDepositPerUser ?? 100_000n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("v_create"), nativeToScVal(overrides.contractId ?? VAULT_CONTRACT)],
+    value: nativeToScVal({
+      asset,
+      name,
+      symbol,
+      rwa_category: rwaCategory,
+      funding_target: fundingTarget,
+      funding_deadline: fundingDeadline,
+      min_deposit: minDeposit,
+      max_deposit_per_user: maxDepositPerUser,
+    }),
+  };
+}
+
+export function makeCancelFundingEvent(overrides: Partial<BaseOverrides> = {}) {
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("fund_cxl")],
+    value: xdr.ScVal.scvVoid(),
+  };
+}
+
+export function makeVaultRemovedEvent(overrides: Partial<BaseOverrides> = {}) {
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("vault_removed")],
+  };
+}
+
+export function makeOperatorAddedEvent(
+  overrides: Partial<BaseOverrides & {
+    caller: string;
+    operator: string;
+    timestamp: bigint;
+  }> = {},
+) {
+  const caller = overrides.caller ?? USER_ADDRESS;
+  const operator = overrides.operator ?? OTHER_ADDRESS;
+  const timestamp = overrides.timestamp ?? 1_700_000_000n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("op_add"), nativeToScVal(caller), nativeToScVal(operator)],
+    value: nativeToScVal(timestamp),
+  };
+}
+
+export function makeOperatorRemovedEvent(
+  overrides: Partial<BaseOverrides & {
+    caller: string;
+    operator: string;
+    timestamp: bigint;
+    reason: string | null;
+  }> = {},
+) {
+  const caller = overrides.caller ?? USER_ADDRESS;
+  const operator = overrides.operator ?? OTHER_ADDRESS;
+  const timestamp = overrides.timestamp ?? 1_700_000_000n;
+  const reason = overrides.reason === undefined ? "manual removal" : overrides.reason;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("op_rem"), nativeToScVal(caller), nativeToScVal(operator)],
+    value: nativeToScVal([timestamp, reason]),
+  };
+}
+
+export function makeRoleGrantedEvent(
+  overrides: Partial<BaseOverrides & {
+    userAddress: string;
+    role: string;
+  }> = {},
+) {
+  const userAddress = overrides.userAddress ?? USER_ADDRESS;
+  const role = overrides.role ?? "Operator";
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("role_grt"), nativeToScVal(userAddress)],
+    value: nativeToScVal(role),
+  };
+}
+
+export function makeRoleRevokedEvent(
+  overrides: Partial<BaseOverrides & {
+    userAddress: string;
+    role: string;
+  }> = {},
+) {
+  const userAddress = overrides.userAddress ?? USER_ADDRESS;
+  const role = overrides.role ?? "Operator";
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("role_rvk"), nativeToScVal(userAddress)],
+    value: nativeToScVal(role),
+  };
+}
+
+export function makeRequestEarlyRedemptionEvent(
+  overrides: Partial<BaseOverrides & {
+    userAddress: string;
+    requestId: number;
+    shares: bigint;
+    timestamp: bigint;
+  }> = {},
+) {
+  const userAddress = overrides.userAddress ?? USER_ADDRESS;
+  const requestId = overrides.requestId ?? 1;
+  const shares = overrides.shares ?? 250n;
+  const timestamp = overrides.timestamp ?? 1_700_000_000n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("erq_req"), nativeToScVal(userAddress)],
+    value: nativeToScVal([requestId, shares, timestamp]),
+  };
+}
+
+export function makeYieldClaimedEvent(
+  overrides: Partial<BaseOverrides & {
+    user: string;
+    amount: bigint;
+    epoch: number;
+  }> = {},
+) {
+  const user = overrides.user ?? USER_ADDRESS;
+  const amount = overrides.amount ?? 1_000n;
+  const epoch = overrides.epoch ?? 1;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("yield_clm"), nativeToScVal(user)],
+    value: nativeToScVal([amount, epoch]),
+  };
+}
+
+export function makeYieldClaimedPartialEvent(
+  overrides: Partial<BaseOverrides & {
+    user: string;
+    claimed: bigint;
+    shortfall: bigint;
+    epoch: number;
+  }> = {},
+) {
+  const user = overrides.user ?? USER_ADDRESS;
+  const claimed = overrides.claimed ?? 700n;
+  const shortfall = overrides.shortfall ?? 300n;
+  const epoch = overrides.epoch ?? 1;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("prt_yld"), nativeToScVal(user)],
+    value: nativeToScVal([claimed, shortfall, epoch]),
+  };
+}
+
+export function makeEarlyRedemptionProcessedEvent(
+  overrides: Partial<BaseOverrides & {
+    user: string;
+    requestId: number;
+    netAssets: bigint;
+  }> = {},
+) {
+  const user = overrides.user ?? USER_ADDRESS;
+  const requestId = overrides.requestId ?? 1;
+  const netAssets = overrides.netAssets ?? 480n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("erq_done"), nativeToScVal(user)],
+    value: nativeToScVal([requestId, netAssets]),
+  };
+}
+
+export function makeEarlyRedemptionCancelledEvent(
+  overrides: Partial<BaseOverrides & {
+    user: string;
+    requestId: number;
+    shares: bigint;
+  }> = {},
+) {
+  const user = overrides.user ?? USER_ADDRESS;
+  const requestId = overrides.requestId ?? 1;
+  const shares = overrides.shares ?? 250n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("erq_can"), nativeToScVal(user)],
+    value: nativeToScVal([requestId, shares]),
+  };
+}
+
+export function makeZkmeVerifierUpdatedEvent(
+  overrides: Partial<BaseOverrides & {
+    caller: string;
+    oldVerifier: string;
+    newVerifier: string;
+  }> = {},
+) {
+  const caller = overrides.caller ?? USER_ADDRESS;
+  const oldVerifier = overrides.oldVerifier ?? OTHER_ADDRESS;
+  const newVerifier = overrides.newVerifier ?? USER_ADDRESS;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("zkme_upd"), nativeToScVal(caller)],
+    value: nativeToScVal([oldVerifier, newVerifier]),
+  };
+}
+
+export function makeKycSetEvent(
+  overrides: Partial<BaseOverrides & {
+    user: string;
+    verified: boolean;
+    timestamp: bigint;
+  }> = {},
+) {
+  const user = overrides.user ?? USER_ADDRESS;
+  const verified = overrides.verified ?? true;
+  const timestamp = overrides.timestamp ?? 1_700_000_000n;
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("kyc_set"), nativeToScVal(user)],
+    value: nativeToScVal([verified, timestamp]),
+  };
+}
+
+export function makePausedEvent(overrides: Partial<BaseOverrides> = {}) {
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("paused")],
+    value: xdr.ScVal.scvVoid(),
+  };
+}
+
+export function makeUnpausedEvent(overrides: Partial<BaseOverrides> = {}) {
+  return {
+    ...baseEvent(overrides),
+    topic: [nativeToScVal("unpaused")],
+    value: xdr.ScVal.scvVoid(),
+  };
+}

--- a/backend/src/vault-state-transitions.e2e.test.ts
+++ b/backend/src/vault-state-transitions.e2e.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The DB layer is mocked (consistent with CI - no live postgres required),
+// mirroring the existing deposit-indexing E2E test. `queryMock` routes on SQL
+// text so it can serve both the indexer's writes and the API's reads.
+vi.mock("./db/index.js", () => ({ query: vi.fn().mockResolvedValue([]) }));
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+vi.mock("./services/stellar.js", () => ({ getSorobanRpc: vi.fn() }));
+vi.mock("pino-http", () => ({ pinoHttp: () => (_req: any, _res: any, next: any) => next() }));
+
+import { Indexer } from "./services/indexer.js";
+import { createApp } from "./app.js";
+import { VAULT_CONTRACT, makeVaultStateChangedEvent } from "./test/fixtures/events.js";
+
+function makeVaultRow(state: string) {
+  const timestamp = new Date("2025-01-01T00:00:00.000Z");
+  return {
+    id: 1,
+    contract_id: VAULT_CONTRACT,
+    factory_id: "FACTORY123",
+    asset: "XLM",
+    name: "Stellar Lumens Vault",
+    symbol: "SVXLM",
+    state,
+    total_assets: "1000000",
+    total_supply: "500000",
+    total_shares_ever_minted: "500000",
+    total_shares_ever_burned: "0",
+    created_at: timestamp,
+    updated_at: timestamp,
+    funding_target: "1000000",
+    funding_deadline: null,
+    min_deposit: null,
+    max_deposit_per_user: null,
+    zkme_verifier_address: null,
+    rwa_name: null,
+    rwa_symbol: null,
+    rwa_document_uri: null,
+    rwa_category: null,
+    depositor_count: 3,
+  };
+}
+
+describe("E2E: vault state transitions (#696)", () => {
+  let queryMock: ReturnType<typeof vi.fn>;
+  let currentState: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    currentState = "Funding";
+    const { query } = await import("./db/index.js");
+    queryMock = query as ReturnType<typeof vi.fn>;
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes("UPDATE vaults SET state")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("FROM vaults v") && sql.includes("WHERE v.contract_id = $1")) {
+        return Promise.resolve([makeVaultRow(currentState)]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  it("reflects each state transition via GET /api/v1/vaults/:contractId and fires vault.matured exactly once", async () => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const indexer = new Indexer({ notify } as any);
+    const app = createApp();
+    const { default: supertest } = await import("supertest");
+
+    const initial = await supertest(app).get(`/api/v1/vaults/${VAULT_CONTRACT}`);
+    expect(initial.status).toBe(200);
+    expect(initial.body.state).toBe("Funding");
+
+    currentState = "Active";
+    await indexer.processEvent(
+      makeVaultStateChangedEvent({ oldState: "Funding", newState: "Active" }),
+    );
+    const afterActive = await supertest(app).get(`/api/v1/vaults/${VAULT_CONTRACT}`);
+    expect(afterActive.status).toBe(200);
+    expect(afterActive.body.state).toBe("Active");
+
+    currentState = "Matured";
+    await indexer.processEvent(
+      makeVaultStateChangedEvent({ oldState: "Active", newState: "Matured" }),
+    );
+    const afterMatured = await supertest(app).get(`/api/v1/vaults/${VAULT_CONTRACT}`);
+    expect(afterMatured.status).toBe(200);
+    expect(afterMatured.body.state).toBe("Matured");
+
+    const maturedCalls = notify.mock.calls.filter((call) => call[0] === "vault.matured");
+    expect(maturedCalls).toHaveLength(1);
+    expect(maturedCalls[0]?.[1]).toMatchObject({ contractId: VAULT_CONTRACT });
+
+    const stateChangedCalls = notify.mock.calls.filter((call) => call[0] === "vault_state_changed");
+    expect(stateChangedCalls).toHaveLength(2);
+  });
+
+  it("does not fire vault.matured for a non-maturity transition", async () => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const indexer = new Indexer({ notify } as any);
+
+    currentState = "Active";
+    await indexer.processEvent(
+      makeVaultStateChangedEvent({ oldState: "Funding", newState: "Active" }),
+    );
+
+    const maturedCalls = notify.mock.calls.filter((call) => call[0] === "vault.matured");
+    expect(maturedCalls).toHaveLength(0);
+  });
+});

--- a/backend/src/yield-claim-flow.e2e.test.ts
+++ b/backend/src/yield-claim-flow.e2e.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The DB layer is mocked (consistent with CI - no live postgres required),
+// mirroring the existing deposit-indexing E2E test. `queryMock` routes on SQL
+// text to stand in for a seeded vault, user, and three epochs (see
+// backend/src/db/seed.ts for the equivalent live-DB seed data).
+vi.mock("./db/index.js", () => ({ query: vi.fn().mockResolvedValue([]) }));
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+vi.mock("./services/stellar.js", () => ({ getSorobanRpc: vi.fn() }));
+vi.mock("pino-http", () => ({ pinoHttp: () => (_req: any, _res: any, next: any) => next() }));
+
+import { Indexer } from "./services/indexer.js";
+import { createApp } from "./app.js";
+import { VAULT_CONTRACT, USER_ADDRESS, makeYieldClaimedEvent } from "./test/fixtures/events.js";
+
+const EPOCHS = [
+  { epoch: 1, yield_amount: "1000", total_shares: "1000" },
+  { epoch: 2, yield_amount: "2000", total_shares: "1000" },
+  { epoch: 3, yield_amount: "3000", total_shares: "1000" },
+];
+
+describe("E2E: yield claim flow (#695)", () => {
+  let queryMock: ReturnType<typeof vi.fn>;
+  let lastClaimedEpoch: number;
+  let totalClaimed: bigint;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    lastClaimedEpoch = -1;
+    totalClaimed = 0n;
+
+    const { query } = await import("./db/index.js");
+    queryMock = query as ReturnType<typeof vi.fn>;
+    queryMock.mockImplementation((sql: string, params: unknown[] = []) => {
+      if (sql.includes("SELECT id FROM indexed_events WHERE tx_hash")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("SET last_claimed_epoch = GREATEST")) {
+        lastClaimedEpoch = Math.max(lastClaimedEpoch, Number(params[0]));
+        return Promise.resolve([]);
+      }
+      if (sql.includes("INSERT INTO indexed_events") && sql.includes("'yield_claimed'")) {
+        const payload = JSON.parse(String(params[3]));
+        totalClaimed += BigInt(payload.amount);
+        return Promise.resolve([]);
+      }
+      if (sql.includes("uvp.shares, uvp.last_claimed_epoch")) {
+        return Promise.resolve([{ shares: "1000", last_claimed_epoch: lastClaimedEpoch }]);
+      }
+      if (sql.includes("e.epoch, e.yield_amount, e.total_shares")) {
+        return Promise.resolve(EPOCHS);
+      }
+      if (sql.includes("SELECT v.contract_id") && sql.includes("uvp.shares > 0")) {
+        return Promise.resolve([{ contract_id: VAULT_CONTRACT }]);
+      }
+      if (sql.includes("total_claimed")) {
+        return Promise.resolve([{ total_claimed: totalClaimed.toString() }]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  it("reduces pending yield and updates the user's totalClaimed after a claim is indexed", async () => {
+    const app = createApp();
+    const { default: supertest } = await import("supertest");
+
+    const before = await supertest(app).get(
+      `/api/v1/yields/${VAULT_CONTRACT}/pending/${USER_ADDRESS}`,
+    );
+    expect(before.status).toBe(200);
+    expect(before.body.pendingYield).toBe("6000");
+    expect(before.body.epochs).toEqual([1, 2, 3]);
+
+    const summaryBefore = await supertest(app).get(`/api/v1/users/${USER_ADDRESS}/yield-summary`);
+    expect(summaryBefore.status).toBe(200);
+    expect(summaryBefore.body.totalClaimed).toBe("0");
+
+    const indexer = new Indexer();
+    await indexer.processEvent(
+      makeYieldClaimedEvent({ contractId: VAULT_CONTRACT, user: USER_ADDRESS, amount: 2000n, epoch: 2 }),
+    );
+
+    const after = await supertest(app).get(
+      `/api/v1/yields/${VAULT_CONTRACT}/pending/${USER_ADDRESS}`,
+    );
+    expect(after.status).toBe(200);
+    expect(after.body.pendingYield).toBe("3000");
+    expect(after.body.epochs).toEqual([3]);
+    expect(after.body.claimedEpochs).toEqual([1, 2]);
+    expect(BigInt(after.body.pendingYield)).toBeLessThan(BigInt(before.body.pendingYield));
+
+    const summaryAfter = await supertest(app).get(`/api/v1/users/${USER_ADDRESS}/yield-summary`);
+    expect(summaryAfter.status).toBe(200);
+    expect(summaryAfter.body.totalClaimed).toBe("2000");
+  });
+});


### PR DESCRIPTION
  ## Summary

  Closes #694, closes #695, closes #696, closes #697

  - **#694** — Unit tests for the request ID middleware (`src/api/middleware/requestId.test.ts`): asserts
  the `X-Request-ID` header matches UUID v4 format, that `requestId` is bound onto the pino logger for
  the request, and that two simultaneous requests get different IDs.
  - **#697** — Shared raw-event fixture factory (`src/test/fixtures/events.ts`): one
  `make*Event(overrides?)` builder per event type `Indexer.processEvent` recognizes (deposit, withdraw,
  yield distributed, vault created/removed/state-changed, cancel funding, operator added/removed, role
  granted/revoked, early redemption request/processed/cancelled, yield claimed/partial, zkme verifier
  updated, kyc set, paused/unpaused). Each builder is validated against the real parser functions in
  `src/test/fixtures/events.test.ts`.
  - **#696** — E2E test (`src/vault-state-transitions.e2e.test.ts`) covering Funding → Active → Matured:
  processes synthetic `vault_state_changed` events through the indexer and asserts each transition is
  visible via `GET /api/v1/vaults/:contractId`, and that the `vault.matured` webhook notification fires
  exactly once, only on the Matured transition.
  - **#695** — E2E test (`src/yield-claim-flow.e2e.test.ts`) covering the yield claim pipeline: processes
  a synthetic `yield_clm` event through the indexer and asserts `GET
  /api/v1/yields/:contractId/pending/:address` reflects the reduced pending yield and `GET
  /api/v1/users/:address/yield-summary` reflects the updated `totalClaimed`.

  ## Fixes found while writing the #695 E2E test

  Building a real end-to-end assertion for `totalClaimed` surfaced two pre-existing integration bugs in
  the yield-claim path that made claimed-yield history unqueryable:

  1. `indexed_events.event_type` was written as `"yield_claimed"` / `"yield_claimed_partial"` by the
  indexer, but read back with the on-chain short codes `'yield_clm'` / `'prt_yld'` in
  `UserService.getUserYieldHistory` — the filter could never match, so `GET
  /api/v1/users/:address/yield-history` always returned empty. Fixed the query to use the actual stored
  event types.
  2. Yield claim events were recorded via the generic `recordEvent()` path, which stores the *raw*
  un-decoded event object (topics/value) as `payload` — not the parsed `user`/`amount`/`epoch` fields the
  history/summary queries read via `payload->>'amount'` etc. Changed both `yield_claimed` and
  `yield_claimed_partial` handling to insert the decoded fields instead (matching the existing precedent
  already used for `kyc_set`), preserving the `indexerEventsProcessedTotal` metric increment that the
  generic path used to perform.

  ## Added

  `GET /api/v1/users/:address/yield-summary` (`getUserYieldSummary` in
  `UserService`/`api/controllers/users.ts`/`api/routes/users.ts`) — issue #695's acceptance criteria
  requires this endpoint but no equivalent existed in the codebase (only a per-vault `GET
  /api/v1/yields/:contractId/summary` and a per-user `yield-history` did). It returns `{ totalClaimed,
  totalPendingYield }`, reusing the existing (previously unused) `UserService.getTotalPendingYield` and
  the fixed claim-history query above.

  ## Notes

  - All new E2E tests follow the existing fully-mocked-DB convention (`src/deposit-indexing.e2e.test.ts`)
  — no live Postgres, consistent with every other test in the suite. "Seeding" a vault/user/three epochs
  and processing indexer events is done by driving the mocked `query` function, since `db/seed.ts` is a
  standalone CLI script (calls `pool.end()`/`process.exit`) not designed to be imported into tests, and
  no other test in the repo stands up `docker-compose.test.yml`.
  - Fork was already in sync with `upstream/main` (StellarYield/StellarYield-Contracts) before this
  branch was cut.

  ## Test plan

  - [x] `npm run lint` — clean on all changed/added files
  - [x] `npx vitest run` — 261/261 tests passing (28 files), including all 3 new/updated suites
  - [x] `npx tsc --noEmit` — no new type errors introduced (pre-existing unrelated errors in
  `src/database`, `src/indexer`, `src/routes`, `src/middleware`, `src/services/notificationService.ts`,
  `src/tasks` confirmed identical before and after this change via `git stash`)
