### PR TITLE
feat: portfolio PnL, analytics summary, income forecast, and operator fee tracking

### DIFF
--- a/backend/src/api/controllers/analytics.ts
+++ b/backend/src/api/controllers/analytics.ts
@@ -1,0 +1,46 @@
+import type { Request, Response, NextFunction } from "express";
+import { query } from "../../db/index.js";
+import { cacheGet, cacheSet } from "../../cache/redis.js";
+import type { AnalyticsSummary } from "../../types/index.js";
+
+const ANALYTICS_CACHE_TTL = 60;
+
+export async function getAnalyticsSummary(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const cached = await cacheGet<AnalyticsSummary>("analytics:summary");
+    if (cached) {
+      res.json(cached);
+      return;
+    }
+
+    const [vaultCountRows, userCountRows, tvlRows, yieldRows, depositorRows] =
+      await Promise.all([
+        query<{ count: string }>("SELECT COUNT(*)::text AS count FROM vaults"),
+        query<{ count: string }>("SELECT COUNT(*)::text AS count FROM users"),
+        query<{ total: string }>(
+          "SELECT COALESCE(SUM(total_assets::numeric), 0)::text AS total FROM vaults",
+        ),
+        query<{ total: string }>(
+          "SELECT COALESCE(SUM(yield_amount::numeric), 0)::text AS total FROM epochs",
+        ),
+        query<{ count: string }>(
+          `SELECT COUNT(DISTINCT user_address)::text AS count
+           FROM user_vault_positions
+           WHERE shares > 0`,
+        ),
+      ]);
+
+    const summary: AnalyticsSummary = {
+      totalUsers: parseInt(userCountRows[0]?.count ?? "0", 10),
+      totalVaults: parseInt(vaultCountRows[0]?.count ?? "0", 10),
+      totalValueLocked: tvlRows[0]?.total ?? "0",
+      totalYieldDistributed: yieldRows[0]?.total ?? "0",
+      totalDepositors: parseInt(depositorRows[0]?.count ?? "0", 10),
+    };
+
+    await cacheSet("analytics:summary", summary, ANALYTICS_CACHE_TTL);
+    res.json(summary);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/controllers/users.ts
+++ b/backend/src/api/controllers/users.ts
@@ -32,6 +32,41 @@ export async function getUserPortfolio(
   }
 }
 
+export async function getUserPortfolioPnl(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const pnl = await userService.getUserPortfolioPnl(
+      String(req.params["address"]),
+    );
+    res.json(pnl);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getUserIncomeForecast(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const address = String(req.params["address"]);
+    const monthsParam = req.query["months"];
+    const months =
+      typeof monthsParam === "string" && /^\d+$/.test(monthsParam)
+        ? Math.min(12, Math.max(1, parseInt(monthsParam, 10)))
+        : 6;
+
+    const forecast = await userService.getUserIncomeForecast(address, months);
+    res.json(forecast);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function getUserShareHistory(
   req: Request,
   res: Response,

--- a/backend/src/api/routes/analytics.ts
+++ b/backend/src/api/routes/analytics.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { getAnalyticsSummary } from "../controllers/analytics.js";
+
+export const analyticsRouter = Router();
+
+analyticsRouter.get("/summary", getAnalyticsSummary);

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -4,9 +4,11 @@ import {
   getKycBatch,
   getPortfoliosBatch,
   getUser,
+  getUserIncomeForecast,
   getUserKyc,
   getUserKycHistory,
   getUserPortfolio,
+  getUserPortfolioPnl,
   getUserShareHistory,
   getUserYieldHistory,
   getUserYieldSummary,
@@ -108,6 +110,16 @@ usersRouter.get(
   "/:address/portfolio",
   validateParams(addressParamSchema),
   getUserPortfolio,
+);
+usersRouter.get(
+  "/:address/portfolio/pnl",
+  validateParams(addressParamSchema),
+  getUserPortfolioPnl,
+);
+usersRouter.get(
+  "/:address/portfolio/income-forecast",
+  validateParams(addressParamSchema),
+  getUserIncomeForecast,
 );
 usersRouter.get(
   "/:address/stream",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { usersRouter } from "./api/routes/users.js";
 import { yieldsRouter } from "./api/routes/yields.js";
 import { adminRouter } from "./api/routes/admin.js";
 import { webhooksRouter } from "./api/routes/webhooks.js";
+import { analyticsRouter } from "./api/routes/analytics.js";
 import { errorHandler } from "./api/middleware/errors.js";
 import { requestId } from "./api/middleware/requestId.js";
 import { publicLimiter, authLimiter } from "./api/middleware/rateLimit.js";
@@ -49,6 +50,7 @@ export function createApp(): Express {
   app.use("/api/v1/vaults", publicLimiter, vaultsRouter);
   app.use("/api/v1/users", publicLimiter, usersRouter);
   app.use("/api/v1/yields", publicLimiter, yieldsRouter);
+  app.use("/api/v1/analytics", publicLimiter, analyticsRouter);
   app.use("/api/v1/admin", authLimiter, adminRouter);
   app.use("/api/v1/webhooks", authLimiter, webhooksRouter);
   app.all(

--- a/backend/src/db/migrations/024_indexed_events_parsed_data.sql
+++ b/backend/src/db/migrations/024_indexed_events_parsed_data.sql
@@ -1,0 +1,6 @@
+-- Add parsed_data JSONB column to indexed_events for storing pre-computed fee
+-- breakdowns and other derived fields alongside the raw event payload.
+-- Issue #785: Track operator fee amounts in indexed_events
+
+ALTER TABLE indexed_events
+  ADD COLUMN IF NOT EXISTS parsed_data JSONB;

--- a/backend/src/db/migrations/025_vault_operator_fee_bps.sql
+++ b/backend/src/db/migrations/025_vault_operator_fee_bps.sql
@@ -1,0 +1,6 @@
+-- Add operator_fee_bps column to vaults to store the operator fee in basis points.
+-- Used to compute parsed_data fee breakdowns on yield_distributed events.
+-- Issue #785: Track operator fee amounts in indexed_events
+
+ALTER TABLE vaults
+  ADD COLUMN IF NOT EXISTS operator_fee_bps INT DEFAULT 0;

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -7,6 +7,7 @@ import {
   readRwaName,
   readRwaSymbol,
   readRwaDocumentUri,
+  readOperatorFeeBps,
 } from "./stellar.js";
 import { VaultService } from "./vault.js";
 import { UserService } from "./user.js";
@@ -119,11 +120,12 @@ export async function storeIndexedEvent(
   eventType: string,
   ev: any,
   payload: Record<string, unknown>,
+  parsedData?: Record<string, unknown>,
 ): Promise<void> {
   await query(
-    `INSERT INTO indexed_events (ledger, tx_hash, contract_id, event_type, payload)
-     VALUES ($1, $2, $3, $4, $5)`,
-    [ev.ledger, ev.txHash, contractId, eventType, JSON.stringify(payload)],
+    `INSERT INTO indexed_events (ledger, tx_hash, contract_id, event_type, payload, parsed_data)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [ev.ledger, ev.txHash, contractId, eventType, JSON.stringify(payload), parsedData ? JSON.stringify(parsedData) : null],
   );
 }
 
@@ -380,8 +382,8 @@ export class Indexer {
 
     const yieldDist = parseYieldDistributedEvent(event);
     if (yieldDist) {
-      await this.handleYieldDistributed(event.contractId ?? "", yieldDist);
-      await this.recordEvent(event, "yield_distributed");
+      const parsedData = await this.handleYieldDistributed(event.contractId ?? "", yieldDist);
+      await this.recordEvent(event, "yield_distributed", parsedData);
       try {
         await this.notificationService?.notify("yield_distributed", yieldDist as any);
       } catch (e) {
@@ -738,14 +740,14 @@ export class Indexer {
   private async handleYieldDistributed(
     contractId: string,
     yieldDist: { epoch: number; amount: bigint; timestamp: bigint },
-  ): Promise<void> {
-    const vaultRow = await query<{ id: number }>(
-      "SELECT id FROM vaults WHERE contract_id = $1",
+  ): Promise<Record<string, unknown> | undefined> {
+    const vaultRow = await query<{ id: number; operator_fee_bps: number }>(
+      "SELECT id, operator_fee_bps FROM vaults WHERE contract_id = $1",
       [contractId],
     );
     if (vaultRow.length === 0) {
       logger.warn({ contractId }, "yield_distributed for unknown vault — skipping epoch record");
-      return;
+      return undefined;
     }
     const vaultId = vaultRow[0].id;
 
@@ -773,10 +775,41 @@ export class Indexer {
       [vaultId, yieldDist.epoch],
     );
 
+    // Compute operator fee breakdown for parsed_data
+    const grossYield = yieldDist.amount;
+    let operatorFeeBps = vaultRow[0].operator_fee_bps ?? 0;
+
+    // Lazily populate operator_fee_bps from chain if still at default (0)
+    if (operatorFeeBps === 0) {
+      try {
+        operatorFeeBps = await readOperatorFeeBps(contractId);
+        if (operatorFeeBps > 0) {
+          await query(
+            `UPDATE vaults SET operator_fee_bps = $1, updated_at = NOW() WHERE id = $2`,
+            [operatorFeeBps, vaultId],
+          );
+        }
+      } catch (err) {
+        logger.warn({ err, contractId }, "Failed to read operator_fee_bps from chain");
+      }
+    }
+
+    const parsedData: Record<string, unknown> | undefined =
+      operatorFeeBps > 0
+        ? {
+            grossYield: grossYield.toString(),
+            operatorFee: (grossYield * BigInt(operatorFeeBps) / 10000n).toString(),
+            netYield:
+              (grossYield - (grossYield * BigInt(operatorFeeBps) / 10000n)).toString(),
+          }
+        : undefined;
+
     logger.info(
-      { contractId, epoch: yieldDist.epoch, amount: yieldDist.amount.toString() },
+      { contractId, epoch: yieldDist.epoch, amount: grossYield.toString() },
       "Processed yield_distributed event",
     );
+
+    return parsedData;
   }
 
   private async handleVaultCreated(
@@ -1102,10 +1135,14 @@ export class Indexer {
     logger.info({ contractId, user: ev.user, verified: ev.verified }, "Processed kyc_set event");
   }
 
-  private async recordEvent(event: any, eventType: string): Promise<void> {
+  private async recordEvent(
+    event: any,
+    eventType: string,
+    parsedData?: Record<string, unknown>,
+  ): Promise<void> {
     await query(
-      `INSERT INTO indexed_events (ledger, tx_hash, contract_id, event_type, payload)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO indexed_events (ledger, tx_hash, contract_id, event_type, payload, parsed_data)
+       VALUES ($1, $2, $3, $4, $5, $6)
        ON CONFLICT DO NOTHING`,
       [
         event.ledger ?? 0,
@@ -1113,6 +1150,7 @@ export class Indexer {
         event.contractId ?? "",
         eventType,
         JSON.stringify(event),
+        parsedData ? JSON.stringify(parsedData) : null,
       ],
     );
     indexerEventsProcessedTotal.inc();

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -300,6 +300,15 @@ export async function readEarlyRedemptionFeeBps(contractId: string): Promise<num
 }
 
 /**
+ * Read the operator fee in basis points from the contract.
+ * Returns a number representing the fee as basis points (e.g., 100 = 1%).
+ */
+export async function readOperatorFeeBps(contractId: string): Promise<number> {
+  const value = await simulateRead<number>(contractId, "operator_fee_bps");
+  return Number(value ?? 0);
+}
+
+/**
  * Read the funding deadline timestamp (unix seconds) from the contract.
  * Returns 0n when no deadline is configured.
  */

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -5,6 +5,10 @@ import type {
   PaginatedResponse,
   YieldHistoryEntry,
   ShareBalanceHistoryEntry,
+  PortfolioPnlResponse,
+  PortfolioPnlPosition,
+  IncomeForecastResponse,
+  IncomeForecastMonth,
 } from "../types/index.js";
 import { query } from "../db/index.js";
 import { YieldService } from "./yield.js";
@@ -182,6 +186,54 @@ export class UserService {
       totalPendingYield: totalPendingYield.toString(),
       totalValue,
     };
+  }
+
+  async getUserPortfolioPnl(address: string): Promise<PortfolioPnlResponse> {
+    const positions = await query<{
+      user_address: string;
+      contract_id: string;
+      shares: string;
+      deposited: string;
+      total_assets: string;
+      total_supply: string;
+    }>(
+      `SELECT uvp.user_address, v.contract_id, uvp.shares, uvp.deposited,
+              v.total_assets, v.total_supply
+       FROM user_vault_positions uvp
+       JOIN vaults v ON uvp.vault_id = v.id
+       WHERE uvp.user_address = $1 AND uvp.shares > 0
+       ORDER BY uvp.deposited DESC`,
+      [address],
+    );
+
+    const pnlPositions: PortfolioPnlPosition[] = positions.map((row) => {
+      const deposited = BigInt(row.deposited || "0");
+      const userShares = BigInt(row.shares || "0");
+      const totalAssets = BigInt(Math.round(parseFloat(row.total_assets || "0")));
+      const totalSupply = BigInt(Math.round(parseFloat(row.total_supply || "0")));
+
+      const currentValue =
+        userShares > 0n && totalSupply > 0n
+          ? (userShares * totalAssets) / totalSupply
+          : 0n;
+
+      const gainLoss = currentValue - deposited;
+
+      const gainLossPercent =
+        deposited > 0n
+          ? Number((gainLoss * 10000n) / deposited) / 100
+          : 0;
+
+      return {
+        contractId: row.contract_id,
+        deposited: deposited.toString(),
+        currentValue: currentValue.toString(),
+        gainLoss: gainLoss.toString(),
+        gainLossPercent: Math.round(gainLossPercent * 100) / 100,
+      };
+    });
+
+    return { positions: pnlPositions };
   }
 
   async getShareBalanceHistory(
@@ -365,5 +417,131 @@ export class UserService {
     });
 
     return { data, total, page, pageSize };
+  }
+
+  async getUserIncomeForecast(
+    address: string,
+    months: number,
+  ): Promise<IncomeForecastResponse> {
+    const clampedMonths = Math.min(12, Math.max(1, months));
+
+    const positions = await query<{
+      vault_id: number;
+      contract_id: string;
+      shares: string;
+    }>(
+      `SELECT uvp.vault_id, v.contract_id, uvp.shares
+       FROM user_vault_positions uvp
+       JOIN vaults v ON uvp.vault_id = v.id
+       WHERE uvp.user_address = $1 AND uvp.shares > 0`,
+      [address],
+    );
+
+    if (positions.length === 0) {
+      const monthsResult: IncomeForecastMonth[] = [];
+      const now = new Date();
+      for (let i = 0; i < clampedMonths; i++) {
+        const d = new Date(now.getFullYear(), now.getMonth() + i + 1, 1);
+        monthsResult.push({
+          month: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`,
+          projectedYield: "0",
+          vaultCount: 0,
+        });
+      }
+      return { months: monthsResult };
+    }
+
+    const vaultIds = positions.map((p) => p.vault_id);
+    const vaultPositionMap = new Map(
+      positions.map((p) => [p.vault_id, { shares: BigInt(p.shares), contractId: p.contract_id }]),
+    );
+
+    // Fetch epoch data for all user vaults in one query
+    const epochRows = await query<{
+      vault_id: number;
+      yield_amount: string;
+      total_shares: string;
+      distributed_at: Date;
+    }>(
+      `SELECT e.vault_id, e.yield_amount, e.total_shares, e.distributed_at
+       FROM epochs e
+       WHERE e.vault_id = ANY($1)
+       ORDER BY e.distributed_at ASC`,
+      [vaultIds],
+    );
+
+    // Compute average yield per month per vault
+    const vaultMonthlyData = new Map<
+      number,
+      { avgMonthlyYield: bigint; shareRatio: number }
+    >();
+
+    const vaultEpochs = new Map<number, typeof epochRows>();
+    for (const row of epochRows) {
+      const list = vaultEpochs.get(row.vault_id) ?? [];
+      list.push(row);
+      vaultEpochs.set(row.vault_id, list);
+    }
+
+    for (const [vaultId, epochs] of vaultEpochs) {
+      if (epochs.length === 0) continue;
+
+      const position = vaultPositionMap.get(vaultId);
+      if (!position || position.shares === 0n) continue;
+
+      const firstEpoch = epochs[0].distributed_at;
+      const lastEpoch = epochs[epochs.length - 1].distributed_at;
+
+      const totalYield = epochs.reduce(
+        (sum, e) => sum + BigInt(e.yield_amount),
+        0n,
+      );
+
+      // Time span in months
+      const spanMs = lastEpoch.getTime() - firstEpoch.getTime();
+      const spanMonths = Math.max(spanMs / (30.44 * 24 * 60 * 60 * 1000), 1);
+
+      const avgMonthlyYield = totalYield / BigInt(Math.round(spanMonths));
+
+      // Compute user's share ratio for this vault
+      const latestTotalShares = BigInt(
+        epochs[epochs.length - 1].total_shares,
+      );
+      const shareRatio =
+        latestTotalShares > 0n
+          ? Number((position.shares * 10000n) / latestTotalShares) / 10000
+          : 0;
+
+      vaultMonthlyData.set(vaultId, { avgMonthlyYield, shareRatio });
+    }
+
+    // Project yield for each month
+    const monthsResult: IncomeForecastMonth[] = [];
+    const now = new Date();
+
+    for (let i = 0; i < clampedMonths; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() + i + 1, 1);
+      const monthStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+
+      let totalProjected = 0n;
+      let vaultCount = 0;
+
+      for (const [_vaultId, data] of vaultMonthlyData) {
+        const userMonthlyYield =
+          BigInt(Math.round(Number(data.avgMonthlyYield) * data.shareRatio));
+        if (userMonthlyYield > 0n) {
+          totalProjected += userMonthlyYield;
+          vaultCount++;
+        }
+      }
+
+      monthsResult.push({
+        month: monthStr,
+        projectedYield: totalProjected.toString(),
+        vaultCount,
+      });
+    }
+
+    return { months: monthsResult };
   }
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -145,3 +145,33 @@ export interface OperatorLogEntry {
   ledger: number;
   timestamp: string;
 }
+
+export interface PortfolioPnlPosition {
+  contractId: string;
+  deposited: string;
+  currentValue: string;
+  gainLoss: string;
+  gainLossPercent: number;
+}
+
+export interface PortfolioPnlResponse {
+  positions: PortfolioPnlPosition[];
+}
+
+export interface IncomeForecastMonth {
+  month: string;
+  projectedYield: string;
+  vaultCount: number;
+}
+
+export interface IncomeForecastResponse {
+  months: IncomeForecastMonth[];
+}
+
+export interface AnalyticsSummary {
+  totalUsers: number;
+  totalVaults: number;
+  totalValueLocked: string;
+  totalYieldDistributed: string;
+  totalDepositors: number;
+}


### PR DESCRIPTION
## Summary

Implements 4 features across issues #782–#785.

### Closes #782 — Portfolio Unrealized Gain/Loss Endpoint

`GET /api/v1/users/:address/portfolio/pnl` returns per-vault PnL with `currentValue`, `gainLoss`, and `gainLossPercent`.

- currentValue = (userShares / totalSupply) x totalAssets
- gainLoss is negative when the vault has lost value
- currentValue is "0" for zero-share positions

### Closes #783 — Platform Analytics Summary Endpoint

`GET /api/v1/analytics/summary` returns totalUsers, totalVaults, totalValueLocked, totalYieldDistributed, totalDepositors.

- No authentication required
- Cached for 60 seconds

### Closes #784 — Portfolio Income Forecast by Calendar Month

`GET /api/v1/users/:address/portfolio/income-forecast?months=6` projects yield per month using historical epoch data and user share ratios.

- Returns up to 12 months
- Months with no active positions return projectedYield: "0"

### Closes #785 — Track Operator Fee Amounts in indexed_events

Adds `parsed_data` JSONB column to `indexed_events` and `operator_fee_bps` column to `vaults`.

- On yield_distributed events, stores `{ grossYield, operatorFee, netYield }` in `parsed_data`
- operatorFeeBps lazily read from on-chain contract state and cached in DB
- Guarantees netYield + operatorFee = grossYield

## Changes

| File | Description |
|------|-------------|
| `backend/src/db/migrations/024_indexed_events_parsed_data.sql` | Add `parsed_data` JSONB column |
| `backend/src/db/migrations/025_vault_operator_fee_bps.sql` | Add `operator_fee_bps` to vaults |
| `backend/src/services/indexer.ts` | Compute fee breakdown on yield_distributed, pass parsedData to recordEvent |
| `backend/src/services/stellar.ts` | Add `readOperatorFeeBps` helper |
| `backend/src/services/user.ts` | Add `getUserPortfolioPnl` and `getUserIncomeForecast` methods |
| `backend/src/api/controllers/users.ts` | Add PnL and income forecast controllers |
| `backend/src/api/routes/users.ts` | Add PnL and income forecast routes |
| `backend/src/api/controllers/analytics.ts` | New analytics summary controller with 60s cache |
| `backend/src/api/routes/analytics.ts` | New analytics router |
| `backend/src/app.ts` | Mount analytics router |
| `backend/src/types/index.ts` | Add new type interfaces |