### PR TITLE
feat: Add fee analytics endpoints (#786, #787, #788, #789)

### DIFF
--- a/backend/src/api/controllers/admin.ts
+++ b/backend/src/api/controllers/admin.ts
@@ -342,3 +342,63 @@ export async function getDbStats(_req: Request, res: Response, next: NextFunctio
     next(err);
   }
 }
+
+/**
+ * GET /api/v1/admin/fees
+ *
+ * Returns platform-wide fee analytics:
+ *   { totalOperatorFees, totalEarlyRedemptionFees, totalPlatformRevenue,
+ *     topFeeVaults }
+ *
+ * topFeeVaults = top 5 vaults by total operator fees.
+ * totalPlatformRevenue = totalOperatorFees + totalEarlyRedemptionFees.
+ *
+ * Issue #789
+ */
+export async function getAdminFees(_req: Request, res: Response, next: NextFunction) {
+  try {
+    // Total operator fees across all vaults from parsed_data
+    const operatorFeeRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM((parsed_data->>'operatorFee')::numeric), 0)::text AS total
+       FROM indexed_events
+       WHERE event_type = 'yield_distributed' AND parsed_data IS NOT NULL`,
+    );
+    const totalOperatorFees = operatorFeeRows[0]?.total ?? "0";
+
+    // Total early redemption fees from redemption_requests
+    const redemptionFeeRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM(fee_revenue), 0)::text AS total
+       FROM redemption_requests
+       WHERE processed = TRUE AND fee_revenue > 0`,
+    );
+    const totalEarlyRedemptionFees = redemptionFeeRows[0]?.total ?? "0";
+
+    const totalOperatorBig = BigInt(Math.round(parseFloat(totalOperatorFees)));
+    const totalRedemptionBig = BigInt(Math.round(parseFloat(totalEarlyRedemptionFees)));
+    const totalPlatformRevenue = (totalOperatorBig + totalRedemptionBig).toString();
+
+    // Top 5 vaults by total operator fees
+    const topFeeVaults = await query<{ contract_id: string; total_fees: string }>(
+      `SELECT
+         ie.contract_id,
+         COALESCE(SUM((ie.parsed_data->>'operatorFee')::numeric), 0)::text AS total_fees
+       FROM indexed_events ie
+       WHERE ie.event_type = 'yield_distributed' AND ie.parsed_data IS NOT NULL
+       GROUP BY ie.contract_id
+       ORDER BY SUM((ie.parsed_data->>'operatorFee')::numeric) DESC
+       LIMIT 5`,
+    );
+
+    res.json({
+      totalOperatorFees: totalOperatorBig.toString(),
+      totalEarlyRedemptionFees: totalRedemptionBig.toString(),
+      totalPlatformRevenue,
+      topFeeVaults: topFeeVaults.map((v) => ({
+        contractId: v.contract_id,
+        totalFees: v.total_fees,
+      })),
+    });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { VaultService } from "../../services/vault.js";
-import { readTotalAssets, readVaultState, readPaused } from "../../services/stellar.js";
+import { readTotalAssets, readVaultState, readPaused, readCooperator, readCooperatorFeeBps } from "../../services/stellar.js";
 import { query } from "../../db/index.js";
 
 const vaultService = new VaultService();
@@ -1061,6 +1061,150 @@ export async function getSimilarVaults(req: Request, res: Response, next: NextFu
     }
     setCacheHeaders(res);
     res.json(similar);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/:contractId/fees
+ *
+ * Returns operator fee summary for a vault:
+ *   { totalOperatorFees, epochCount, averageFeePerEpoch, feeBps,
+ *     earlyRedemptionFeeRevenue }
+ *
+ * totalOperatorFees is computed from indexed_events.parsed_data->>'operatorFee'.
+ * earlyRedemptionFeeRevenue is the sum of fee_revenue from processed redemption_requests.
+ *
+ * Issue #786, #788
+ */
+export async function getVaultFees(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = contractAddressSchema.safeParse(req.params["contractId"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid contractId format" });
+      return;
+    }
+    const contractId = parsed.data;
+
+    const vaultRows = await query<{ id: number; operator_fee_bps: number }>(
+      "SELECT id, operator_fee_bps FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+    const vaultId = vaultRows[0].id;
+    const feeBps = vaultRows[0].operator_fee_bps ?? 0;
+
+    // Total operator fees from parsed_data on yield_distributed events
+    const feeRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM((parsed_data->>'operatorFee')::numeric), 0)::text AS total
+       FROM indexed_events
+       WHERE contract_id = $1 AND event_type = 'yield_distributed' AND parsed_data IS NOT NULL`,
+      [contractId],
+    );
+    const totalOperatorFees = feeRows[0]?.total ?? "0";
+
+    // Epoch count for average calculation
+    const epochRows = await query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM epochs WHERE vault_id = $1",
+      [vaultId],
+    );
+    const epochCount = parseInt(epochRows[0]?.count ?? "0", 10);
+
+    const totalOperatorFeesBig = BigInt(Math.round(parseFloat(totalOperatorFees)));
+    const averageFeePerEpoch = epochCount > 0
+      ? (totalOperatorFeesBig / BigInt(epochCount)).toString()
+      : "0";
+
+    // Early redemption fee revenue (Issue #788)
+    const redemptionFeeRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM(fee_revenue), 0)::text AS total
+       FROM redemption_requests
+       WHERE vault_id = $1 AND processed = TRUE AND fee_revenue > 0`,
+      [vaultId],
+    );
+    const earlyRedemptionFeeRevenue = redemptionFeeRows[0]?.total ?? "0";
+
+    setCacheHeaders(res);
+    res.json({
+      totalOperatorFees: totalOperatorFeesBig.toString(),
+      epochCount,
+      averageFeePerEpoch,
+      feeBps,
+      earlyRedemptionFeeRevenue,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/vaults/:contractId/fees/cooperator
+ *
+ * Returns cooperator fee breakdown for a vault:
+ *   { cooperatorAddress, cooperatorFeeBps, totalCooperatorFees }
+ *
+ * totalCooperatorFees = totalOperatorFees × cooperatorFeeBps / 10000
+ * Returns zeroes if cooperatorFeeBps is 0.
+ *
+ * Issue #787
+ */
+export async function getCooperatorFees(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = contractAddressSchema.safeParse(req.params["contractId"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid contractId format" });
+      return;
+    }
+    const contractId = parsed.data;
+
+    const vaultRows = await query<{ id: number }>(
+      "SELECT id FROM vaults WHERE contract_id = $1",
+      [contractId],
+    );
+    if (vaultRows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+
+    // Read cooperator address from chain
+    let cooperatorAddress = "";
+    try {
+      cooperatorAddress = await readCooperator(contractId);
+    } catch {
+      // If chain read fails, return zeroes
+    }
+
+    // Get cooperator fee bps from chain
+    let cooperatorFeeBps = 0;
+    try {
+      cooperatorFeeBps = await readCooperatorFeeBps(contractId);
+    } catch {
+      // cooperator_fee_bps not available
+    }
+
+    // Total operator fees
+    const feeRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM((parsed_data->>'operatorFee')::numeric), 0)::text AS total
+       FROM indexed_events
+       WHERE contract_id = $1 AND event_type = 'yield_distributed' AND parsed_data IS NOT NULL`,
+      [contractId],
+    );
+    const totalOperatorFees = BigInt(Math.round(parseFloat(feeRows[0]?.total ?? "0")));
+
+    const totalCooperatorFees = cooperatorFeeBps > 0
+      ? (totalOperatorFees * BigInt(cooperatorFeeBps) / 10000n).toString()
+      : "0";
+
+    setCacheHeaders(res);
+    res.json({
+      cooperatorAddress,
+      cooperatorFeeBps,
+      totalCooperatorFees,
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit, backfillIndexer, deleteApiKey, getApiKeys, getWebhookDeliveries, getArchivedVaults, getTotalSupplyConsistency, getDbStats } from "../controllers/admin.js";
+import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit, backfillIndexer, deleteApiKey, getApiKeys, getWebhookDeliveries, getArchivedVaults, getTotalSupplyConsistency, getDbStats, getAdminFees } from "../controllers/admin.js";
 import { requireApiKey } from "../middleware/auth.js";
 
 export const adminRouter = Router();
@@ -17,3 +17,4 @@ adminRouter.get("/api-keys", getApiKeys);
 adminRouter.delete("/api-keys/:id", deleteApiKey);
 adminRouter.get("/webhooks/:id/deliveries", getWebhookDeliveries);
 adminRouter.get("/db/stats", getDbStats);
+adminRouter.get("/fees", getAdminFees);

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -29,6 +29,8 @@ import {
   getMaturingSoonVaults,
   getFullyFundedVaults,
   getSimilarVaults,
+  getVaultFees,
+  getCooperatorFees,
 } from "../controllers/vaults.js";
 import { validateParams, validateQuery } from "../middleware/validate.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -126,6 +128,10 @@ vaultsRouter.get(
   validateParams(vaultParamsSchema),
   getEarlyRedemptionFee,
 );
+// Operator fee summary per vault: GET /api/v1/vaults/:contractId/fees
+vaultsRouter.get("/:contractId/fees", validateParams(vaultParamsSchema), getVaultFees);
+// Cooperator fee breakdown: GET /api/v1/vaults/:contractId/fees/cooperator
+vaultsRouter.get("/:contractId/fees/cooperator", validateParams(vaultParamsSchema), getCooperatorFees);
 // Export vault data as CSV: GET /api/v1/vaults/:contractId/export.csv
 vaultsRouter.get("/:contractId/export.csv", validateParams(vaultParamsSchema), exportVaultCsv);
 // Operators list: GET /api/v1/vaults/:contractId/operators

--- a/backend/src/db/migrations/026_redemption_fee_revenue.sql
+++ b/backend/src/db/migrations/026_redemption_fee_revenue.sql
@@ -1,0 +1,9 @@
+-- Add fee_revenue and gross_assets columns to redemption_requests to track
+-- early redemption fee revenue per processed redemption.
+-- Issue #788: Add early redemption fee revenue tracking
+
+ALTER TABLE redemption_requests
+  ADD COLUMN IF NOT EXISTS fee_revenue NUMERIC DEFAULT 0;
+
+ALTER TABLE redemption_requests
+  ADD COLUMN IF NOT EXISTS gross_assets NUMERIC DEFAULT 0;

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -927,13 +927,47 @@ export class Indexer {
     }
     const vaultId = vaultRow[0].id;
 
-    await query(
-      `UPDATE redemption_requests SET processed = TRUE
-       WHERE vault_id = $1 AND request_id = $2 AND processed = FALSE`,
+    // Look up the redemption request to get shares for gross-asset computation
+    const reqRows = await query<{ shares: string }>(
+      `SELECT shares FROM redemption_requests
+       WHERE vault_id = $1 AND request_id = $2 AND processed = FALSE
+       LIMIT 1`,
       [vaultId, event.requestId],
     );
+
+    let feeRevenue = 0;
+    let grossAssets = 0;
+
+    if (reqRows.length > 0) {
+      const shares = toBigIntOrZero(reqRows[0].shares);
+
+      const vaultState = await query<{ total_assets: string; total_supply: string }>(
+        "SELECT total_assets::text, total_supply::text FROM vaults WHERE id = $1",
+        [vaultId],
+      );
+
+      if (vaultState.length > 0) {
+        const totalAssets = toBigIntOrZero(vaultState[0].total_assets);
+        const totalSupply = toBigIntOrZero(vaultState[0].total_supply);
+
+        // Compute gross assets at current exchange rate (1:1 when no supply)
+        const gross = totalSupply > 0n
+          ? (shares * totalAssets) / totalSupply
+          : shares;
+
+        grossAssets = Number(gross);
+        feeRevenue = grossAssets - Number(event.netAssets);
+        if (feeRevenue < 0) feeRevenue = 0;
+      }
+    }
+
+    await query(
+      `UPDATE redemption_requests SET processed = TRUE, fee_revenue = $3, gross_assets = $4
+       WHERE vault_id = $1 AND request_id = $2 AND processed = FALSE`,
+      [vaultId, event.requestId, feeRevenue, grossAssets],
+    );
     logger.info(
-      { contractId, user: event.user, requestId: event.requestId },
+      { contractId, user: event.user, requestId: event.requestId, feeRevenue },
       "Processed early_redemption_processed event",
     );
   }

--- a/backend/src/services/openapi.ts
+++ b/backend/src/services/openapi.ts
@@ -283,6 +283,54 @@ function registerPaths(): void {
 
   registry.registerPath({
     method: "get",
+    path: "/api/v1/vaults/{contractId}/fees",
+    summary: "Get operator fee summary per vault",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: {
+        description: "Vault fee summary",
+        content: {
+          "application/json": {
+            schema: z.object({
+              totalOperatorFees: z.string(),
+              epochCount: z.number(),
+              averageFeePerEpoch: z.string(),
+              feeBps: z.number(),
+              earlyRedemptionFeeRevenue: z.string(),
+            }),
+          },
+        },
+      },
+      404: { description: "Vault not found", content: { "application/json": { schema: errorResponseSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/vaults/{contractId}/fees/cooperator",
+    summary: "Get cooperator fee breakdown per vault",
+    tags: ["Vaults"],
+    parameters: [{ name: "contractId", in: "path", required: true, schema: { type: "string" } }],
+    responses: {
+      200: {
+        description: "Cooperator fee breakdown",
+        content: {
+          "application/json": {
+            schema: z.object({
+              cooperatorAddress: z.string(),
+              cooperatorFeeBps: z.number(),
+              totalCooperatorFees: z.string(),
+            }),
+          },
+        },
+      },
+      404: { description: "Vault not found", content: { "application/json": { schema: errorResponseSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
     path: "/api/v1/users/{address}",
     summary: "Get user by address",
     tags: ["Users"],
@@ -349,6 +397,28 @@ function registerPaths(): void {
     tags: ["Admin"],
     responses: {
       200: { description: "Admin statistics", content: { "application/json": { schema: adminStatsSchema } } },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v1/admin/fees",
+    summary: "Get platform-wide fee analytics (requires API key)",
+    tags: ["Admin"],
+    responses: {
+      200: {
+        description: "Platform fee analytics",
+        content: {
+          "application/json": {
+            schema: z.object({
+              totalOperatorFees: z.string(),
+              totalEarlyRedemptionFees: z.string(),
+              totalPlatformRevenue: z.string(),
+              topFeeVaults: z.array(z.object({ contractId: z.string(), totalFees: z.string() })),
+            }),
+          },
+        },
+      },
     },
   });
 

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -309,6 +309,15 @@ export async function readOperatorFeeBps(contractId: string): Promise<number> {
 }
 
 /**
+ * Read the cooperator fee in basis points from the contract.
+ * Returns 0 if not set.
+ */
+export async function readCooperatorFeeBps(contractId: string): Promise<number> {
+  const value = await simulateRead<number>(contractId, "cooperator_fee_bps");
+  return Number(value ?? 0);
+}
+
+/**
  * Read the funding deadline timestamp (unix seconds) from the contract.
  * Returns 0n when no deadline is configured.
  */


### PR DESCRIPTION
## Summary

Adds platform-wide and per-vault fee analytics endpoints to the backend API.

### Changes

#### New Endpoints
- **`GET /api/v1/vaults/:contractId/fees`** — Operator fee summary per vault
  - Returns `totalOperatorFees`, `epochCount`, `averageFeePerEpoch`, `feeBps`, `earlyRedemptionFeeRevenue`
  - Computes `totalOperatorFees` from `SUM(indexed_events.parsed_data->>'operatorFee')`
  - Includes early redemption fee revenue from processed redemption_requests
  - Returns zeroes for a vault with no yield history

- **`GET /api/v1/vaults/:contractId/fees/cooperator`** — Cooperator fee breakdown
  - Returns `cooperatorAddress`, `cooperatorFeeBps`, `totalCooperatorFees`
  - `totalCooperatorFees = totalOperatorFees × cooperatorFeeBps / 10000`
  - Returns zeroes if `cooperatorFeeBps = 0`

- **`GET /api/v1/admin/fees`** — Platform-wide fee analytics (requires API key)
  - Returns `totalOperatorFees`, `totalEarlyRedemptionFees`, `totalPlatformRevenue`, `topFeeVaults`
  - `totalPlatformRevenue = totalOperatorFees + totalEarlyRedemptionFees`
  - `topFeeVaults` = top 5 vaults by total operator fees

#### Database Migration
- **`026_redemption_fee_revenue.sql`** — Adds `fee_revenue` and `gross_assets` columns to `redemption_requests`

#### Indexer Updates
- `handleEarlyRedemptionProcessed` now populates `fee_revenue` and `gross_assets` on the redemption request when processing early redemption events

#### Other
- Added `readCooperatorFeeBps` to `stellar.ts`
- Updated OpenAPI documentation for all new endpoints

Closes #786
Closes #787
Closes #788
Closes #789