### PR TITLE
feat: AML flags, compliance snapshot endpoints, and auth logging

### DIFF
--- a/backend/src/api/controllers/admin.ts
+++ b/backend/src/api/controllers/admin.ts
@@ -5,6 +5,7 @@ import { logger } from "../../logger.js";
 import { sseManager } from "../../services/sseManager.js";
 import { z } from "zod";
 
+const stellarAddressSchema = z.string().length(56).regex(/^G[A-Z2-7]{55}$/);
 const contractAddressSchema = z.string().length(56).regex(/^C[A-Z2-7]{55}$/);
 
 export async function getAdminStats(_req: Request, res: Response, next: NextFunction) {
@@ -412,6 +413,195 @@ export async function getAdminFees(_req: Request, res: Response, next: NextFunct
         totalFees: v.total_fees,
       })),
     });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * POST /api/v1/admin/users/:address/aml-flag
+ *
+ * Sets aml_flagged = true on a user record. Admin only. (#798)
+ */
+export async function flagUserAml(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = stellarAddressSchema.safeParse(req.params["address"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid address format" });
+      return;
+    }
+    const address = parsed.data;
+
+    const rows = await query<{ id: number }>(
+      "SELECT id FROM users WHERE address = $1",
+      [address],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "User not found" });
+      return;
+    }
+
+    await query(
+      `UPDATE users SET aml_flagged = TRUE, aml_flagged_at = NOW(), updated_at = NOW()
+       WHERE address = $1`,
+      [address],
+    );
+
+    res.json({ address, amlFlagged: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * POST /api/v1/admin/users/:address/aml-clear
+ *
+ * Sets aml_flagged = false on a user record. Admin only. (#798)
+ */
+export async function clearUserAml(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = stellarAddressSchema.safeParse(req.params["address"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid address format" });
+      return;
+    }
+    const address = parsed.data;
+
+    const rows = await query<{ id: number }>(
+      "SELECT id FROM users WHERE address = $1",
+      [address],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "User not found" });
+      return;
+    }
+
+    await query(
+      `UPDATE users SET aml_flagged = FALSE, aml_flagged_at = NULL, updated_at = NOW()
+       WHERE address = $1`,
+      [address],
+    );
+
+    res.json({ address, amlFlagged: false });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/admin/compliance/flagged-users
+ *
+ * Returns all users where aml_flagged = true. Admin only. (#799)
+ */
+export async function getFlaggedUsers(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const rows = await query<{
+      address: string;
+      aml_flagged_at: Date;
+      total_deposited: string;
+      kyc_verified: boolean;
+    }>(
+      `SELECT
+         u.address,
+         u.aml_flagged_at,
+         COALESCE(SUM(uvp.deposited), 0)::text AS total_deposited,
+         u.kyc_verified
+       FROM users u
+       LEFT JOIN user_vault_positions uvp ON uvp.user_address = u.address
+       WHERE u.aml_flagged = TRUE
+       GROUP BY u.address, u.aml_flagged_at, u.kyc_verified
+       ORDER BY u.aml_flagged_at DESC`,
+    );
+
+    res.json(
+      rows.map((r) => ({
+        address: r.address,
+        amlFlaggedAt: r.aml_flagged_at,
+        totalDeposited: r.total_deposited,
+        kycVerified: r.kyc_verified,
+      })),
+    );
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * GET /api/v1/admin/compliance/positions-snapshot
+ *
+ * Returns all user vault positions as of a given timestamp using
+ * share_balance_snapshots. Supports contractId filter and CSV output. (#800)
+ */
+export async function getPositionsSnapshot(req: Request, res: Response, next: NextFunction) {
+  try {
+    const asOfParam = req.query["asOf"] as string | undefined;
+    const contractIdParam = req.query["contractId"] as string | undefined;
+    const formatParam = req.query["format"] as string | undefined;
+
+    if (!asOfParam) {
+      res.status(400).json({ error: "BadRequest", message: "asOf query parameter is required (ISO 8601)" });
+      return;
+    }
+
+    const asOf = new Date(asOfParam);
+    if (isNaN(asOf.getTime())) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid asOf timestamp" });
+      return;
+    }
+
+    if (contractIdParam) {
+      const cidParsed = contractAddressSchema.safeParse(contractIdParam);
+      if (!cidParsed.success) {
+        res.status(400).json({ error: "BadRequest", message: "Invalid contractId format" });
+        return;
+      }
+    }
+
+    const params: unknown[] = [asOf.toISOString()];
+    let contractFilter = "";
+    if (contractIdParam) {
+      params.push(contractIdParam);
+      contractFilter = `AND v.contract_id = $${params.length}`;
+    }
+
+    const rows = await query<{
+      user_address: string;
+      vault_contract_id: string;
+      shares: string;
+      recorded_at: Date;
+    }>(
+      `SELECT DISTINCT ON (sbs.user_address, sbs.vault_id)
+         sbs.user_address,
+         v.contract_id AS vault_contract_id,
+         sbs.shares::text AS shares,
+         sbs.recorded_at
+       FROM share_balance_snapshots sbs
+       JOIN vaults v ON sbs.vault_id = v.id
+       WHERE sbs.recorded_at <= $1
+         ${contractFilter}
+       ORDER BY sbs.user_address, sbs.vault_id, sbs.epoch DESC`,
+      params,
+    );
+
+    if (formatParam === "csv") {
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader("Content-Disposition", `attachment; filename="positions-snapshot-${asOf.toISOString()}.csv"`);
+      const header = "user_address,vault_contract_id,shares,recorded_at\n";
+      const csvBody = rows
+        .map((r) => `${r.user_address},${r.vault_contract_id},${r.shares},${r.recorded_at.toISOString()}`)
+        .join("\n");
+      res.send(header + csvBody);
+      return;
+    }
+
+    res.json(
+      rows.map((r) => ({
+        userAddress: r.user_address,
+        vaultContractId: r.vault_contract_id,
+        shares: r.shares,
+        recordedAt: r.recorded_at,
+      })),
+    );
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/middleware/auth.ts
+++ b/backend/src/api/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 import type { Request, Response, NextFunction } from "express";
 import { query } from "../../db/index.js";
+import { logger } from "../../logger.js";
 
 interface ApiKey {
   id: number;
@@ -17,8 +18,20 @@ declare module "express-serve-static-core" {
 
 const READ_ONLY_METHODS = new Set(["GET", "HEAD"]);
 
+function getClientIp(req: Request): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    return forwarded.split(",")[0].trim();
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0].trim();
+  }
+  return req.socket.remoteAddress ?? "unknown";
+}
+
 export function requireApiKey(options?: { role?: string; minRole?: "readonly" | "admin" }) {
   return async (req: Request, res: Response, next: NextFunction) => {
+    const ip = getClientIp(req);
     const authHeader = req.headers.authorization;
     let plaintext: string | undefined;
 
@@ -31,6 +44,15 @@ export function requireApiKey(options?: { role?: string; minRole?: "readonly" | 
     }
 
     if (!plaintext) {
+      logger.info({
+        event: "auth_attempt",
+        success: false,
+        ip,
+        keyLabel: null,
+        path: req.path,
+        method: req.method,
+        reason: "missing_key",
+      });
       res.status(401).json({ error: "Unauthorized", message: "Missing API key" });
       return;
     }
@@ -42,6 +64,15 @@ export function requireApiKey(options?: { role?: string; minRole?: "readonly" | 
     ).catch(() => [] as ApiKey[]);
 
     if (rows.length === 0) {
+      logger.info({
+        event: "auth_attempt",
+        success: false,
+        ip,
+        keyLabel: null,
+        path: req.path,
+        method: req.method,
+        reason: "key_not_found",
+      });
       res.status(403).json({ error: "Forbidden", message: "Invalid API key" });
       return;
     }
@@ -49,21 +80,57 @@ export function requireApiKey(options?: { role?: string; minRole?: "readonly" | 
     const apiKey = rows[0];
 
     if (apiKey.expiresAt && apiKey.expiresAt.getTime() <= Date.now()) {
+      logger.info({
+        event: "auth_attempt",
+        success: false,
+        ip,
+        keyLabel: apiKey.label,
+        path: req.path,
+        method: req.method,
+        reason: "expired",
+      });
       res.status(401).json({ error: "Unauthorized", message: "API key has expired" });
       return;
     }
 
     if (options?.role && apiKey.role !== options.role) {
+      logger.info({
+        event: "auth_attempt",
+        success: false,
+        ip,
+        keyLabel: apiKey.label,
+        path: req.path,
+        method: req.method,
+        reason: "insufficient_permissions",
+      });
       res.status(403).json({ error: "Forbidden", message: "Insufficient permissions" });
       return;
     }
 
     if (options?.minRole === "readonly" && apiKey.role !== "admin") {
       if (apiKey.role !== "readonly" || !READ_ONLY_METHODS.has(req.method)) {
+        logger.info({
+          event: "auth_attempt",
+          success: false,
+          ip,
+          keyLabel: apiKey.label,
+          path: req.path,
+          method: req.method,
+          reason: "insufficient_permissions",
+        });
         res.status(403).json({ error: "Forbidden", message: "Insufficient permissions" });
         return;
       }
     }
+
+    logger.info({
+      event: "auth_attempt",
+      success: true,
+      ip,
+      keyLabel: apiKey.label,
+      path: req.path,
+      method: req.method,
+    });
 
     req.apiKey = apiKey;
     next();

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit, backfillIndexer, deleteApiKey, getApiKeys, getWebhookDeliveries, getArchivedVaults, getTotalSupplyConsistency, getDbStats, streamIndexerProgress, getAdminFees } from "../controllers/admin.js";
+import { getAdminStats, getAdminIndexer, getAdminEvents, getVaultAudit, backfillIndexer, deleteApiKey, getApiKeys, getWebhookDeliveries, getArchivedVaults, getTotalSupplyConsistency, getDbStats, streamIndexerProgress, getAdminFees, flagUserAml, clearUserAml, getFlaggedUsers, getPositionsSnapshot } from "../controllers/admin.js";
 import { requireApiKey } from "../middleware/auth.js";
 
 export const adminRouter = Router();
@@ -19,3 +19,8 @@ adminRouter.delete("/api-keys/:id", deleteApiKey);
 adminRouter.get("/webhooks/:id/deliveries", getWebhookDeliveries);
 adminRouter.get("/db/stats", getDbStats);
 adminRouter.get("/fees", getAdminFees);
+
+adminRouter.post("/users/:address/aml-flag", flagUserAml);
+adminRouter.post("/users/:address/aml-clear", clearUserAml);
+adminRouter.get("/compliance/flagged-users", getFlaggedUsers);
+adminRouter.get("/compliance/positions-snapshot", getPositionsSnapshot);

--- a/backend/src/db/migrations/027_aml_flag.sql
+++ b/backend/src/db/migrations/027_aml_flag.sql
@@ -1,0 +1,7 @@
+-- Add AML flag columns to users table (Issue #798)
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS aml_flagged BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS aml_flagged_at TIMESTAMPTZ;

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -24,6 +24,8 @@ CREATE TABLE IF NOT EXISTS users (
   id              SERIAL PRIMARY KEY,
   address         TEXT NOT NULL UNIQUE,
   kyc_verified    BOOLEAN DEFAULT FALSE,
+  aml_flagged     BOOLEAN NOT NULL DEFAULT FALSE,
+  aml_flagged_at  TIMESTAMPTZ,
   created_at      TIMESTAMPTZ DEFAULT NOW(),
   updated_at      TIMESTAMPTZ DEFAULT NOW()
 );

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -48,10 +48,12 @@ export class UserService {
       id: number;
       address: string;
       kyc_verified: boolean;
+      aml_flagged: boolean;
+      aml_flagged_at: Date | null;
       created_at: Date;
       updated_at: Date;
     }>(
-      `SELECT id, address, kyc_verified, created_at, updated_at 
+      `SELECT id, address, kyc_verified, aml_flagged, aml_flagged_at, created_at, updated_at 
        FROM users 
        WHERE address = $1
        LIMIT 1`,
@@ -67,6 +69,8 @@ export class UserService {
       id: row.id,
       address: row.address,
       kycVerified: row.kyc_verified,
+      amlFlagged: row.aml_flagged,
+      amlFlaggedAt: row.aml_flagged_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -345,10 +349,12 @@ export class UserService {
       id: number;
       address: string;
       kyc_verified: boolean;
+      aml_flagged: boolean;
+      aml_flagged_at: Date | null;
       created_at: Date;
       updated_at: Date;
     }>(
-      `SELECT id, address, kyc_verified, created_at, updated_at 
+      `SELECT id, address, kyc_verified, aml_flagged, aml_flagged_at, created_at, updated_at 
        FROM users 
        WHERE address ILIKE $1 
        LIMIT 20`,
@@ -359,6 +365,8 @@ export class UserService {
       id: row.id,
       address: row.address,
       kycVerified: row.kyc_verified,
+      amlFlagged: row.aml_flagged,
+      amlFlaggedAt: row.aml_flagged_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     }));

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -42,6 +42,8 @@ export interface User {
   id: number;
   address: string;
   kycVerified: boolean;
+  amlFlagged: boolean;
+  amlFlaggedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary

Implements four compliance and security features across the backend API.

### Changes

**Issue #798 — AML flag field on user records**
- New migration `027_aml_flag.sql` adds `aml_flagged` (BOOLEAN) and `aml_flagged_at` (TIMESTAMPTZ) to `users`
- `POST /api/v1/admin/users/:address/aml-flag` sets `aml_flagged = true`
- `POST /api/v1/admin/users/:address/aml-clear` sets `aml_flagged = false`
- `GET /api/v1/users/:address` now includes `amlFlagged` and `amlFlaggedAt`
- Admin-only access enforced

**Issue #799 — AML-flagged users list endpoint**
- `GET /api/v1/admin/compliance/flagged-users` returns all users where `aml_flagged = true`
- Includes `address`, `amlFlaggedAt`, `totalDeposited`, `kycVerified`
- Ordered by `amlFlaggedAt DESC`

**Issue #800 — Regulatory position snapshot endpoint**
- `GET /api/v1/admin/compliance/positions-snapshot?asOf=<iso>` returns positions at a point in time
- Uses `share_balance_snapshots` to determine historical balances
- Supports `contractId` filter and `?format=csv` for CSV download

**Issue #801 — IP address logging for authentication events**
- All auth attempts now emit a structured log at `info` level
- Log includes: `event`, `success`, `ip`, `keyLabel`, `path`, `method`
- Uses `X-Forwarded-For` (first value) when behind a proxy
- Failed attempts include `reason` (`key_not_found`, `expired`, `insufficient_permissions`, `missing_key`)
- API key values are never logged — only the label

### Files Changed
- `backend/src/db/migrations/027_aml_flag.sql` (new)
- `backend/src/db/schema.sql` (updated users table)
- `backend/src/types/index.ts` (User interface)
- `backend/src/services/user.ts` (getUser, searchUsers)
- `backend/src/api/controllers/admin.ts` (4 new handlers)
- `backend/src/api/routes/admin.ts` (4 new routes)
- `backend/src/api/middleware/auth.ts` (auth attempt logging)

Closes #798
Closes #799
Closes #800
Closes #801