### PR TITLE
feat: Multi-field sorting and range filters for vault & epoch endpoints

### DIFF
--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -33,6 +33,8 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       cursor,
       sort,
       order,
+      createdFrom,
+      createdTo,
       q,
     } = req.query as unknown as {
       page: number;
@@ -42,9 +44,22 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       cursor?: string;
       sort?: string;
       order?: "asc" | "desc";
+      createdFrom?: string;
+      createdTo?: string;
       q?: string;
     };
-    const result = await vaultService.listVaults({ page, pageSize, state, category, cursor, sort, order, q });
+    const result = await vaultService.listVaults({
+      page,
+      pageSize,
+      state,
+      category,
+      cursor,
+      sort,
+      order,
+      createdFrom,
+      createdTo,
+      q,
+    });
     setCacheHeaders(res);
     res.json(result);
   } catch (err) {

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -35,6 +35,8 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       order,
       createdFrom,
       createdTo,
+      minTotalAssets,
+      maxTotalAssets,
       q,
     } = req.query as unknown as {
       page: number;
@@ -46,6 +48,8 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       order?: "asc" | "desc";
       createdFrom?: string;
       createdTo?: string;
+      minTotalAssets?: string;
+      maxTotalAssets?: string;
       q?: string;
     };
     const result = await vaultService.listVaults({
@@ -58,6 +62,8 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       order,
       createdFrom,
       createdTo,
+      minTotalAssets,
+      maxTotalAssets,
       q,
     });
     setCacheHeaders(res);

--- a/backend/src/api/controllers/vaults.ts
+++ b/backend/src/api/controllers/vaults.ts
@@ -40,8 +40,8 @@ export async function listVaults(req: Request, res: Response, next: NextFunction
       state?: string;
       category?: string;
       cursor?: string;
-      sort: "created_at" | "total_assets";
-      order: "asc" | "desc";
+      sort?: string;
+      order?: "asc" | "desc";
       q?: string;
     };
     const result = await vaultService.listVaults({ page, pageSize, state, category, cursor, sort, order, q });

--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -18,7 +18,15 @@ function formatYieldPerShare(yieldAmount: string, totalShares: string): string {
 
 export async function getVaultEpochs(req: Request, res: Response, next: NextFunction) {
   try {
-    const epochs = await yieldService.getVaultEpochs(String(req.params["contractId"]));
+    // Yield range filters, already validated by the route schema (#858).
+    const { minYield, maxYield } = (req.query ?? {}) as unknown as {
+      minYield?: string;
+      maxYield?: string;
+    };
+    const epochs = await yieldService.getVaultEpochs(String(req.params["contractId"]), {
+      minYield,
+      maxYield,
+    });
     res.json(
       epochs.map((e) => ({
         ...e,

--- a/backend/src/api/routes/vaults-query.test.ts
+++ b/backend/src/api/routes/vaults-query.test.ts
@@ -188,3 +188,80 @@ describe("GET /api/v1/vaults creation date range validation (#856)", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("GET /api/v1/vaults total assets range validation (#857)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listVaults.mockResolvedValue({ data: [], total: 0, page: 1, pageSize: 20 });
+  });
+
+  it("accepts a TVL range and forwards both bounds as strings", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?minTotalAssets=1000000&maxTotalAssets=5000000",
+    );
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions()).toMatchObject({
+      minTotalAssets: "1000000",
+      maxTotalAssets: "5000000",
+    });
+  });
+
+  it("accepts minTotalAssets on its own as an open-ended filter", async () => {
+    const res = await request.get("/api/v1/vaults?minTotalAssets=1000000");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions().maxTotalAssets).toBeUndefined();
+  });
+
+  it("accepts a bound beyond Number.MAX_SAFE_INTEGER without losing precision", async () => {
+    const huge = "170141183460469231731687303715884105727";
+    const res = await request.get(`/api/v1/vaults?maxTotalAssets=${huge}`);
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions().maxTotalAssets).toBe(huge);
+  });
+
+  it("accepts zero as a lower bound", async () => {
+    const res = await request.get("/api/v1/vaults?minTotalAssets=0");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions().minTotalAssets).toBe("0");
+  });
+
+  it("returns 400 for a non-numeric value", async () => {
+    const res = await request.get("/api/v1/vaults?minTotalAssets=abc");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("ValidationError");
+    expect(mocks.listVaults).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a negative value", async () => {
+    const res = await request.get("/api/v1/vaults?minTotalAssets=-1");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a fractional value", async () => {
+    const res = await request.get("/api/v1/vaults?maxTotalAssets=1000.5");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when minTotalAssets exceeds maxTotalAssets", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?minTotalAssets=5000000&maxTotalAssets=1000000",
+    );
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body.issues)).toContain("must not be greater than");
+  });
+
+  it("compares the bounds numerically, not lexicographically", async () => {
+    // "9" > "10" as strings, but 9 < 10 as numbers, so this must be accepted.
+    const res = await request.get("/api/v1/vaults?minTotalAssets=9&maxTotalAssets=10");
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/src/api/routes/vaults-query.test.ts
+++ b/backend/src/api/routes/vaults-query.test.ts
@@ -108,3 +108,83 @@ describe("GET /api/v1/vaults sort validation (#855)", () => {
     expect(forwardedOptions()).toMatchObject({ sort: "created_at", order: "desc" });
   });
 });
+
+describe("GET /api/v1/vaults creation date range validation (#856)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listVaults.mockResolvedValue({ data: [], total: 0, page: 1, pageSize: 20 });
+  });
+
+  it("accepts a calendar date range and forwards both bounds", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?createdFrom=2025-01-01&createdTo=2025-06-30",
+    );
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions()).toMatchObject({
+      createdFrom: "2025-01-01",
+      createdTo: "2025-06-30",
+    });
+  });
+
+  it("accepts a full ISO date-time range", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?createdFrom=2025-01-01T00:00:00Z&createdTo=2025-06-30T23:59:59Z",
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts createdFrom on its own as an open-ended filter", async () => {
+    const res = await request.get("/api/v1/vaults?createdFrom=2025-01-01");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions().createdFrom).toBe("2025-01-01");
+    expect(forwardedOptions().createdTo).toBeUndefined();
+  });
+
+  it("accepts createdTo on its own as an open-ended filter", async () => {
+    const res = await request.get("/api/v1/vaults?createdTo=2025-06-30");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions().createdTo).toBe("2025-06-30");
+    expect(forwardedOptions().createdFrom).toBeUndefined();
+  });
+
+  it("returns 400 for a malformed date", async () => {
+    const res = await request.get("/api/v1/vaults?createdFrom=not-a-date");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("ValidationError");
+    expect(mocks.listVaults).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-ISO date layout", async () => {
+    const res = await request.get("/api/v1/vaults?createdFrom=01/02/2025");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an ISO-shaped but impossible date", async () => {
+    const res = await request.get("/api/v1/vaults?createdTo=2025-02-30");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when createdFrom is after createdTo", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?createdFrom=2025-06-30&createdTo=2025-01-01",
+    );
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body.issues)).toContain("must not be after");
+  });
+
+  it("allows createdFrom equal to createdTo", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?createdFrom=2025-01-01&createdTo=2025-01-01",
+    );
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/src/api/routes/vaults-query.test.ts
+++ b/backend/src/api/routes/vaults-query.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+// Mock the data layer so the HTTP stack (routing, Zod validation, controller)
+// runs end-to-end without a real database or Stellar RPC.
+const mocks = vi.hoisted(() => ({
+  listVaults: vi.fn(),
+}));
+
+vi.mock("../../db/index.js", () => ({
+  query: vi.fn().mockResolvedValue([]),
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+vi.mock("../../services/stellar.js");
+
+// Only VaultService is stubbed — the router imports the real `parseVaultSort`
+// from this module to validate the `sort` parameter.
+vi.mock("../../services/vault.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/vault.js")>();
+  return {
+    ...actual,
+    VaultService: vi.fn(() => ({ listVaults: mocks.listVaults })),
+  };
+});
+
+import { vaultsRouter } from "./vaults.js";
+
+function buildApp() {
+  const app = express();
+  app.use("/api/v1/vaults", vaultsRouter);
+  return app;
+}
+
+const request = supertest(buildApp());
+
+/** The options object the controller forwarded to VaultService.listVaults. */
+function forwardedOptions() {
+  return mocks.listVaults.mock.calls[0][0];
+}
+
+describe("GET /api/v1/vaults sort validation (#855)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listVaults.mockResolvedValue({ data: [], total: 0, page: 1, pageSize: 20 });
+  });
+
+  it("accepts a multi-field sort and forwards it to the service", async () => {
+    const res = await request.get("/api/v1/vaults?sort=state:asc,total_assets:desc");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions().sort).toBe("state:asc,total_assets:desc");
+  });
+
+  it("accepts up to three sort fields", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?sort=state:asc,total_assets:desc,created_at:asc",
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 for more than three sort fields", async () => {
+    const res = await request.get(
+      "/api/v1/vaults?sort=state:asc,total_assets:desc,created_at:asc,name:asc",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("ValidationError");
+    expect(JSON.stringify(res.body.issues)).toContain("at most 3 fields");
+    expect(mocks.listVaults).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a sort field outside the allowlist", async () => {
+    const res = await request.get("/api/v1/vaults?sort=not_a_column:asc");
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body.issues)).toContain("Unknown sort field");
+    expect(mocks.listVaults).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid sort direction", async () => {
+    const res = await request.get("/api/v1/vaults?sort=state:upwards");
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body.issues)).toContain("Invalid sort direction");
+  });
+
+  it("returns 400 for a duplicated sort field", async () => {
+    const res = await request.get("/api/v1/vaults?sort=state:asc,state:desc");
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body.issues)).toContain("Duplicate sort field");
+  });
+
+  it("keeps the legacy single-field sort and order pair working", async () => {
+    const res = await request.get("/api/v1/vaults?sort=total_assets&order=asc");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions()).toMatchObject({ sort: "total_assets", order: "asc" });
+  });
+
+  it("defaults to created_at desc when sort is omitted", async () => {
+    const res = await request.get("/api/v1/vaults");
+
+    expect(res.status).toBe(200);
+    expect(forwardedOptions()).toMatchObject({ sort: "created_at", order: "desc" });
+  });
+});

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -72,6 +72,12 @@ const isoDateSchema = z.string().refine(isValidIsoDate, {
   message: "must be an ISO 8601 date (YYYY-MM-DD) or date-time",
 });
 
+// Token amounts exceed Number.MAX_SAFE_INTEGER, so BigInt-safe strings are kept
+// as strings all the way to the ::numeric cast rather than coerced to a number.
+const nonNegativeAmountSchema = z
+  .string()
+  .regex(/^\d+$/, "must be a non-negative integer");
+
 const listVaultsQuerySchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1),
@@ -86,6 +92,9 @@ const listVaultsQuerySchema = z
     // Creation date range; either bound may stand alone for an open-ended filter (#856).
     createdFrom: isoDateSchema.optional(),
     createdTo: isoDateSchema.optional(),
+    // Total assets (TVL) range; either bound may stand alone (#857).
+    minTotalAssets: nonNegativeAmountSchema.optional(),
+    maxTotalAssets: nonNegativeAmountSchema.optional(),
     q: z.string().optional(),
   })
   .superRefine((value, ctx) => {
@@ -103,6 +112,18 @@ const listVaultsQuerySchema = z
         code: z.ZodIssueCode.custom,
         path: ["createdFrom"],
         message: "createdFrom must not be after createdTo",
+      });
+    }
+
+    if (
+      value.minTotalAssets !== undefined &&
+      value.maxTotalAssets !== undefined &&
+      BigInt(value.minTotalAssets) > BigInt(value.maxTotalAssets)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["minTotalAssets"],
+        message: "minTotalAssets must not be greater than maxTotalAssets",
       });
     }
   });

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -39,6 +39,39 @@ import { parseVaultSort } from "../../services/vault.js";
 
 const contractAddressSchema = z.string().length(56).regex(/^C[A-Z2-7]{55}$/);
 
+// Accepts a calendar date (2025-01-31) or a full ISO 8601 date-time, with or
+// without an offset.
+const ISO_DATE_PATTERN =
+  /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/**
+ * Validate an ISO 8601 date or date-time string.
+ *
+ * The calendar round-trip is required because `Date.parse` silently rolls
+ * overflowing components over — "2025-02-30" becomes March 2 rather than NaN —
+ * so the shape check alone would let impossible dates through.
+ */
+function isValidIsoDate(value: string): boolean {
+  if (!ISO_DATE_PATTERN.test(value)) return false;
+
+  const [year, month, day] = value.slice(0, 10).split("-").map(Number);
+  const asUtc = new Date(Date.UTC(year, month - 1, day));
+  if (
+    asUtc.getUTCFullYear() !== year ||
+    asUtc.getUTCMonth() !== month - 1 ||
+    asUtc.getUTCDate() !== day
+  ) {
+    return false;
+  }
+
+  // Catches out-of-range time components such as T25:00:00Z.
+  return !Number.isNaN(Date.parse(value));
+}
+
+const isoDateSchema = z.string().refine(isValidIsoDate, {
+  message: "must be an ISO 8601 date (YYYY-MM-DD) or date-time",
+});
+
 const listVaultsQuerySchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1),
@@ -50,12 +83,27 @@ const listVaultsQuerySchema = z
     // A bare field name (`?sort=total_assets`) still takes its direction from `order`.
     sort: z.string().default("created_at"),
     order: z.enum(["asc", "desc"]).default("desc"),
+    // Creation date range; either bound may stand alone for an open-ended filter (#856).
+    createdFrom: isoDateSchema.optional(),
+    createdTo: isoDateSchema.optional(),
     q: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     const parsed = parseVaultSort(value.sort, value.order);
     if (!parsed.ok) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["sort"], message: parsed.message });
+    }
+
+    if (
+      value.createdFrom !== undefined &&
+      value.createdTo !== undefined &&
+      Date.parse(value.createdFrom) > Date.parse(value.createdTo)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["createdFrom"],
+        message: "createdFrom must not be after createdTo",
+      });
     }
   });
 

--- a/backend/src/api/routes/vaults.ts
+++ b/backend/src/api/routes/vaults.ts
@@ -35,19 +35,29 @@ import {
 } from "../controllers/vaults.js";
 import { validateParams, validateQuery } from "../middleware/validate.js";
 import { requireApiKey } from "../middleware/auth.js";
+import { parseVaultSort } from "../../services/vault.js";
 
 const contractAddressSchema = z.string().length(56).regex(/^C[A-Z2-7]{55}$/);
 
-const listVaultsQuerySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).default(20).transform((value) => Math.min(value, 100)),
-  state: z.string().optional(),
-  category: z.string().optional(),
-  cursor: z.string().optional(),
-  sort: z.enum(["created_at", "total_assets"]).default("created_at"),
-  order: z.enum(["asc", "desc"]).default("desc"),
-  q: z.string().optional(),
-});
+const listVaultsQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).default(20).transform((value) => Math.min(value, 100)),
+    state: z.string().optional(),
+    category: z.string().optional(),
+    cursor: z.string().optional(),
+    // Comma-separated `field[:direction]` list, e.g. `state:asc,total_assets:desc` (#855).
+    // A bare field name (`?sort=total_assets`) still takes its direction from `order`.
+    sort: z.string().default("created_at"),
+    order: z.enum(["asc", "desc"]).default("desc"),
+    q: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    const parsed = parseVaultSort(value.sort, value.order);
+    if (!parsed.ok) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["sort"], message: parsed.message });
+    }
+  });
 
 const vaultParamsSchema = z.object({
   contractId: contractAddressSchema,

--- a/backend/src/api/routes/yields-query.test.ts
+++ b/backend/src/api/routes/yields-query.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import supertest from "supertest";
+
+// Mock the data layer so the HTTP stack (routing, Zod validation, controller)
+// runs end-to-end without a real database.
+const mocks = vi.hoisted(() => ({
+  getVaultEpochs: vi.fn(),
+}));
+
+vi.mock("../../db/index.js", () => ({
+  query: vi.fn().mockResolvedValue([]),
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+vi.mock("../../services/yield.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/yield.js")>();
+  return {
+    ...actual,
+    YieldService: vi.fn(() => ({ getVaultEpochs: mocks.getVaultEpochs })),
+  };
+});
+
+import { yieldsRouter } from "./yields.js";
+
+function buildApp() {
+  const app = express();
+  app.use("/api/v1/yields", yieldsRouter);
+  return app;
+}
+
+const request = supertest(buildApp());
+
+const CONTRACT_ID = "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3B";
+const EPOCHS_PATH = `/api/v1/yields/${CONTRACT_ID}/epochs`;
+
+/** The filter options the controller forwarded to YieldService.getVaultEpochs. */
+function forwardedFilters() {
+  return mocks.getVaultEpochs.mock.calls[0][1];
+}
+
+describe("GET /api/v1/yields/:contractId/epochs yield range validation (#858)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getVaultEpochs.mockResolvedValue([]);
+  });
+
+  it("accepts a yield range and forwards both bounds as strings", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?minYield=100&maxYield=500`);
+
+    expect(res.status).toBe(200);
+    expect(forwardedFilters()).toMatchObject({ minYield: "100", maxYield: "500" });
+  });
+
+  it("accepts minYield on its own as an open-ended filter", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?minYield=100`);
+
+    expect(res.status).toBe(200);
+    expect(forwardedFilters().minYield).toBe("100");
+    expect(forwardedFilters().maxYield).toBeUndefined();
+  });
+
+  it("accepts maxYield on its own as an open-ended filter", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?maxYield=500`);
+
+    expect(res.status).toBe(200);
+    expect(forwardedFilters().maxYield).toBe("500");
+    expect(forwardedFilters().minYield).toBeUndefined();
+  });
+
+  it("forwards no bounds when neither is supplied", async () => {
+    const res = await request.get(EPOCHS_PATH);
+
+    expect(res.status).toBe(200);
+    expect(forwardedFilters()).toEqual({ minYield: undefined, maxYield: undefined });
+  });
+
+  it("accepts zero as a lower bound", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?minYield=0`);
+
+    expect(res.status).toBe(200);
+    expect(forwardedFilters().minYield).toBe("0");
+  });
+
+  it("accepts a bound beyond Number.MAX_SAFE_INTEGER without losing precision", async () => {
+    const huge = "170141183460469231731687303715884105727";
+    const res = await request.get(`${EPOCHS_PATH}?maxYield=${huge}`);
+
+    expect(res.status).toBe(200);
+    expect(forwardedFilters().maxYield).toBe(huge);
+  });
+
+  it("returns 400 for a non-numeric value", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?minYield=abc`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("ValidationError");
+    expect(mocks.getVaultEpochs).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a negative value", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?maxYield=-1`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a fractional value", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?minYield=1.5`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when minYield exceeds maxYield", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?minYield=500&maxYield=100`);
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body.issues)).toContain("must not be greater than");
+  });
+
+  it("compares the bounds numerically, not lexicographically", async () => {
+    // "9" > "10" as strings, but 9 < 10 as numbers, so this must be accepted.
+    const res = await request.get(`${EPOCHS_PATH}?minYield=9&maxYield=10`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("still accepts the pre-existing epoch parameter", async () => {
+    const res = await request.get(`${EPOCHS_PATH}?epoch=3`);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/src/api/routes/yields.ts
+++ b/backend/src/api/routes/yields.ts
@@ -10,9 +10,32 @@ import { getYieldsStream } from "../controllers/yields-stream.js";
 import { validateQuery } from "../middleware/validate.js";
 import { sseLimitPerIp } from "../middleware/sseLimitPerIp.js";
 
-const epochQuerySchema = z.object({
-  epoch: z.coerce.number().int().positive().optional(),
-});
+// Yield amounts exceed Number.MAX_SAFE_INTEGER, so BigInt-safe strings are kept
+// as strings all the way to the ::numeric cast rather than coerced to a number.
+const nonNegativeAmountSchema = z
+  .string()
+  .regex(/^\d+$/, "must be a non-negative integer");
+
+const epochQuerySchema = z
+  .object({
+    epoch: z.coerce.number().int().positive().optional(),
+    // Yield amount range; either bound may stand alone (#858).
+    minYield: nonNegativeAmountSchema.optional(),
+    maxYield: nonNegativeAmountSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.minYield !== undefined &&
+      value.maxYield !== undefined &&
+      BigInt(value.minYield) > BigInt(value.maxYield)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["minYield"],
+        message: "minYield must not be greater than maxYield",
+      });
+    }
+  });
 
 const yieldHistoryQuerySchema = z.object({
   from: z.string().datetime().optional(),

--- a/backend/src/services/openapi.ts
+++ b/backend/src/services/openapi.ts
@@ -139,8 +139,32 @@ function registerPaths(): void {
         page: z.coerce.number().optional(),
         pageSize: z.coerce.number().optional(),
         state: z.string().optional(),
-        sort: z.enum(["created_at", "total_assets"]).optional(),
+        sort: z
+          .string()
+          .optional()
+          .describe(
+            "Comma-separated list of up to 3 `field[:direction]` pairs, e.g. " +
+              "`state:asc,total_assets:desc`. Allowed fields: created_at, updated_at, " +
+              "total_assets, total_supply, state, name. A field with no explicit " +
+              "direction inherits `order`.",
+          ),
         order: z.enum(["asc", "desc"]).optional(),
+        createdFrom: z
+          .string()
+          .optional()
+          .describe("Inclusive lower bound on creation date (ISO 8601 date or date-time)."),
+        createdTo: z
+          .string()
+          .optional()
+          .describe("Inclusive upper bound on creation date (ISO 8601 date or date-time)."),
+        minTotalAssets: z
+          .string()
+          .optional()
+          .describe("Inclusive lower bound on total assets, as a non-negative integer string."),
+        maxTotalAssets: z
+          .string()
+          .optional()
+          .describe("Inclusive upper bound on total assets, as a non-negative integer string."),
       }),
     },
     responses: {

--- a/backend/src/services/vault-list-filters.test.ts
+++ b/backend/src/services/vault-list-filters.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../db/index.js", () => ({ query: vi.fn() }));
+vi.mock("../logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("../cache/redis.js", () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  cacheDel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { VaultService } from "./vault.js";
+import * as db from "../db/index.js";
+
+/** SQL and bound parameters of the vault page query (the first `query` call). */
+function listCall(): { sql: string; params: unknown[] } {
+  const [sql, params] = vi.mocked(db.query).mock.calls[0] as [string, unknown[]];
+  return { sql, params };
+}
+
+/** SQL and bound parameters of the COUNT query (the second `query` call). */
+function countCall(): { sql: string; params: unknown[] } {
+  const [sql, params] = vi.mocked(db.query).mock.calls[1] as [string, unknown[]];
+  return { sql, params };
+}
+
+describe("VaultService.listVaults creation date range (#856)", () => {
+  let service: VaultService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new VaultService();
+    vi.mocked(db.query).mockResolvedValue([]);
+  });
+
+  it("applies both bounds when a full range is supplied", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      createdFrom: "2025-01-01",
+      createdTo: "2025-06-30",
+    });
+
+    const { sql, params } = listCall();
+    expect(sql).toContain("v.created_at >= $1::timestamptz");
+    expect(sql).toContain("v.created_at <= $2::timestamptz");
+    expect(params).toEqual(expect.arrayContaining(["2025-01-01", "2025-06-30"]));
+  });
+
+  it("applies an open-ended lower bound when only createdFrom is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20, createdFrom: "2025-01-01" });
+
+    const { sql, params } = listCall();
+    expect(sql).toContain("v.created_at >= $1::timestamptz");
+    expect(sql).not.toContain("v.created_at <=");
+    expect(params).toEqual(expect.arrayContaining(["2025-01-01"]));
+  });
+
+  it("applies an open-ended upper bound when only createdTo is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20, createdTo: "2025-06-30" });
+
+    const { sql } = listCall();
+    expect(sql).toContain("v.created_at <= $1::timestamptz");
+    expect(sql).not.toContain("v.created_at >=");
+  });
+
+  it("adds no date predicate when neither bound is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20 });
+
+    const { sql } = listCall();
+    expect(sql).not.toContain("v.created_at >=");
+    expect(sql).not.toContain("v.created_at <=");
+  });
+
+  it("binds the dates as parameters rather than inlining them", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      createdFrom: "2025-01-01T00:00:00Z",
+    });
+
+    const { sql } = listCall();
+    expect(sql).not.toContain("2025-01-01");
+  });
+
+  it("numbers placeholders correctly alongside the state filter", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      state: "Active",
+      createdFrom: "2025-01-01",
+      createdTo: "2025-06-30",
+    });
+
+    const { sql, params } = listCall();
+    expect(sql).toContain("v.state = $1");
+    expect(sql).toContain("v.created_at >= $2::timestamptz");
+    expect(sql).toContain("v.created_at <= $3::timestamptz");
+    expect(params.slice(0, 3)).toEqual(["Active", "2025-01-01", "2025-06-30"]);
+  });
+
+  it("applies the same date range to the COUNT query so total matches", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      createdFrom: "2025-01-01",
+      createdTo: "2025-06-30",
+    });
+
+    const { sql, params } = countCall();
+    expect(sql).toContain("COUNT(*)");
+    expect(sql).toContain("v.created_at >= $1::timestamptz");
+    expect(sql).toContain("v.created_at <= $2::timestamptz");
+    expect(params).toEqual(["2025-01-01", "2025-06-30"]);
+  });
+
+  it("keeps the archived exclusion alongside the date range", async () => {
+    await service.listVaults({ page: 1, pageSize: 20, createdFrom: "2025-01-01" });
+
+    expect(listCall().sql).toContain("v.archived = FALSE");
+  });
+});

--- a/backend/src/services/vault-list-filters.test.ts
+++ b/backend/src/services/vault-list-filters.test.ts
@@ -121,3 +121,101 @@ describe("VaultService.listVaults creation date range (#856)", () => {
     expect(listCall().sql).toContain("v.archived = FALSE");
   });
 });
+
+describe("VaultService.listVaults total assets range (#857)", () => {
+  let service: VaultService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new VaultService();
+    vi.mocked(db.query).mockResolvedValue([]);
+  });
+
+  it("applies both bounds when a full range is supplied", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      minTotalAssets: "1000000",
+      maxTotalAssets: "5000000",
+    });
+
+    const { sql, params } = listCall();
+    expect(sql).toContain("v.total_assets >= $1::numeric");
+    expect(sql).toContain("v.total_assets <= $2::numeric");
+    expect(params).toEqual(expect.arrayContaining(["1000000", "5000000"]));
+  });
+
+  it("applies an open-ended lower bound when only minTotalAssets is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20, minTotalAssets: "1000000" });
+
+    const { sql } = listCall();
+    expect(sql).toContain("v.total_assets >= $1::numeric");
+    expect(sql).not.toContain("v.total_assets <=");
+  });
+
+  it("applies an open-ended upper bound when only maxTotalAssets is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20, maxTotalAssets: "5000000" });
+
+    const { sql } = listCall();
+    expect(sql).toContain("v.total_assets <= $1::numeric");
+    expect(sql).not.toContain("v.total_assets >=");
+  });
+
+  it("adds no TVL predicate when neither bound is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20 });
+
+    const { sql } = listCall();
+    expect(sql).not.toContain("v.total_assets >=");
+    expect(sql).not.toContain("v.total_assets <=");
+  });
+
+  it("treats a zero lower bound as a real filter rather than an absent one", async () => {
+    await service.listVaults({ page: 1, pageSize: 20, minTotalAssets: "0" });
+
+    const { sql, params } = listCall();
+    expect(sql).toContain("v.total_assets >= $1::numeric");
+    expect(params).toEqual(expect.arrayContaining(["0"]));
+  });
+
+  it("keeps amounts beyond Number.MAX_SAFE_INTEGER as exact strings", async () => {
+    const huge = "170141183460469231731687303715884105727";
+
+    await service.listVaults({ page: 1, pageSize: 20, maxTotalAssets: huge });
+
+    const { params } = listCall();
+    expect(params).toEqual(expect.arrayContaining([huge]));
+  });
+
+  it("numbers placeholders correctly when combined with date and state filters", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      state: "Active",
+      createdFrom: "2025-01-01",
+      minTotalAssets: "1000000",
+      maxTotalAssets: "5000000",
+    });
+
+    const { sql, params } = listCall();
+    expect(sql).toContain("v.state = $1");
+    expect(sql).toContain("v.created_at >= $2::timestamptz");
+    expect(sql).toContain("v.total_assets >= $3::numeric");
+    expect(sql).toContain("v.total_assets <= $4::numeric");
+    expect(params.slice(0, 4)).toEqual(["Active", "2025-01-01", "1000000", "5000000"]);
+  });
+
+  it("applies the same TVL range to the COUNT query so total matches", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      minTotalAssets: "1000000",
+      maxTotalAssets: "5000000",
+    });
+
+    const { sql, params } = countCall();
+    expect(sql).toContain("COUNT(*)");
+    expect(sql).toContain("v.total_assets >= $1::numeric");
+    expect(sql).toContain("v.total_assets <= $2::numeric");
+    expect(params).toEqual(["1000000", "5000000"]);
+  });
+});

--- a/backend/src/services/vault-sorting.test.ts
+++ b/backend/src/services/vault-sorting.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../db/index.js", () => ({ query: vi.fn() }));
+vi.mock("../logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("../cache/redis.js", () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  cacheDel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { VaultService, parseVaultSort, MAX_VAULT_SORT_FIELDS } from "./vault.js";
+import * as db from "../db/index.js";
+
+/** The SQL string handed to the first `query` call — the vault page query. */
+function listSql(): string {
+  return vi.mocked(db.query).mock.calls[0][0] as string;
+}
+
+/** The ORDER BY clause of the vault page query, whitespace-collapsed. */
+function orderByOf(sql: string): string {
+  const match = /ORDER BY([\s\S]*?)LIMIT/.exec(sql);
+  return match ? match[1].replace(/\s+/g, " ").trim() : "";
+}
+
+describe("parseVaultSort (#855)", () => {
+  it("defaults to created_at using the order parameter", () => {
+    expect(parseVaultSort(undefined, "desc")).toEqual({
+      ok: true,
+      specs: [{ field: "created_at", direction: "desc" }],
+    });
+    expect(parseVaultSort("", "asc")).toEqual({
+      ok: true,
+      specs: [{ field: "created_at", direction: "asc" }],
+    });
+  });
+
+  it("parses a comma-separated list of field:direction pairs", () => {
+    expect(parseVaultSort("state:asc,total_assets:desc", "desc")).toEqual({
+      ok: true,
+      specs: [
+        { field: "state", direction: "asc" },
+        { field: "total_assets", direction: "desc" },
+      ],
+    });
+  });
+
+  it("preserves the order the fields were listed in", () => {
+    const result = parseVaultSort("total_assets:desc,state:asc", "desc");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.specs.map((s) => s.field)).toEqual(["total_assets", "state"]);
+  });
+
+  it("falls back to the order parameter for fields with no explicit direction", () => {
+    // Legacy single-field form: ?sort=total_assets&order=asc
+    expect(parseVaultSort("total_assets", "asc")).toEqual({
+      ok: true,
+      specs: [{ field: "total_assets", direction: "asc" }],
+    });
+    expect(parseVaultSort("state,total_assets:desc", "asc")).toEqual({
+      ok: true,
+      specs: [
+        { field: "state", direction: "asc" },
+        { field: "total_assets", direction: "desc" },
+      ],
+    });
+  });
+
+  it("tolerates whitespace around fields", () => {
+    expect(parseVaultSort(" state:asc , total_assets:desc ", "desc")).toEqual({
+      ok: true,
+      specs: [
+        { field: "state", direction: "asc" },
+        { field: "total_assets", direction: "desc" },
+      ],
+    });
+  });
+
+  it("accepts exactly the maximum number of fields", () => {
+    const result = parseVaultSort("state:asc,total_assets:desc,created_at:asc", "desc");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.specs).toHaveLength(MAX_VAULT_SORT_FIELDS);
+  });
+
+  it("rejects more than the maximum number of fields", () => {
+    const result = parseVaultSort(
+      "state:asc,total_assets:desc,created_at:asc,name:asc",
+      "desc",
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("at most 3 fields");
+  });
+
+  it("rejects fields outside the allowlist", () => {
+    const result = parseVaultSort("state:asc,rwa_document_uri:desc", "desc");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("Unknown sort field");
+    expect(result.message).toContain("rwa_document_uri");
+  });
+
+  it("rejects an invalid direction", () => {
+    const result = parseVaultSort("state:sideways", "desc");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("Invalid sort direction");
+  });
+
+  it("rejects duplicate fields", () => {
+    const result = parseVaultSort("state:asc,state:desc", "desc");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("Duplicate sort field");
+  });
+
+  it("rejects empty segments", () => {
+    expect(parseVaultSort("state:asc,,total_assets:desc", "desc").ok).toBe(false);
+    expect(parseVaultSort("state:asc:desc", "desc").ok).toBe(false);
+  });
+
+  it("rejects SQL injection attempts through the sort field", () => {
+    const result = parseVaultSort("created_at; DROP TABLE vaults--", "desc");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("VaultService.listVaults multi-field sorting (#855)", () => {
+  let service: VaultService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new VaultService();
+    vi.mocked(db.query).mockResolvedValue([]);
+  });
+
+  it("emits one ORDER BY term per sort field, in order", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      sort: "state:asc,total_assets:desc",
+      order: "desc",
+    });
+
+    expect(orderByOf(listSql())).toBe("v.state ASC, v.total_assets DESC");
+  });
+
+  it("still honours the legacy single-field sort and order pair", async () => {
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      sort: "total_assets",
+      order: "asc",
+    });
+
+    expect(orderByOf(listSql())).toBe("v.total_assets ASC");
+  });
+
+  it("defaults to created_at DESC when no sort is supplied", async () => {
+    await service.listVaults({ page: 1, pageSize: 20 });
+
+    expect(orderByOf(listSql())).toBe("v.created_at DESC");
+  });
+
+  it("appends the id tiebreaker in the primary sort direction when paging by cursor", async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({ id: 5, created_at: new Date("2025-01-01").toISOString() }),
+    ).toString("base64url");
+
+    await service.listVaults({
+      page: 1,
+      pageSize: 20,
+      cursor,
+      sort: "state:asc,total_assets:desc",
+      order: "desc",
+    });
+
+    expect(orderByOf(listSql())).toBe("v.state ASC, v.total_assets DESC, v.id ASC");
+  });
+
+  it("throws rather than interpolating an unvalidated sort field into SQL", async () => {
+    await expect(
+      service.listVaults({
+        page: 1,
+        pageSize: 20,
+        sort: "created_at; DROP TABLE vaults--",
+        order: "desc",
+      }),
+    ).rejects.toThrow(/Invalid sort parameter/);
+
+    expect(db.query).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -12,14 +12,112 @@ const TTL_BY_STATE: Record<string, number> = {
 };
 const DEFAULT_TTL = 30;
 
+/**
+ * Columns the vault list endpoint may be sorted by (#855).
+ *
+ * Sort fields are interpolated straight into the ORDER BY clause, so every
+ * incoming value must be matched against this allowlist before it reaches SQL.
+ */
+export const VAULT_SORT_FIELDS = [
+  "created_at",
+  "updated_at",
+  "total_assets",
+  "total_supply",
+  "state",
+  "name",
+] as const;
+
+export type VaultSortField = (typeof VAULT_SORT_FIELDS)[number];
+
+export type SortDirection = "asc" | "desc";
+
+export interface VaultSortSpec {
+  field: VaultSortField;
+  direction: SortDirection;
+}
+
+/** Maximum number of comma-separated sort fields accepted by the vault list endpoint (#855). */
+export const MAX_VAULT_SORT_FIELDS = 3;
+
+export type VaultSortParseResult =
+  | { ok: true; specs: VaultSortSpec[] }
+  | { ok: false; message: string };
+
+function isVaultSortField(value: string): value is VaultSortField {
+  return (VAULT_SORT_FIELDS as readonly string[]).includes(value);
+}
+
+/**
+ * Parse the `sort` query parameter into an ordered list of sort specs (#855).
+ *
+ * Accepts a comma-separated list of `field[:direction]` pairs, e.g.
+ * `state:asc,total_assets:desc`. A pair with no explicit direction falls back to
+ * `defaultOrder`, which keeps the legacy `?sort=total_assets&order=asc` form
+ * working. Returns a failure result rather than throwing, so the route layer can
+ * surface the reason as an HTTP 400.
+ */
+export function parseVaultSort(
+  sort: string | undefined,
+  defaultOrder: SortDirection = "desc",
+): VaultSortParseResult {
+  const raw = (sort ?? "").trim();
+  if (raw === "") {
+    return { ok: true, specs: [{ field: "created_at", direction: defaultOrder }] };
+  }
+
+  const segments = raw.split(",").map((segment) => segment.trim());
+  if (segments.some((segment) => segment === "")) {
+    return { ok: false, message: "sort must not contain empty fields" };
+  }
+  if (segments.length > MAX_VAULT_SORT_FIELDS) {
+    return {
+      ok: false,
+      message: `sort accepts at most ${MAX_VAULT_SORT_FIELDS} fields, received ${segments.length}`,
+    };
+  }
+
+  const specs: VaultSortSpec[] = [];
+  const seen = new Set<string>();
+
+  for (const segment of segments) {
+    const [field, direction, ...rest] = segment.split(":");
+    if (rest.length > 0) {
+      return {
+        ok: false,
+        message: `Invalid sort entry "${segment}", expected "field" or "field:asc|desc"`,
+      };
+    }
+    if (!isVaultSortField(field)) {
+      return {
+        ok: false,
+        message: `Unknown sort field "${field}". Allowed fields: ${VAULT_SORT_FIELDS.join(", ")}`,
+      };
+    }
+    if (direction !== undefined && direction !== "asc" && direction !== "desc") {
+      return {
+        ok: false,
+        message: `Invalid sort direction "${direction}" for field "${field}", expected "asc" or "desc"`,
+      };
+    }
+    if (seen.has(field)) {
+      return { ok: false, message: `Duplicate sort field "${field}"` };
+    }
+    seen.add(field);
+    specs.push({ field, direction: direction ?? defaultOrder });
+  }
+
+  return { ok: true, specs };
+}
+
 interface ListVaultsOptions {
   page: number;
   pageSize: number;
   state?: string;
   category?: string;
   cursor?: string;
-  sort: "created_at" | "total_assets";
-  order: "asc" | "desc";
+  /** Comma-separated `field[:direction]` list — see {@link parseVaultSort} (#855). */
+  sort?: string;
+  order?: SortDirection;
   q?: string; // forwarded from controller; listVaults currently delegates text search to /search
 }
 
@@ -126,9 +224,21 @@ export class VaultService {
     const cached = await cacheGet<PaginatedResponse<Vault>>(cacheKey);
     if (cached) return cached;
 
-    const { page, pageSize, state, category, cursor, sort, order } = opts;
-    const sortColumn = sort === "total_assets" ? "total_assets" : "created_at";
-    const sortDirection = order === "asc" ? "ASC" : "DESC";
+    const { page, pageSize, state, category, cursor, order } = opts;
+
+    // Multi-field sorting (#855). The route layer validates `sort` and returns a
+    // 400 for bad input; re-parsing here keeps unvalidated callers out of SQL.
+    const sortResult = parseVaultSort(opts.sort, order ?? "desc");
+    if (!sortResult.ok) {
+      throw new Error(`Invalid sort parameter: ${sortResult.message}`);
+    }
+    const orderByClause = sortResult.specs
+      .map((spec) => `v.${spec.field} ${spec.direction === "asc" ? "ASC" : "DESC"}`)
+      .join(", ");
+
+    // Cursor pagination keys off (created_at, id), so the tiebreaker and the
+    // cursor comparison both follow the primary sort field's direction.
+    const sortDirection = sortResult.specs[0].direction === "asc" ? "ASC" : "DESC";
     const isDesc = sortDirection === "DESC";
 
     // Decode cursor if provided
@@ -201,7 +311,7 @@ export class VaultService {
                ), 0) AS depositor_count
         FROM vaults v
         ${whereClause}
-        ORDER BY v.${sortColumn} ${sortDirection}, v.id ${sortDirection}
+        ORDER BY ${orderByClause}, v.id ${sortDirection}
         LIMIT $${limitIdx}`;
     } else {
       const offset = (page - 1) * pageSize;
@@ -218,7 +328,7 @@ export class VaultService {
                ), 0) AS depositor_count
         FROM vaults v
         ${whereClause}
-        ORDER BY v.${sortColumn} ${sortDirection}
+        ORDER BY ${orderByClause}
         LIMIT $${limitIdx} OFFSET $${limitIdx + 1}`;
     }
 

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -122,6 +122,10 @@ interface ListVaultsOptions {
   createdFrom?: string;
   /** Inclusive upper bound on `created_at`, as an ISO 8601 date or date-time (#856). */
   createdTo?: string;
+  /** Inclusive lower bound on `total_assets`, as a non-negative integer string (#857). */
+  minTotalAssets?: string;
+  /** Inclusive upper bound on `total_assets`, as a non-negative integer string (#857). */
+  maxTotalAssets?: string;
   q?: string; // forwarded from controller; listVaults currently delegates text search to /search
 }
 
@@ -131,6 +135,8 @@ interface VaultListFilters {
   category?: string;
   createdFrom?: string;
   createdTo?: string;
+  minTotalAssets?: string;
+  maxTotalAssets?: string;
 }
 
 /**
@@ -161,6 +167,11 @@ function buildVaultListFilters(
   // Creation date range (#856). Either bound may be omitted for an open-ended range.
   if (filters.createdFrom) add((p) => `v.created_at >= ${p}::timestamptz`, filters.createdFrom);
   if (filters.createdTo) add((p) => `v.created_at <= ${p}::timestamptz`, filters.createdTo);
+
+  // Total assets (TVL) range (#857). Bound as strings and cast to NUMERIC so
+  // values beyond Number.MAX_SAFE_INTEGER keep full precision.
+  if (filters.minTotalAssets) add((p) => `v.total_assets >= ${p}::numeric`, filters.minTotalAssets);
+  if (filters.maxTotalAssets) add((p) => `v.total_assets <= ${p}::numeric`, filters.maxTotalAssets);
 
   return { conditions, params, nextIdx: idx };
 }
@@ -304,6 +315,8 @@ export class VaultService {
       category,
       createdFrom: opts.createdFrom,
       createdTo: opts.createdTo,
+      minTotalAssets: opts.minTotalAssets,
+      maxTotalAssets: opts.maxTotalAssets,
     };
     const filtered = buildVaultListFilters(filters);
     const conditions = filtered.conditions;

--- a/backend/src/services/vault.ts
+++ b/backend/src/services/vault.ts
@@ -118,7 +118,51 @@ interface ListVaultsOptions {
   /** Comma-separated `field[:direction]` list — see {@link parseVaultSort} (#855). */
   sort?: string;
   order?: SortDirection;
+  /** Inclusive lower bound on `created_at`, as an ISO 8601 date or date-time (#856). */
+  createdFrom?: string;
+  /** Inclusive upper bound on `created_at`, as an ISO 8601 date or date-time (#856). */
+  createdTo?: string;
   q?: string; // forwarded from controller; listVaults currently delegates text search to /search
+}
+
+/** Row-selection filters shared by the vault list query and its COUNT companion. */
+interface VaultListFilters {
+  state?: string;
+  category?: string;
+  createdFrom?: string;
+  createdTo?: string;
+}
+
+/**
+ * Build the WHERE fragments common to the vault list query and the COUNT that
+ * produces `total`, so both always select the same set of rows.
+ *
+ * Placeholders are numbered from `startIdx + 1`; `nextIdx` reports the highest
+ * placeholder used so the caller can keep numbering from there. Every bound is
+ * a bound parameter — nothing here is interpolated from user input.
+ */
+function buildVaultListFilters(
+  filters: VaultListFilters,
+  startIdx = 0,
+): { conditions: string[]; params: any[]; nextIdx: number } {
+  const conditions: string[] = [];
+  const params: any[] = [];
+  let idx = startIdx;
+
+  const add = (toCondition: (placeholder: string) => string, value: unknown): void => {
+    idx++;
+    conditions.push(toCondition(`$${idx}`));
+    params.push(value);
+  };
+
+  if (filters.state) add((p) => `v.state = ${p}`, filters.state);
+  if (filters.category) add((p) => `v.rwa_category = ${p}`, filters.category);
+
+  // Creation date range (#856). Either bound may be omitted for an open-ended range.
+  if (filters.createdFrom) add((p) => `v.created_at >= ${p}::timestamptz`, filters.createdFrom);
+  if (filters.createdTo) add((p) => `v.created_at <= ${p}::timestamptz`, filters.createdTo);
+
+  return { conditions, params, nextIdx: idx };
 }
 
 interface VaultRow {
@@ -255,21 +299,16 @@ export class VaultService {
       }
     }
 
-    const conditions: string[] = [];
-    const params: any[] = [];
-    let paramIdx = 0;
-
-    if (state) {
-      paramIdx++;
-      conditions.push(`v.state = $${paramIdx}`);
-      params.push(state);
-    }
-
-    if (category) {
-      paramIdx++;
-      conditions.push(`v.rwa_category = $${paramIdx}`);
-      params.push(category);
-    }
+    const filters: VaultListFilters = {
+      state,
+      category,
+      createdFrom: opts.createdFrom,
+      createdTo: opts.createdTo,
+    };
+    const filtered = buildVaultListFilters(filters);
+    const conditions = filtered.conditions;
+    const params = filtered.params;
+    let paramIdx = filtered.nextIdx;
 
     // Filter out archived vaults from standard list queries (#674)
     conditions.push(`v.archived = FALSE`);
@@ -349,19 +388,8 @@ export class VaultService {
     // Get total count (only when not using cursor, to avoid expensive counts)
     let total = 0;
     if (!cursor) {
-      const countConditions: string[] = [];
-      const countParams: any[] = [];
-      let countIdx = 0;
-      if (state) {
-        countIdx++;
-        countConditions.push(`v.state = $${countIdx}`);
-        countParams.push(state);
-      }
-      if (category) {
-        countIdx++;
-        countConditions.push(`v.rwa_category = $${countIdx}`);
-        countParams.push(category);
-      }
+      const { conditions: countConditions, params: countParams } =
+        buildVaultListFilters(filters);
       const countWhere = countConditions.length > 0 ? `WHERE ${countConditions.join(" AND ")}` : "";
       const countResult = await query<{ count: string }>(
         `SELECT COUNT(*) as count FROM vaults v ${countWhere}`,

--- a/backend/src/services/yield-epoch-filters.test.ts
+++ b/backend/src/services/yield-epoch-filters.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../db/index.js", () => ({ query: vi.fn() }));
+vi.mock("../cache/redis.js", () => ({
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+  cacheDel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { YieldService } from "./yield.js";
+import * as db from "../db/index.js";
+import * as cache from "../cache/redis.js";
+
+const CONTRACT_ID = "CDLZFC3SYJYHZDQA6M57EYUC2XBDA6LQF3M6KFRDZ7TXJYJL2K3B";
+
+/** SQL and bound parameters of the epoch query. */
+function epochCall(): { sql: string; params: unknown[] } {
+  const [sql, params] = vi.mocked(db.query).mock.calls[0] as [string, unknown[]];
+  return { sql, params };
+}
+
+describe("YieldService.getVaultEpochs yield range (#858)", () => {
+  let service: YieldService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(cache.cacheGet).mockResolvedValue(null);
+    service = new YieldService();
+    vi.mocked(db.query).mockResolvedValue([]);
+  });
+
+  it("applies both bounds when a full range is supplied", async () => {
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "100", maxYield: "500" });
+
+    const { sql, params } = epochCall();
+    expect(sql).toContain("e.yield_amount >= $2::numeric");
+    expect(sql).toContain("e.yield_amount <= $3::numeric");
+    expect(params).toEqual([CONTRACT_ID, "100", "500"]);
+  });
+
+  it("applies an open-ended lower bound when only minYield is supplied", async () => {
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "100" });
+
+    const { sql, params } = epochCall();
+    expect(sql).toContain("e.yield_amount >= $2::numeric");
+    expect(sql).not.toContain("e.yield_amount <=");
+    expect(params).toEqual([CONTRACT_ID, "100"]);
+  });
+
+  it("applies an open-ended upper bound when only maxYield is supplied", async () => {
+    await service.getVaultEpochs(CONTRACT_ID, { maxYield: "500" });
+
+    const { sql, params } = epochCall();
+    expect(sql).toContain("e.yield_amount <= $2::numeric");
+    expect(sql).not.toContain("e.yield_amount >=");
+    expect(params).toEqual([CONTRACT_ID, "500"]);
+  });
+
+  it("leaves the query untouched when no bounds are supplied", async () => {
+    await service.getVaultEpochs(CONTRACT_ID);
+
+    const { sql, params } = epochCall();
+    expect(sql).not.toContain("e.yield_amount >=");
+    expect(sql).not.toContain("e.yield_amount <=");
+    expect(params).toEqual([CONTRACT_ID]);
+  });
+
+  it("treats a zero lower bound as a real filter rather than an absent one", async () => {
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "0" });
+
+    const { sql, params } = epochCall();
+    expect(sql).toContain("e.yield_amount >= $2::numeric");
+    expect(params).toEqual([CONTRACT_ID, "0"]);
+  });
+
+  it("keeps the yield filter inside the outer WHERE, not the lateral subquery", async () => {
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "100" });
+
+    const { sql } = epochCall();
+    // The bound must land after the vault predicate and before ORDER BY, so it
+    // filters epochs rather than the yield_distributed event lookup.
+    const wherePos = sql.indexOf("WHERE v.contract_id = $1");
+    const filterPos = sql.indexOf("e.yield_amount >=");
+    const orderPos = sql.indexOf("ORDER BY e.epoch ASC");
+    expect(wherePos).toBeGreaterThan(-1);
+    expect(filterPos).toBeGreaterThan(wherePos);
+    expect(filterPos).toBeLessThan(orderPos);
+  });
+
+  it("binds the amounts as parameters rather than inlining them", async () => {
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "12345", maxYield: "67890" });
+
+    const { sql } = epochCall();
+    expect(sql).not.toContain("12345");
+    expect(sql).not.toContain("67890");
+  });
+
+  it("keeps amounts beyond Number.MAX_SAFE_INTEGER as exact strings", async () => {
+    const huge = "170141183460469231731687303715884105727";
+
+    await service.getVaultEpochs(CONTRACT_ID, { maxYield: huge });
+
+    expect(epochCall().params).toEqual([CONTRACT_ID, huge]);
+  });
+
+  it("varies the cache key by filter so filtered results are not served unfiltered", async () => {
+    await service.getVaultEpochs(CONTRACT_ID);
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "100" });
+    await service.getVaultEpochs(CONTRACT_ID, { minYield: "100", maxYield: "500" });
+
+    const keys = vi.mocked(cache.cacheGet).mock.calls.map(([key]) => key);
+    expect(new Set(keys).size).toBe(3);
+    // Invalidation uses the `epochs:*` wildcard, so every key must stay under it.
+    expect(keys.every((key) => key.startsWith("epochs:"))).toBe(true);
+  });
+
+  it("serves a cached result for a repeated identical filter", async () => {
+    const cachedEpochs = [{ id: 1, vaultId: 10, epoch: 1, yieldAmount: "200" }];
+    vi.mocked(cache.cacheGet).mockResolvedValue(cachedEpochs);
+
+    const result = await service.getVaultEpochs(CONTRACT_ID, { minYield: "100" });
+
+    expect(result).toEqual(cachedEpochs);
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it("returns only the rows the database matched", async () => {
+    vi.mocked(db.query).mockResolvedValue([
+      {
+        id: 2,
+        vault_id: 10,
+        epoch: 2,
+        yield_amount: "300",
+        total_shares: "1000",
+        distributed_at: new Date("2025-02-01"),
+        net_yield: null,
+      },
+    ]);
+
+    const epochs = await service.getVaultEpochs(CONTRACT_ID, {
+      minYield: "100",
+      maxYield: "500",
+    });
+
+    expect(epochs).toHaveLength(1);
+    expect(epochs[0].epoch).toBe(2);
+    expect(epochs[0].yieldAmount).toBe("300");
+  });
+});

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -5,6 +5,14 @@ import { cacheGet, cacheSet, cacheDel } from "../cache/redis.js";
 const EPOCHS_CACHE_TTL = 30;
 const PENDING_YIELD_CACHE_TTL = 10;
 
+/** Yield amount range filters for the epoch list endpoint (#858). */
+export interface EpochFilterOptions {
+  /** Inclusive lower bound on `yield_amount`, as a non-negative integer string. */
+  minYield?: string;
+  /** Inclusive upper bound on `yield_amount`, as a non-negative integer string. */
+  maxYield?: string;
+}
+
 export class YieldService {
   private formatYieldPerShare(yieldAmount: string, totalShares: string): string {
     const yieldBig = BigInt(yieldAmount);
@@ -19,8 +27,28 @@ export class YieldService {
     return `${integer}.${fraction}`;
   }
 
-  async getVaultEpochs(contractId: string): Promise<Epoch[]> {
-    const cacheKey = `epochs:${contractId}`;
+  async getVaultEpochs(contractId: string, filters: EpochFilterOptions = {}): Promise<Epoch[]> {
+    const { minYield, maxYield } = filters;
+
+    // Yield range (#858). Bounds are bound parameters cast to NUMERIC, so large
+    // amounts keep full precision. Either bound may be omitted for an open-ended
+    // filter. The params array stays [contractId] when neither is supplied.
+    const conditions: string[] = [];
+    const params: unknown[] = [contractId];
+    if (minYield !== undefined) {
+      params.push(minYield);
+      conditions.push(`e.yield_amount >= $${params.length}::numeric`);
+    }
+    if (maxYield !== undefined) {
+      params.push(maxYield);
+      conditions.push(`e.yield_amount <= $${params.length}::numeric`);
+    }
+    const yieldFilterSql = conditions.length > 0 ? ` AND ${conditions.join(" AND ")}` : "";
+
+    // The filters are part of the cache key so a filtered result is never served
+    // for a differently-filtered (or unfiltered) request. Invalidation uses the
+    // `epochs:*` wildcard, which still matches these keys.
+    const cacheKey = `epochs:${contractId}:${minYield ?? ""}:${maxYield ?? ""}`;
     const cached = await cacheGet<Epoch[]>(cacheKey);
     if (cached) return cached;
 
@@ -45,9 +73,9 @@ export class YieldService {
          ORDER BY created_at DESC
          LIMIT 1
        ) ie ON TRUE
-       WHERE v.contract_id = $1
+       WHERE v.contract_id = $1${yieldFilterSql}
        ORDER BY e.epoch ASC`,
-      [contractId],
+      params,
     );
 
     const epochs = rows.map((row) => ({


### PR DESCRIPTION
Adds multi-field sorting and three range filters to the vault and epoch list endpoints.

Closes #855
Closes #856
Closes #857
Closes #858

## What changed

### #855 — Multi-field sorting on `GET /api/v1/vaults`
`sort` now accepts a comma-separated list of `field[:direction]` pairs:

```
GET /api/v1/vaults?sort=state:asc,total_assets:desc
```

- Up to 3 fields, validated against an allowlist (`created_at`, `updated_at`, `total_assets`, `total_supply`, `state`, `name`).
- Unknown fields, invalid directions, duplicates, and more than 3 fields return **400**.
- Sort fields are interpolated into `ORDER BY`, so they are validated in the route *and* re-parsed in `VaultService.listVaults` — a caller that bypasses route validation cannot reach SQL with an unvalidated field.

### #856 — Creation date range on `GET /api/v1/vaults`
`createdFrom` / `createdTo` accept an ISO 8601 date (`2025-01-01`) or date-time, applying `created_at >= … AND created_at <= …`. Either bound may stand alone for an open-ended filter.

### #857 — Total assets range on `GET /api/v1/vaults`
`minTotalAssets` / `maxTotalAssets` accept non-negative integer strings, applying `total_assets >= … AND total_assets <= …`. Either bound may stand alone.

### #858 — Yield amount range on `GET /api/v1/yields/:contractId/epochs`
`minYield` / `maxYield` accept non-negative integer strings, applying `yield_amount >= … AND yield_amount <= …`. Either bound may stand alone.

## Implementation notes

- **BigInt safety.** Token amounts exceed `Number.MAX_SAFE_INTEGER`, so all amount bounds stay strings end to end and are cast with `::numeric` in SQL. The min/max comparison uses `BigInt` so it orders numerically, not lexicographically (`9` vs `10`).
- **Date validation.** The calendar round-trip check is deliberate: `Date.parse("2025-02-30")` silently rolls over to March 2 rather than returning `NaN`, so a shape check alone would let impossible dates through.
- **`total` stays consistent.** Vault filter building moved into a shared helper used by both the list query and the `COUNT` that produces `total`, so the two can't drift apart.
- **Epoch cache correctness.** The epoch cache key now includes the yield bounds, so a filtered result is never served for a differently-filtered request. Invalidation already uses the `epochs:*` wildcard, which still matches the new keys.
- **All bounds are bound parameters** — nothing derived from user input is interpolated into SQL.

## Backward compatibility

No changes to existing behaviour:

- The legacy `?sort=<field>&order=<dir>` form still works — a field with no explicit direction inherits `order`.
- With no new parameters supplied, the generated SQL and its bound parameters are unchanged on both endpoints.
- Cursor pagination still keys off `(created_at, id)`, following the primary sort field's direction.

## Verification

| | Baseline (`main`) | This branch |
|---|---|---|
| `npm test` | 12 failed files / 46 failed tests / 222 passed | 12 failed files / 46 failed tests / **304 passed** |
| `npx tsc --noEmit` | 34 errors | 34 errors (identical set) |
| `npm run lint` | 4 errors | 4 errors (identical set) |

**82 new tests, all passing. Zero regressions** — the same test files fail before and after, and the type/lint error sets are identical. Those pre-existing failures are unrelated to these endpoints and were present on `main` before this branch.

New test files:
- `src/services/vault-sorting.test.ts` (17) — sort parsing, allowlist, `ORDER BY` generation, SQL-injection rejection
- `src/services/vault-list-filters.test.ts` (16) — date/TVL predicates, placeholder numbering, `COUNT` agreement
- `src/services/yield-epoch-filters.test.ts` (11) — yield predicates, cache-key variation
- `src/api/routes/vaults-query.test.ts` (26) — HTTP 200/400 behaviour via supertest
- `src/api/routes/yields-query.test.ts` (12) — HTTP 200/400 behaviour via supertest

The OpenAPI spec for `/api/v1/vaults` was stale (it still described `sort` as a single-value enum) and has been updated to match.

## One thing worth a maintainer's call

A date-only `createdTo=2025-06-30` casts to midnight, so vaults created later that day fall outside the range. This matches the `created_at <= $createdTo` behaviour specified in #856, so I kept it literal rather than silently widening the bound to end-of-day. Happy to change it if you'd prefer the inclusive-day reading.