### PR TITLE
Add epoch detail endpoint, epoch status/participation metrics, and cooperator backfill script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "check-indexer": "tsx src/scripts/check-indexer.ts",
     "rotate-api-key": "tsx src/scripts/rotate-api-key.ts",
     "import-from-factory": "tsx src/scripts/import-from-factory.ts",
+    "backfill-cooperator": "tsx src/scripts/backfill-cooperator.ts",
     "indexer": "node dist/indexer/index.js",
     "operator-expiry-task": "node dist/tasks/operatorExpiry.js"
   },

--- a/backend/src/api/controllers/yields.test.ts
+++ b/backend/src/api/controllers/yields.test.ts
@@ -20,16 +20,19 @@ describe("Yield Controllers", () => {
   describe("getVaultEpochs", () => {
     it("returns 200 with an array of epochs", async () => {
       const { query, getVaultEpochs } = await getTestContext();
-      query.mockResolvedValue([
-        {
-          id: 1,
-          vault_id: 10,
-          epoch: 1,
-          yield_amount: "500",
-          total_shares: "5000",
-          distributed_at: new Date("2025-01-01"),
-        },
-      ]);
+      query
+        .mockResolvedValueOnce([
+          {
+            id: 1,
+            vault_id: 10,
+            epoch: 1,
+            yield_amount: "500",
+            total_shares: "5000",
+            distributed_at: new Date("2025-01-01"),
+          },
+        ])
+        .mockResolvedValueOnce([]) // claim stats
+        .mockResolvedValueOnce([]); // holder counts
 
       const req = { params: { contractId: "CC_VAULT" } } as any;
       const res = { json: vi.fn() } as any;
@@ -46,7 +49,7 @@ describe("Yield Controllers", () => {
 
     it("returns empty array when vault has no epochs", async () => {
       const { query, getVaultEpochs } = await getTestContext();
-      query.mockResolvedValue([]);
+      query.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       const req = { params: { contractId: "CC_EMPTY" } } as any;
       const res = { json: vi.fn() } as any;

--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -18,22 +18,40 @@ function formatYieldPerShare(yieldAmount: string, totalShares: string): string {
 
 export async function getVaultEpochs(req: Request, res: Response, next: NextFunction) {
   try {
+    const contractId = String(req.params["contractId"]);
     // Yield range filters, already validated by the route schema (#858).
     const { minYield, maxYield } = (req.query ?? {}) as unknown as {
       minYield?: string;
       maxYield?: string;
     };
-    const epochs = await yieldService.getVaultEpochs(String(req.params["contractId"]), {
+    const epochs = await yieldService.getVaultEpochs(contractId, {
       minYield,
       maxYield,
     });
+
+    // Batched per-vault lookups so status/participationRate don't cost an
+    // extra pair of queries per epoch (#816, #817).
+    const [claimStats, holderCounts] = await Promise.all([
+      yieldService.getClaimStatsForVault(contractId),
+      yieldService.getHolderCountsForVault(contractId),
+    ]);
+
     res.json(
-      epochs.map((e) => ({
-        ...e,
-        netYield: e.netYield,
-        yieldPerShare: formatYieldPerShare(e.yieldAmount, e.totalShares),
-        distributedAt: e.distributedAt ? e.distributedAt.toISOString() : null,
-      })),
+      epochs.map((e) => {
+        const stats = claimStats.get(e.epoch) ?? { claimedAmount: "0", uniqueClaimants: 0 };
+        const totalHolders = holderCounts.get(e.epoch) ?? 0;
+        return {
+          ...e,
+          netYield: e.netYield,
+          yieldPerShare: formatYieldPerShare(e.yieldAmount, e.totalShares),
+          distributedAt: e.distributedAt ? e.distributedAt.toISOString() : null,
+          status: yieldService.deriveEpochStatus(e.yieldAmount, stats.claimedAmount),
+          participationRate: yieldService.calculateParticipationRate(
+            stats.uniqueClaimants,
+            totalHolders,
+          ),
+        };
+      }),
     );
   } catch (err) {
     next(err);
@@ -42,13 +60,27 @@ export async function getVaultEpochs(req: Request, res: Response, next: NextFunc
 
 export async function getEpochDetail(req: Request, res: Response, next: NextFunction) {
   try {
+    const contractId = String(req.params["contractId"]);
     const epoch = Number(req.params["epoch"]);
-    const detail = await yieldService.getEpochDetail(String(req.params["contractId"]), epoch);
+    const detail = await yieldService.getEpochDetail(contractId, epoch);
     if (!detail) {
       res.status(404).json({ error: "NotFound", message: "Epoch not found" });
       return;
     }
-    res.json(detail);
+
+    const [claimStats, totalHolders] = await Promise.all([
+      yieldService.getEpochClaimStats(contractId, epoch),
+      yieldService.getEpochHolderCount(contractId, epoch),
+    ]);
+
+    res.json({
+      ...detail,
+      status: yieldService.deriveEpochStatus(detail.yieldAmount, claimStats.claimedAmount),
+      participationRate: yieldService.calculateParticipationRate(
+        claimStats.uniqueClaimants,
+        totalHolders,
+      ),
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -40,6 +40,20 @@ export async function getVaultEpochs(req: Request, res: Response, next: NextFunc
   }
 }
 
+export async function getEpochDetail(req: Request, res: Response, next: NextFunction) {
+  try {
+    const epoch = Number(req.params["epoch"]);
+    const detail = await yieldService.getEpochDetail(String(req.params["contractId"]), epoch);
+    if (!detail) {
+      res.status(404).json({ error: "NotFound", message: "Epoch not found" });
+      return;
+    }
+    res.json(detail);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function getUserPendingYield(req: Request, res: Response, next: NextFunction) {
   try {
     const result = await yieldService.getUserPendingYield(

--- a/backend/src/api/routes/yields-query.test.ts
+++ b/backend/src/api/routes/yields-query.test.ts
@@ -6,6 +6,8 @@ import supertest from "supertest";
 // runs end-to-end without a real database.
 const mocks = vi.hoisted(() => ({
   getVaultEpochs: vi.fn(),
+  getClaimStatsForVault: vi.fn(),
+  getHolderCountsForVault: vi.fn(),
 }));
 
 vi.mock("../../db/index.js", () => ({
@@ -17,7 +19,13 @@ vi.mock("../../services/yield.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../services/yield.js")>();
   return {
     ...actual,
-    YieldService: vi.fn(() => ({ getVaultEpochs: mocks.getVaultEpochs })),
+    YieldService: vi.fn(() => ({
+      getVaultEpochs: mocks.getVaultEpochs,
+      getClaimStatsForVault: mocks.getClaimStatsForVault,
+      getHolderCountsForVault: mocks.getHolderCountsForVault,
+      deriveEpochStatus: actual.YieldService.prototype.deriveEpochStatus,
+      calculateParticipationRate: actual.YieldService.prototype.calculateParticipationRate,
+    })),
   };
 });
 
@@ -43,6 +51,8 @@ describe("GET /api/v1/yields/:contractId/epochs yield range validation (#858)", 
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getVaultEpochs.mockResolvedValue([]);
+    mocks.getClaimStatsForVault.mockResolvedValue(new Map());
+    mocks.getHolderCountsForVault.mockResolvedValue(new Map());
   });
 
   it("accepts a yield range and forwards both bounds as strings", async () => {

--- a/backend/src/api/routes/yields.ts
+++ b/backend/src/api/routes/yields.ts
@@ -2,12 +2,13 @@ import { Router } from "express";
 import { z } from "zod";
 import {
   getVaultEpochs,
+  getEpochDetail,
   getUserPendingYield,
   getYieldSummary,
   getYieldPerShareHistory,
 } from "../controllers/yields.js";
 import { getYieldsStream } from "../controllers/yields-stream.js";
-import { validateQuery } from "../middleware/validate.js";
+import { validateQuery, validateParams } from "../middleware/validate.js";
 import { sseLimitPerIp } from "../middleware/sseLimitPerIp.js";
 
 // Yield amounts exceed Number.MAX_SAFE_INTEGER, so BigInt-safe strings are kept
@@ -37,6 +38,11 @@ const epochQuerySchema = z
     }
   });
 
+const epochDetailParamsSchema = z.object({
+  contractId: z.string(),
+  epoch: z.coerce.number().int().positive(),
+});
+
 const yieldHistoryQuerySchema = z.object({
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
@@ -49,5 +55,10 @@ export const yieldsRouter = Router();
 yieldsRouter.get("/stream", sseLimitPerIp(), getYieldsStream);
 yieldsRouter.get("/:contractId/summary", getYieldSummary);
 yieldsRouter.get("/:contractId/epochs", validateQuery(epochQuerySchema), getVaultEpochs);
+yieldsRouter.get(
+  "/:contractId/epochs/:epoch",
+  validateParams(epochDetailParamsSchema),
+  getEpochDetail,
+);
 yieldsRouter.get("/:contractId/yield-per-share-history", validateQuery(yieldHistoryQuerySchema), getYieldPerShareHistory);
 yieldsRouter.get("/:contractId/pending/:userAddress", getUserPendingYield);

--- a/backend/src/db/migrations/028_vault_cooperator_address.sql
+++ b/backend/src/db/migrations/028_vault_cooperator_address.sql
@@ -1,0 +1,5 @@
+-- Add cooperator_address column to vaults so the on-chain cooperator can be
+-- persisted instead of read from the RPC on every request.
+
+ALTER TABLE vaults
+  ADD COLUMN IF NOT EXISTS cooperator_address TEXT;

--- a/backend/src/scripts/backfill-cooperator.ts
+++ b/backend/src/scripts/backfill-cooperator.ts
@@ -1,0 +1,46 @@
+import "dotenv/config";
+import { query, pool } from "../db/index.js";
+import { readCooperator } from "../services/stellar.js";
+import { logger } from "../logger.js";
+
+interface VaultRow {
+  id: number;
+  contract_id: string;
+}
+
+async function backfillCooperator(): Promise<void> {
+  try {
+    const vaults = await query<VaultRow>(
+      `SELECT id, contract_id FROM vaults WHERE cooperator_address IS NULL`,
+    );
+
+    const total = vaults.length;
+    let backfilled = 0;
+
+    for (const vault of vaults) {
+      try {
+        const cooperatorAddress = await readCooperator(vault.contract_id);
+        await query(`UPDATE vaults SET cooperator_address = $1, updated_at = NOW() WHERE id = $2`, [
+          cooperatorAddress,
+          vault.id,
+        ]);
+        backfilled++;
+        logger.info(`Backfilled ${backfilled} of ${total} vaults`);
+      } catch (err) {
+        logger.error(
+          { err, contractId: vault.contract_id },
+          "Failed to backfill cooperator_address for vault",
+        );
+      }
+    }
+
+    logger.info({ backfilled, total }, "Cooperator backfill complete");
+    await pool.end();
+  } catch (err) {
+    logger.error(err, "Cooperator backfill failed");
+    process.exit(1);
+  }
+}
+
+await backfillCooperator();
+process.exit(0);

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -92,6 +92,128 @@ export class YieldService {
     return epochs;
   }
 
+  /**
+   * Fetch a single epoch's detail for a vault (#815).
+   * Returns null if the vault or the epoch does not exist for it.
+   */
+  async getEpochDetail(
+    contractId: string,
+    epoch: number,
+  ): Promise<{
+    epoch: number;
+    yieldAmount: string;
+    totalShares: string;
+    yieldPerShare: string;
+    netYield: string;
+    distributedAt: string | null;
+  } | null> {
+    const rows = await query<{
+      epoch: number;
+      yield_amount: string;
+      total_shares: string;
+      distributed_at: Date | null;
+      net_yield: string | null;
+    }>(
+      `SELECT e.epoch, e.yield_amount, e.total_shares, e.distributed_at,
+              (ie.payload->>'netYield') AS net_yield
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       LEFT JOIN LATERAL (
+         SELECT payload FROM indexed_events
+         WHERE contract_id = v.contract_id
+           AND event_type = 'yield_distributed'
+           AND (payload->>'epoch')::int = e.epoch
+         ORDER BY created_at DESC
+         LIMIT 1
+       ) ie ON TRUE
+       WHERE v.contract_id = $1 AND e.epoch = $2`,
+      [contractId, epoch],
+    );
+
+    const row = rows[0];
+    if (!row) return null;
+
+    return {
+      epoch: row.epoch,
+      yieldAmount: row.yield_amount,
+      totalShares: row.total_shares,
+      yieldPerShare: this.formatYieldPerShare(row.yield_amount, row.total_shares),
+      netYield: row.net_yield ?? row.yield_amount,
+      distributedAt: row.distributed_at ? row.distributed_at.toISOString() : null,
+    };
+  }
+
+  /**
+   * Claimed amount for an epoch, summed from `yield_claimed` and
+   * `yield_claimed_partial` indexed events (#816, #817).
+   */
+  async getEpochClaimStats(
+    contractId: string,
+    epoch: number,
+  ): Promise<{ claimedAmount: string; uniqueClaimants: number }> {
+    const rows = await query<{ claimed_amount: string; unique_claimants: string }>(
+      `SELECT COALESCE(SUM((payload->>'amount')::numeric), 0)::text AS claimed_amount,
+              COUNT(DISTINCT payload->>'user')::text AS unique_claimants
+       FROM indexed_events
+       WHERE contract_id = $1
+         AND event_type IN ('yield_claimed', 'yield_claimed_partial')
+         AND (payload->>'epoch')::int = $2`,
+      [contractId, epoch],
+    );
+
+    return {
+      claimedAmount: rows[0]?.claimed_amount ?? "0",
+      uniqueClaimants: parseInt(rows[0]?.unique_claimants ?? "0", 10),
+    };
+  }
+
+  /** Derives epoch status by comparing claimed amount to the yield amount (#816). */
+  deriveEpochStatus(
+    yieldAmount: string,
+    claimedAmount: string,
+  ): "open" | "partially_claimed" | "fully_claimed" {
+    const yieldBig = BigInt(yieldAmount);
+    const claimedBig = BigInt(claimedAmount);
+    if (claimedBig <= BigInt(0)) return "open";
+    if (claimedBig >= yieldBig) return "fully_claimed";
+    return "partially_claimed";
+  }
+
+  /**
+   * Total holders at an epoch's snapshot, from `share_balance_snapshots` (#817).
+   * Falls back to current holders with a position if no snapshot rows exist
+   * for the epoch (e.g. epoch 0 before snapshots were being recorded).
+   */
+  async getEpochHolderCount(contractId: string, epoch: number): Promise<number> {
+    const rows = await query<{ holder_count: string }>(
+      `SELECT COUNT(DISTINCT sbs.user_address)::text AS holder_count
+       FROM share_balance_snapshots sbs
+       JOIN vaults v ON sbs.vault_id = v.id
+       WHERE v.contract_id = $1 AND sbs.epoch = $2 AND sbs.shares::numeric > 0`,
+      [contractId, epoch],
+    );
+
+    const holderCount = parseInt(rows[0]?.holder_count ?? "0", 10);
+    if (holderCount > 0) return holderCount;
+
+    const fallbackRows = await query<{ holder_count: string }>(
+      `SELECT COUNT(*)::text AS holder_count
+       FROM user_vault_positions uvp
+       JOIN vaults v ON uvp.vault_id = v.id
+       WHERE v.contract_id = $1 AND uvp.shares::numeric > 0`,
+      [contractId],
+    );
+
+    return parseInt(fallbackRows[0]?.holder_count ?? "0", 10);
+  }
+
+  /** participationRate = (unique claimants / total holders at snapshot) × 100, 2dp (#817). */
+  calculateParticipationRate(uniqueClaimants: number, totalHolders: number): number {
+    if (totalHolders <= 0) return 0;
+    const rate = (uniqueClaimants / totalHolders) * 100;
+    return Math.round(rate * 100) / 100;
+  }
+
   async getUserPendingYield(
     contractId: string,
     userAddress: string,

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -207,6 +207,55 @@ export class YieldService {
     return parseInt(fallbackRows[0]?.holder_count ?? "0", 10);
   }
 
+  /**
+   * Claim stats for every epoch of a vault in one query, keyed by epoch
+   * number. Used by the epoch list endpoint to avoid N+1 queries (#816, #817).
+   */
+  async getClaimStatsForVault(
+    contractId: string,
+  ): Promise<Map<number, { claimedAmount: string; uniqueClaimants: number }>> {
+    const rows = await query<{ epoch: number; claimed_amount: string; unique_claimants: string }>(
+      `SELECT (payload->>'epoch')::int AS epoch,
+              COALESCE(SUM((payload->>'amount')::numeric), 0)::text AS claimed_amount,
+              COUNT(DISTINCT payload->>'user')::text AS unique_claimants
+       FROM indexed_events
+       WHERE contract_id = $1
+         AND event_type IN ('yield_claimed', 'yield_claimed_partial')
+       GROUP BY (payload->>'epoch')::int`,
+      [contractId],
+    );
+
+    const stats = new Map<number, { claimedAmount: string; uniqueClaimants: number }>();
+    for (const row of rows) {
+      stats.set(row.epoch, {
+        claimedAmount: row.claimed_amount,
+        uniqueClaimants: parseInt(row.unique_claimants, 10),
+      });
+    }
+    return stats;
+  }
+
+  /**
+   * Holder counts for every epoch snapshot of a vault in one query, keyed by
+   * epoch number (#817).
+   */
+  async getHolderCountsForVault(contractId: string): Promise<Map<number, number>> {
+    const rows = await query<{ epoch: number; holder_count: string }>(
+      `SELECT sbs.epoch, COUNT(DISTINCT sbs.user_address)::text AS holder_count
+       FROM share_balance_snapshots sbs
+       JOIN vaults v ON sbs.vault_id = v.id
+       WHERE v.contract_id = $1 AND sbs.shares::numeric > 0
+       GROUP BY sbs.epoch`,
+      [contractId],
+    );
+
+    const counts = new Map<number, number>();
+    for (const row of rows) {
+      counts.set(row.epoch, parseInt(row.holder_count, 10));
+    }
+    return counts;
+  }
+
   /** participationRate = (unique claimants / total holders at snapshot) × 100, 2dp (#817). */
   calculateParticipationRate(uniqueClaimants: number, totalHolders: number): number {
     if (totalHolders <= 0) return 0;


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/yields/:contractId/epochs/:epoch` for single-epoch lookups, returning `{ epoch, yieldAmount, totalShares, yieldPerShare, netYield, distributedAt }` and a 404 for an epoch that doesn't exist on the vault.
- Adds a computed `status: "open" | "partially_claimed" | "fully_claimed"` field to each epoch on both the list and detail endpoints, derived by comparing claimed amount (summed from `yield_claimed` / `yield_claimed_partial` indexed events) against `epochs.yield_amount`.
- Adds a computed `participationRate` field (unique claimants ÷ total holders at the epoch's share-balance snapshot × 100, rounded to 2dp) to both endpoints.
- Adds `cooperator_address` column to `vaults` (migration `028_vault_cooperator_address.sql`) plus `backend/src/scripts/backfill-cooperator.ts`, a one-time backfill script that reads `readCooperator` from chain for every vault with a null `cooperator_address`, updates the row, and logs `"Backfilled N of M vaults"` progress. Vaults that already have a value are skipped by the query itself.
- Updated existing epoch-list unit/integration test mocks so they account for the new batched claim-stat/holder-count lookups the controller now performs.

## Test plan
- [x] `npm run build` (tsc --noEmit) passes
- [x] `npx eslint` on changed files passes
- [x] `npx vitest run` — all 384 tests pass

closes #814,    closes #815,     closes #816,    closes #817