### PR TITLE
feat: yield timeline endpoint, trace spans, DB pool & RPC error alerting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,3 +45,13 @@ REQUEST_BODY_LIMIT=100kb
 
 # Shared secret for HMAC-signed requests between internal services (/internal/* routes)
 INTERNAL_SECRET=
+
+# DB pool exhaustion alerting (#828)
+# Log an error when more than this many connection requests are queued waiting for a pool slot.
+# Default: 5. Set to 0 to disable.
+DB_POOL_ALERT_WAITING=5
+
+# RPC error rate alerting (#829)
+# Log an error when the RPC error rate in a 5-minute window exceeds this percentage.
+# Default: 10 (i.e. 10%). Range: 1–100.
+RPC_ERROR_RATE_ALERT_PCT=10

--- a/backend/src/api/controllers/yields.ts
+++ b/backend/src/api/controllers/yields.ts
@@ -107,6 +107,37 @@ export async function getYieldSummary(req: Request, res: Response, next: NextFun
   }
 }
 
+export async function getYieldTimeline(req: Request, res: Response, next: NextFunction) {
+  try {
+    const contractId = String(req.params["contractId"]);
+    const fromParam = req.query.from as string | undefined;
+    const toParam = req.query.to as string | undefined;
+
+    let fromDate: Date | undefined;
+    let toDate: Date | undefined;
+
+    if (fromParam) {
+      fromDate = new Date(fromParam);
+      if (isNaN(fromDate.getTime())) {
+        res.status(400).json({ error: "BadRequest", message: "Invalid from date format" });
+        return;
+      }
+    }
+    if (toParam) {
+      toDate = new Date(toParam);
+      if (isNaN(toDate.getTime())) {
+        res.status(400).json({ error: "BadRequest", message: "Invalid to date format" });
+        return;
+      }
+    }
+
+    const result = await yieldService.getYieldTimeline(contractId, fromDate, toDate);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function getYieldPerShareHistory(
   req: Request,
   res: Response,

--- a/backend/src/api/routes/yields.ts
+++ b/backend/src/api/routes/yields.ts
@@ -6,6 +6,7 @@ import {
   getUserPendingYield,
   getYieldSummary,
   getYieldPerShareHistory,
+  getYieldTimeline,
 } from "../controllers/yields.js";
 import { getYieldsStream } from "../controllers/yields-stream.js";
 import { validateQuery, validateParams } from "../middleware/validate.js";
@@ -62,3 +63,10 @@ yieldsRouter.get(
 );
 yieldsRouter.get("/:contractId/yield-per-share-history", validateQuery(yieldHistoryQuerySchema), getYieldPerShareHistory);
 yieldsRouter.get("/:contractId/pending/:userAddress", getUserPendingYield);
+
+const timelineQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+});
+
+yieldsRouter.get("/:contractId/timeline", validateQuery(timelineQuerySchema), getYieldTimeline);

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -114,6 +114,16 @@ const envSchema = z.object({
     .default("15000")
     .transform((v) => parseInt(v, 10))
     .pipe(z.number().int().min(1)),
+  DB_POOL_ALERT_WAITING: z
+    .string()
+    .default("5")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(0)),
+  RPC_ERROR_RATE_ALERT_PCT: z
+    .string()
+    .default("10")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(1).max(100)),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -178,4 +188,6 @@ export const config = {
     maxAge: parsed.data.CORS_MAX_AGE,
   },
   sseHeartbeatMs: parsed.data.SSE_HEARTBEAT_MS,
+  dbPoolAlertWaiting: parsed.data.DB_POOL_ALERT_WAITING,
+  rpcErrorRateAlertPct: parsed.data.RPC_ERROR_RATE_ALERT_PCT,
 } as const;

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -54,6 +54,18 @@ process.on("SIGTERM", async () => {
   await pool.end();
 });
 
+// ── Pool exhaustion alerting (#828) ───────────────────────────────────────────
+// Every 10 s, log at error level if the number of queued connection requests
+// exceeds DB_POOL_ALERT_WAITING (default 5). Healthy operation never logs here.
+if (process.env["NODE_ENV"] !== "test") {
+  setInterval(() => {
+    const waiting = pool.waitingCount;
+    if (waiting > config.dbPoolAlertWaiting) {
+      logger.error(`DB pool exhaustion: ${waiting} connections waiting`);
+    }
+  }, 10_000).unref();
+}
+
 // Validate on startup — exit immediately if DATABASE_URL is unreachable
 if (process.env["NODE_ENV"] !== "test") {
   validateConnection().catch((err) => {

--- a/backend/src/services/indexer.ts
+++ b/backend/src/services/indexer.ts
@@ -15,6 +15,39 @@ import { NotificationService } from "./notifications.js";
 import { indexerEventsProcessedTotal, indexerLastLedger } from "./metrics.js";
 import { cacheDel } from "../cache/redis.js";
 import { sseService } from "./sse.js";
+import { recordRpcSuccess, recordRpcError } from "./rpcMonitor.js";
+
+// ── Lightweight trace spans (#827) ────────────────────────────────────────────
+// No external tracing dependency — spans are emitted as structured pino log
+// entries with traceId/spanId/parentSpanId so they can be correlated in any
+// log aggregator (Loki, CloudWatch, Datadog, etc.).
+
+let _spanSeq = 0;
+function nextSpanId(): string {
+  return (++_spanSeq).toString(16).padStart(8, "0");
+}
+
+interface Span {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startMs: number;
+  attrs: Record<string, unknown>;
+}
+
+function startSpan(name: string, attrs: Record<string, unknown> = {}, parent?: Span): Span {
+  const traceId = parent?.traceId ?? nextSpanId() + nextSpanId();
+  return { traceId, spanId: nextSpanId(), parentSpanId: parent?.spanId, name, startMs: Date.now(), attrs };
+}
+
+function finishSpan(span: Span, extra: Record<string, unknown> = {}): void {
+  const durationMs = Date.now() - span.startMs;
+  logger.debug(
+    { traceId: span.traceId, spanId: span.spanId, parentSpanId: span.parentSpanId, durationMs, ...span.attrs, ...extra },
+    span.name,
+  );
+}
 
 // ── Upstream helpers ───────────────────────────────────────────────────────────
 
@@ -59,8 +92,11 @@ async function withBackoff<T>(
   let attempt = 0;
   while (true) {
     try {
-      return await fn();
+      const result = await fn();
+      recordRpcSuccess();
+      return result;
     } catch (err: any) {
+      recordRpcError();
       const is429 =
         err?.response?.status === 429 ||
         err?.status === 429 ||
@@ -225,6 +261,7 @@ export class Indexer {
   }
 
   async tick(): Promise<void> {
+    const tickSpan = startSpan("indexer.tick");
     const server = getSorobanRpc();
 
     let latestLedger: number;
@@ -233,6 +270,7 @@ export class Indexer {
       latestLedger = resp.sequence;
     } catch (err) {
       logger.warn({ err }, "RPC error fetching latest ledger during tick");
+      finishSpan(tickSpan, { error: true });
       return;
     }
 
@@ -243,9 +281,14 @@ export class Indexer {
       logger.error(`Indexer lag: ${lag} ledgers behind chain tip`);
     }
 
-    if (latestLedger <= this.lastLedger) return;
+    if (latestLedger <= this.lastLedger) {
+      finishSpan(tickSpan, { ledgerRange: 0, eventCount: 0 });
+      return;
+    }
 
     const from = this.lastLedger + 1;
+    tickSpan.attrs["ledgerRange"] = `${from}-${latestLedger}`;
+
     const contractIds = Array.from(this.watchedContractIds);
     const filters = contractIds.length > 0
       ? contractIds.map((id) => ({ contractIds: [id] }))
@@ -259,8 +302,11 @@ export class Indexer {
       events = resp.events;
     } catch (err) {
       logger.warn({ err, from, to: latestLedger }, "RPC error fetching events during tick");
+      finishSpan(tickSpan, { error: true });
       return;
     }
+
+    tickSpan.attrs["eventCount"] = events.length;
 
     logger.info(
       { from, to: latestLedger, eventCount: events.length },
@@ -268,11 +314,7 @@ export class Indexer {
     );
 
     for (const event of events) {
-      logger.debug(
-        { contractId: event.contractId, type: event.type, ledger: event.ledger },
-        "Processing event",
-      );
-      await this.processEvent(event);
+      await this.processEvent(event, tickSpan);
     }
 
     await this.notificationService?.processRetries();
@@ -280,6 +322,7 @@ export class Indexer {
     this.lastLedger = latestLedger;
     await this.persistLastLedger();
     this.lastTickAt = new Date();
+    finishSpan(tickSpan);
   }
 
   private async backfill(tipLedger: number): Promise<void> {
@@ -325,7 +368,21 @@ export class Indexer {
     }
   }
 
-  async processEvent(event: any): Promise<void> {
+  async processEvent(event: any, parentSpan?: Span): Promise<void> {
+    const eventSpan = startSpan(
+      "indexer.process_event",
+      { eventType: event.type ?? "unknown", contractId: event.contractId ?? "" },
+      parentSpan,
+    );
+
+    try {
+      await this._processEventInner(event);
+    } finally {
+      finishSpan(eventSpan);
+    }
+  }
+
+  private async _processEventInner(event: any): Promise<void> {
     const existing = await query(
       "SELECT id FROM indexed_events WHERE tx_hash = $1 AND contract_id = $2 AND event_type = $3 AND ledger = $4",
       [event.id ?? event.txHash ?? "", event.contractId ?? "", event.type ?? "", event.ledger ?? 0],

--- a/backend/src/services/rpcMonitor.ts
+++ b/backend/src/services/rpcMonitor.ts
@@ -1,0 +1,46 @@
+import { config } from "../config.js";
+import { logger } from "../logger.js";
+
+// ── RPC error-rate alerting (#829) ────────────────────────────────────────────
+//
+// Tracks RPC success and error counts in a rolling 5-minute window held in
+// memory. At the end of each window the rate is evaluated: if errors / total
+// exceeds RPC_ERROR_RATE_ALERT_PCT (default 10 %), an error-level log is
+// emitted. Counters reset at the start of every new window.
+
+let windowErrors = 0;
+let windowSuccesses = 0;
+
+export function recordRpcSuccess(): void {
+  windowSuccesses++;
+}
+
+export function recordRpcError(): void {
+  windowErrors++;
+}
+
+function flushWindow(): void {
+  const total = windowErrors + windowSuccesses;
+  if (total === 0) {
+    windowErrors = 0;
+    windowSuccesses = 0;
+    return;
+  }
+
+  const ratePct = Math.round((windowErrors / total) * 100);
+  if (ratePct > config.rpcErrorRateAlertPct) {
+    logger.error(
+      { windowErrors, windowSuccesses, total, ratePct },
+      `RPC error rate ${ratePct}% exceeds threshold`,
+    );
+  }
+
+  windowErrors = 0;
+  windowSuccesses = 0;
+}
+
+// Only start the interval outside of tests so unit tests aren't burdened with
+// timer teardown. The interval is unref'd so it never prevents process exit.
+if (process.env["NODE_ENV"] !== "test") {
+  setInterval(flushWindow, 5 * 60 * 1000).unref();
+}

--- a/backend/src/services/yield.ts
+++ b/backend/src/services/yield.ts
@@ -455,4 +455,56 @@ export class YieldService {
 
     return { data, total };
   }
+
+  // ── Epoch yield distribution timeline (#822) ────────────────────────────────
+  // Returns all epochs for a vault ordered by epoch number, optionally bounded
+  // by ISO date filters on distributed_at. `totalInRange` is the exact sum of
+  // all yieldAmount values in the result set.
+  async getYieldTimeline(
+    contractId: string,
+    from?: Date,
+    to?: Date,
+  ): Promise<{
+    points: Array<{ epoch: number; yieldAmount: string; distributedAt: string | null }>;
+    totalInRange: string;
+  }> {
+    const conditions: string[] = ["v.contract_id = $1"];
+    const params: unknown[] = [contractId];
+
+    if (from) {
+      params.push(from);
+      conditions.push(`e.distributed_at >= $${params.length}`);
+    }
+    if (to) {
+      params.push(to);
+      conditions.push(`e.distributed_at <= $${params.length}`);
+    }
+
+    const where = conditions.join(" AND ");
+
+    const rows = await query<{
+      epoch: number;
+      yield_amount: string;
+      distributed_at: Date | null;
+    }>(
+      `SELECT e.epoch, e.yield_amount, e.distributed_at
+       FROM epochs e
+       JOIN vaults v ON e.vault_id = v.id
+       WHERE ${where}
+       ORDER BY e.epoch ASC`,
+      params,
+    );
+
+    const points = rows.map((row) => ({
+      epoch: row.epoch,
+      yieldAmount: row.yield_amount,
+      distributedAt: row.distributed_at ? row.distributed_at.toISOString() : null,
+    }));
+
+    const totalInRange = points
+      .reduce((sum, p) => sum + BigInt(p.yieldAmount), 0n)
+      .toString();
+
+    return { points, totalInRange };
+  }
 }


### PR DESCRIPTION
## Summary

- **#822** — New `GET /api/v1/yields/:contractId/timeline` endpoint returns `{ points: [{ epoch, yieldAmount, distributedAt }], totalInRange }` with optional `from`/`to` ISO date filters. `totalInRange` is the exact BigInt sum of all `yieldAmount` values in the filtered result.

- **#827** — Each indexer tick is now wrapped in a root `indexer.tick` span (attrs: `ledgerRange`, `eventCount`). Every event processed during the tick gets a child `indexer.process_event` span (attrs: `eventType`, `contractId`). Spans are emitted as structured pino log entries with `traceId`, `spanId`, `parentSpanId`, and `durationMs` — no external tracing SDK required; they correlate in any log aggregator (Loki, CloudWatch, Datadog).

- **#828** — A `setInterval` (10 s, unref'd) in `db/index.ts` checks `pool.waitingCount` on each tick and logs at `error` level (`"DB pool exhaustion: N connections waiting"`) whenever the count exceeds `DB_POOL_ALERT_WAITING` (default 5). Normal operation never triggers the log.

- **#829** — New `rpcMonitor.ts` module hooks into `withBackoff` via `recordRpcSuccess` / `recordRpcError`. A 5-minute window tracks cumulative counts; at window end, if `errors / total > RPC_ERROR_RATE_ALERT_PCT` (default 10%), an error log fires (`"RPC error rate N% exceeds threshold"`). Counters reset every window.

## Changed files

| File | Change |
|------|--------|
| `backend/src/config.ts` | Added `DB_POOL_ALERT_WAITING`, `RPC_ERROR_RATE_ALERT_PCT` env vars |
| `backend/src/db/index.ts` | Added 10-second pool exhaustion check interval |
| `backend/src/services/rpcMonitor.ts` | New — 5-minute RPC error-rate window tracker |
| `backend/src/services/indexer.ts` | Integrated rpcMonitor + trace spans on tick/processEvent |
| `backend/src/services/yield.ts` | Added `getYieldTimeline()` method |
| `backend/src/api/controllers/yields.ts` | Added `getYieldTimeline` controller |
| `backend/src/api/routes/yields.ts` | Registered `/:contractId/timeline` route |
| `backend/.env.example` | Documented new env vars |

Closes #822
Closes #827
Closes #828
Closes #829