### PR TITLE
Apollo GraphQL server, SSE reconnection, CHANGELOG template, indexer docs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,3 +60,11 @@ DB_POOL_ALERT_WAITING=5
 # Log an error when the RPC error rate in a 5-minute window exceeds this percentage.
 # Default: 10 (i.e. 10%). Range: 1–100.
 RPC_ERROR_RATE_ALERT_PCT=10
+
+# Redis connection used for caching and SSE replay-buffer durability (optional;
+# caching/replay degrade gracefully to in-memory-only when unset)
+REDIS_URL=
+
+# Number of past vault SSE events buffered per vault for Last-Event-ID replay
+# on reconnect (#761). Default: 100.
+SSE_REPLAY_BUFFER=100

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Maintainers:** as you merge PRs, add an entry under `[Unreleased]` in the
+> matching category below (skip categories with nothing to report). When
+> cutting a release, rename `[Unreleased]` to the new version and date (e.g.
+> `## [1.2.0] - 2026-07-26`), then add a fresh `[Unreleased]` section above it
+> with all six empty headings restored.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/backend/README.md
+++ b/backend/README.md
@@ -135,6 +135,8 @@ Require `X-API-Key` header with admin key.
 ## Documentation
 
 - [Webhook Documentation](docs/webhooks.md) - Webhook payload schemas and verification
+- [Indexer Architecture](docs/indexer.md) - Polling loop, event dispatch, dedup, and backfill
+- [Indexer Event Reference](docs/events.md) - Every event parser, its DB effect, and its webhook
 
 ## Vault States
 

--- a/backend/docs/indexer.md
+++ b/backend/docs/indexer.md
@@ -1,0 +1,135 @@
+# Indexer Architecture
+
+The indexer (`src/services/indexer.ts`, class `Indexer`) polls the configured Soroban RPC
+endpoint for contract events emitted by watched vault contracts, turns them into typed
+domain events, and writes the resulting state to Postgres. This document covers how the
+poller runs, how an event goes from raw RPC payload to a DB write, and how to extend it
+with a new event type. For the full topic → parser → DB-effect → webhook reference table,
+see [`events.md`](./events.md); for webhook payload shapes, see [`webhooks.md`](./webhooks.md).
+
+## Entry point
+
+`src/index.ts` constructs a single `Indexer` instance (`indexerSingleton.ts`) and calls
+`indexer.start()` once at boot (not awaited — it runs for the lifetime of the process) and
+`indexer.stop()` on graceful shutdown, which just flips a `running` flag that the poll loop
+checks between iterations.
+
+## Polling loop lifecycle
+
+`start()`:
+
+1. Reads the last indexed ledger from the `indexer_state` table (`getLastIndexedLedger()`),
+   falling back to `INDEXER_START_LEDGER` if no row exists yet.
+2. If `VAULT_FACTORY_CONTRACT_ID` is not configured, the indexer runs in **state-only mode**:
+   it loops calling `tickStateOnly()`, which only advances `lastLedger` to the chain tip
+   without fetching or processing any events. This exists so the service still starts up
+   (health checks, REST API, etc.) in environments without a factory contract deployed.
+3. Otherwise, it fetches the current chain tip. If the gap between the last indexed ledger
+   and the tip exceeds `INDEXER_BATCH_SIZE`, it runs a one-time `backfill()` pass before
+   entering the steady-state loop (see [Backfill mechanism](#backfill-mechanism)).
+4. Enters the steady-state loop: `while (running) { await tick(); await sleepWhileRunning(INDEXER_POLL_INTERVAL_MS); }`.
+   `sleepWhileRunning` sleeps in 250ms steps and re-checks `running` between them, so `stop()`
+   takes effect within ~250ms instead of blocking for the full poll interval.
+
+`tick()` (one poll iteration):
+
+1. Fetches the current chain tip ledger via RPC (wrapped in `withBackoff`, which retries
+   on HTTP 429 with exponential backoff).
+2. If the indexer has fallen more than `INDEXER_LAG_ALERT_LEDGERS` behind the tip, logs an
+   error (alerting hook, not a hard failure).
+3. If there are no new ledgers, returns early — nothing else runs.
+4. Calls `server.getEvents({ startLedger, filters })`, filtered to the set of watched
+   contract IDs (the factory contract plus every vault contract discovered via
+   `vault_created` events), and passes each returned event to `processEvent()` in order.
+5. Runs any due notification retries (`notificationService.processRetries()`).
+6. Advances and persists `lastLedger` (`indexer_state.last_ledger`) — this is the resume
+   point on restart.
+
+Each tick and each `processEvent()` call opens a lightweight trace span (`startSpan`/`finishSpan`
+near the top of `indexer.ts`) logged at `debug` level with a `traceId`/`spanId`/`parentSpanId`,
+so a single tick and all the events it processed can be correlated in log aggregation without
+a full tracing backend.
+
+## Backfill mechanism
+
+`backfill(tipLedger)` walks from the last indexed ledger to the chain tip in
+`INDEXER_BATCH_SIZE`-ledger chunks, calling `getEvents` and `processEvent()` per chunk and
+persisting `lastLedger` after each successful chunk. If an RPC call fails mid-backfill, it
+stops (rather than retrying indefinitely) — `lastLedger` reflects the last successfully
+completed chunk, so the next regular `tick()`/backfill will resume from there.
+
+Backfill runs in two situations:
+
+- **Automatically at startup**, when the gap to the chain tip exceeds `INDEXER_BATCH_SIZE`
+  (e.g. after downtime).
+- **On demand via the admin API** (`POST /api/v1/admin/indexer/backfill`), for recovering a
+  specific ledger range after an RPC outage. This doesn't call `backfill()` directly — it
+  enqueues a `pg-boss` job (`indexer-backfill`), processed by
+  `indexerBackfillWorker.ts#processIndexerBackfill`, which calls `indexer.queueBackfill(from, to)`.
+  Queuing (rather than an inline HTTP-triggered backfill) means the job survives an API
+  process restart and the request range is capped at 10,000 ledgers.
+
+## Event dispatch: `processEvent`
+
+`processEvent(event, parentSpan)` is a thin span wrapper around `_processEventInner(event)`,
+which does the real dispatch. It is **not** a lookup table — it's a sequential chain of
+`const parsed = parseXEvent(event); if (parsed) { ...handle...; return; }` blocks, one per
+event type, tried in the order they appear in the method. Each `parseXEvent` function:
+
+- Returns `null` immediately (never throws) if the raw event's `topics[0]` symbol doesn't
+  match the event name it's responsible for.
+- Otherwise decodes the XDR topics/value into a typed `ParsedXEvent` object.
+
+Because parsers are tried in sequence and each returns before the next is checked, only the
+first matching parser runs for a given event — order only matters for topics that could
+otherwise collide (see the note on `parseKycSetEvent` vs. `parseKycVerifiedEvent` in `events.md`).
+
+## Deduplication
+
+At the top of `_processEventInner`, before any parser runs:
+
+```ts
+const existing = await query(
+  "SELECT id FROM indexed_events WHERE tx_hash = $1 AND contract_id = $2 AND event_type = $3 AND ledger = $4",
+  [event.id ?? event.txHash ?? "", event.contractId ?? "", event.type ?? "", event.ledger ?? 0],
+);
+if (existing.length > 0) return;
+```
+
+This is the actual dedup guard — it's a plain `SELECT`-then-skip, not a DB constraint. Note
+that the `INSERT ... ON CONFLICT DO NOTHING` used elsewhere when recording events (see
+`recordEvent()`) has no matching unique index in `indexed_events`, so it never actually
+triggers a conflict; it's harmless but not what prevents duplicate processing. Reprocessing
+safety therefore currently depends on the indexer being single-threaded/single-instance and
+processing events strictly in order — running two indexer instances against the same
+database concurrently would race past this check.
+
+## How to add a new event type
+
+1. **Write the parser.** Add `parseXEvent(rawEvent: unknown): ParsedXEvent | null` near the
+   bottom of `indexer.ts`, next to the existing parsers. Match `topics[0]`'s decoded symbol
+   against your event's topic name and `return null` for anything else; decode the rest of
+   the topics/value with `scValToNative` (see `parseDepositEvent` for the reference shape).
+2. **Write the handler.** Add a `private async handleX(contractId, parsed)` method that
+   performs the DB write(s) for this event (upsert/update the relevant table(s)).
+3. **Wire it into `_processEventInner`.** Add a new block:
+   ```ts
+   const x = parseXEvent(event);
+   if (x) {
+     await this.handleX(event.contractId ?? "", x);
+     await this.recordEvent(event, "x_event_type");
+     // optional: await this.notificationService?.notify("x.event", {...});
+     return;
+   }
+   ```
+   `recordEvent()` writes the raw + parsed payload to `indexed_events` for audit/replay and
+   increments the `indexerEventsProcessedTotal` metric — always call it (or insert into
+   `indexed_events` directly, as `yield_distributed`/`yield_claimed` do when they need to
+   store extra derived fields) so the event shows up in `GET /api/v1/admin/indexer` history.
+4. **Notify subscribers, if relevant.** Call
+   `this.notificationService?.notify("webhook.event.name", payload)` inside a `try/catch`
+   (a notification failure must never fail event processing) and document the payload shape
+   in [`webhooks.md`](./webhooks.md).
+5. **Document it.** Add a row to the table in [`events.md`](./events.md).
+6. **Test it.** Add a unit test for the parser (decode a fixture event, assert the parsed
+   fields) and, if the handler has non-trivial DB logic, a test for `handleX` mocking `query`.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@apollo/server": "^5.5.1",
+        "@as-integrations/express4": "^1.1.2",
         "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@stellar/stellar-sdk": "^14.0.0",
         "@stellaryield/sdk": "file:../sdk",
@@ -19,7 +21,6 @@
         "express-rate-limit": "^8.5.2",
         "express-validator": "^7.0.1",
         "graphql": "^16.14.2",
-        "graphql-http": "^1.22.4",
         "helmet": "8.0.0",
         "ioredis": "^5.4.2",
         "node-cron": "^3.0.3",
@@ -380,7 +381,6 @@
       "version": "8.59.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -598,7 +598,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -964,7 +963,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1654,7 +1652,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1878,7 +1875,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1971,6 +1967,423 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apollo/cache-control-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.3.tgz",
+      "integrity": "sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/protobufjs": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.8.tgz",
+      "integrity": "sha512-r7xNeUqZX+eBBEmyvaPw0/cSz6zgf5jdH8mjUz8ynKpNs/GU7vi2T7sNcZINk2ZID7wwjG91FCgdpCrQuJ8rzA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "apollo-pbjs": "bin/pbjs",
+        "apollo-pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@apollo/server": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.1.tgz",
+      "integrity": "sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/cache-control-types": "^1.0.3",
+        "@apollo/server-gateway-interface": "^2.0.0",
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.createhash": "^3.0.0",
+        "@apollo/utils.fetcher": "^3.0.0",
+        "@apollo/utils.isnodelike": "^3.0.0",
+        "@apollo/utils.keyvaluecache": "^4.0.0",
+        "@apollo/utils.logger": "^3.0.0",
+        "@apollo/utils.usagereporting": "^2.1.0",
+        "@apollo/utils.withrequired": "^3.0.0",
+        "@graphql-tools/schema": "^10.0.0",
+        "async-retry": "^1.2.1",
+        "body-parser": "^2.2.2",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "finalhandler": "^2.1.0",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^11.1.0",
+        "negotiator": "^1.0.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "graphql": "^16.11.0"
+      }
+    },
+    "node_modules/@apollo/server-gateway-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-2.0.0.tgz",
+      "integrity": "sha512-3HEMD6fSantG2My3jWkb9dvfkF9vJ4BDLRjMgsnD790VINtuPaEp+h3Hg9HOHiWkML6QsOhnaRqZ+gvhp3y8Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.fetcher": "^3.0.0",
+        "@apollo/utils.keyvaluecache": "^4.0.0",
+        "@apollo/utils.logger": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/usage-reporting-protobuf": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.2.tgz",
+      "integrity": "sha512-aTnAD41RYz0d5dawlyR5Iclkgzx0Xb0njUJmEfvZ6pS4f4HU8wCYyctPpWat/HWp2PmRwDfX5R1k4uVcDKZ4xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.8"
+      }
+    },
+    "node_modules/@apollo/utils.createhash": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-3.0.1.tgz",
+      "integrity": "sha512-CKrlySj4eQYftBE5MJ8IzKwIibQnftDT7yGfsJy5KSEEnLlPASX0UTpbKqkjlVEwPPd4mEwI7WOM7XNxEuO05A==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/utils.isnodelike": "^3.0.0",
+        "sha.js": "^2.4.11"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@apollo/utils.dropunuseddefinitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
+      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.fetcher": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-3.1.0.tgz",
+      "integrity": "sha512-Z3QAyrsQkvrdTuHAFwWDNd+0l50guwoQUoaDQssLOjkmnmVuvXlJykqlEJolio+4rFwBnWdoY1ByFdKaQEcm7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@apollo/utils.isnodelike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-3.0.0.tgz",
+      "integrity": "sha512-xrjyjfkzunZ0DeF6xkHaK5IKR8F1FBq6qV+uZ+h9worIF/2YSzA0uoBxGv6tbTeo9QoIQnRW4PVFzGix5E7n/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-4.0.0.tgz",
+      "integrity": "sha512-mKw1myRUkQsGPNB+9bglAuhviodJ2L2MRYLTafCMw5BIo7nbvCPNCkLnIHjZ1NOzH7SnMAr5c9LmXiqsgYqLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/utils.logger": "^3.0.0",
+        "lru-cache": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@apollo/utils.printwithreducedwhitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
+      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.removealiases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
+      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.sortast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
+      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.stripsensitiveliterals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
+      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.usagereporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
+      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
+        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
+        "@apollo/utils.removealiases": "2.0.1",
+        "@apollo/utils.sortast": "^2.0.1",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.withrequired": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-3.0.0.tgz",
+      "integrity": "sha512-aaxeavfJ+RHboh7c2ofO5HHtQobGX4AgUujXP4CXpREHp9fQ9jPi6K9T1jrAKe7HIipoP0OJ1gd6JamSkFIpvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@as-integrations/express4": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@as-integrations/express4/-/express4-1.1.2.tgz",
+      "integrity": "sha512-PGeMcwoOKdYnZ4LtsmM7aLNoel3tbK8wKnfyahdRau1qb7wLbuaXB35zg3w34Ov4bm3WJtO3yzd8Bw5jVE+aIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0 || ^5.0.0",
+        "express": "^4.0.0"
       }
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
@@ -2569,6 +2982,66 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@graphql-tools/merge": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.2.2.tgz",
+      "integrity": "sha512-DSLLAztOIQId7QE3m8Ehk5lV+0pjxNSSRDHPzlYQ9E4KJ9AoUMBprC4C+eX3v4srh05S2ujm5/veqAr5yEWFSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.2.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "10.0.38",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.38.tgz",
+      "integrity": "sha512-Kckk2/vm+rELJ7ijvFaAn9ouWSVUTD0D4SJIvYF4rKeuQHAfCzE/jzMFonZVpTXleqJjPXLZjVbuaMorw7A5Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "^9.2.2",
+        "@graphql-tools/utils": "^11.2.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "dev": true,
@@ -2681,6 +3154,69 @@
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
@@ -3226,6 +3762,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -3366,7 +3908,6 @@
       "version": "8.60.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -3679,6 +4220,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -3694,7 +4247,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3778,6 +4330,15 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4205,6 +4766,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -4463,7 +5036,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4631,7 +5203,6 @@
     "node_modules/express": {
       "version": "4.22.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5025,24 +5596,8 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-http": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
-      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
-      "license": "MIT",
-      "workspaces": [
-        "implementations/**/*"
-      ],
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/has-flag": {
@@ -5402,6 +5957,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
     "node_modules/logform": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
@@ -5419,10 +5980,38 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/luxon": {
       "version": "3.7.2",
@@ -5738,7 +6327,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -5839,7 +6427,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6165,6 +6752,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -6744,6 +7340,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.22.3",
       "dev": true,
@@ -6814,7 +7416,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6911,7 +7512,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7477,6 +8077,15 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -7612,7 +8221,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,8 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@apollo/server": "^5.5.1",
+    "@as-integrations/express4": "^1.1.2",
     "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@stellar/stellar-sdk": "^14.0.0",
     "@stellaryield/sdk": "file:../sdk",
@@ -37,7 +39,6 @@
     "express-rate-limit": "^8.5.2",
     "express-validator": "^7.0.1",
     "graphql": "^16.14.2",
-    "graphql-http": "^1.22.4",
     "helmet": "8.0.0",
     "ioredis": "^5.4.2",
     "node-cron": "^3.0.3",

--- a/backend/src/api/controllers/sse.test.ts
+++ b/backend/src/api/controllers/sse.test.ts
@@ -108,6 +108,53 @@ describe("SSE Infrastructure and Endpoints (#758, #759, #760, #757)", () => {
       expect(fakeRes.write).not.toHaveBeenCalled();
     });
 
+  });
+
+  describe("SSE reconnection with Last-Event-ID (#761)", () => {
+    const validC1 = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    it("assigns a monotonically increasing id to each vault event", () => {
+      const fakeReq: any = createFakeReq();
+      const fakeRes: any = createFakeRes();
+      sseManager.addVaultClient(fakeReq, fakeRes);
+
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "1" } });
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "2" } });
+
+      expect(fakeRes.write).toHaveBeenNthCalledWith(1, expect.stringMatching(/^id: 1\ndata: /));
+      expect(fakeRes.write).toHaveBeenNthCalledWith(2, expect.stringMatching(/^id: 2\ndata: /));
+    });
+
+    it("replays only events after Last-Event-ID on reconnect", () => {
+      // Events broadcast while no client is connected still land in the replay buffer.
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "1" } });
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "2" } });
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "3" } });
+
+      const fakeReq: any = createFakeReq({}, { "last-event-id": "1" });
+      const fakeRes: any = createFakeRes();
+      sseManager.addVaultClient(fakeReq, fakeRes, new Set([validC1]));
+
+      expect(fakeRes.write).toHaveBeenCalledTimes(2);
+      expect(fakeRes.write).toHaveBeenNthCalledWith(1, expect.stringMatching(/^id: 2\ndata: /));
+      expect(fakeRes.write).toHaveBeenNthCalledWith(2, expect.stringMatching(/^id: 3\ndata: /));
+    });
+
+    it("replays nothing for a client with no Last-Event-ID (only future events)", () => {
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "1" } });
+
+      const fakeReq: any = createFakeReq();
+      const fakeRes: any = createFakeRes();
+      sseManager.addVaultClient(fakeReq, fakeRes, new Set([validC1]));
+
+      expect(fakeRes.write).not.toHaveBeenCalled();
+
+      sseManager.broadcastVaultEvent({ contractId: validC1, type: "deposit", payload: { assets: "2" } });
+      expect(fakeRes.write).toHaveBeenCalledWith(expect.stringMatching(/^id: 2\ndata: /));
+    });
+  });
+
+  describe("SseManager indexer progress broadcast (#757)", () => {
     it("broadcasts indexer progress events to indexer clients", () => {
       const fakeReq: any = createFakeReq();
       const fakeRes: any = createFakeRes();

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -58,3 +58,14 @@ describe("GraphQL schema export - #773", () => {
     expect(() => buildSchema(res.text)).not.toThrow();
   });
 });
+
+describe("Apollo GraphQL server - #765", () => {
+  it("POST /api/graphql with { query: \"{ health }\" } returns { data: { health: \"ok\" } }", async () => {
+    const { default: supertest } = await import("supertest");
+    const res = await supertest(app)
+      .post("/api/graphql")
+      .send({ query: "{ health }" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: { health: "ok" } });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,7 +2,6 @@ import cors from "cors";
 import express, { type Express } from "express";
 import helmet from "helmet";
 import { pinoHttp } from "pino-http";
-import { createHandler } from "graphql-http/lib/use/express";
 import { printSchema } from "graphql";
 import { config } from "./config.js";
 import { logger } from "./logger.js";
@@ -22,8 +21,7 @@ import { publicLimiter, authLimiter } from "./api/middleware/rateLimit.js";
 import { httpRequestsTotal, getMetrics } from "./services/metrics.js";
 import { setupOpenApiRoutes } from "./services/openapi.js";
 import { schema } from "./graphql/schema.js";
-import { root } from "./graphql/resolvers.js";
-import { createGraphQLContext } from "./graphql/context.js";
+import { apolloMiddleware } from "./graphql/apolloServer.js";
 
 export function createApp(): Express {
   const app = express();
@@ -60,13 +58,10 @@ export function createApp(): Express {
   app.use("/api/v1/admin", authLimiter, adminRouter);
   app.use("/api/v1/webhooks", authLimiter, webhooksRouter);
   app.use("/internal", authLimiter, internalAuth, internalRouter);
-  app.all(
-    "/graphql",
-    publicLimiter,
-    createHandler({ schema, rootValue: root, context: createGraphQLContext }),
-  );
   // SDL export for client codegen tools (e.g. graphql-codegen); cached since the
-  // schema only changes on server restart (#773).
+  // schema only changes on server restart (#773). Registered before the Apollo
+  // mount below so this exact sub-path is matched first (Express matches
+  // `app.use("/api/graphql", ...)` as a prefix, which would otherwise shadow it).
   let cachedSchemaSdl: string | null = null;
   app.get("/api/graphql/schema", publicLimiter, (_req, res) => {
     if (cachedSchemaSdl === null) {
@@ -75,6 +70,9 @@ export function createApp(): Express {
     res.set("Content-Type", "application/graphql");
     res.send(cachedSchemaSdl);
   });
+  // GraphQL endpoint served via Apollo Server (#765). The Playground/Sandbox
+  // landing page is only enabled in development (see graphql/apolloServer.ts).
+  app.use("/api/graphql", publicLimiter, apolloMiddleware);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", "text/plain");
     res.send(await getMetrics());

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -125,6 +125,11 @@ const envSchema = z.object({
     .default("15000")
     .transform((v) => parseInt(v, 10))
     .pipe(z.number().int().min(1)),
+  SSE_REPLAY_BUFFER: z
+    .string()
+    .default("100")
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().min(1)),
   DB_POOL_ALERT_WAITING: z
     .string()
     .default("5")
@@ -219,6 +224,7 @@ export const config = {
     maxAge: parsed.data.CORS_MAX_AGE,
   },
   sseHeartbeatMs: parsed.data.SSE_HEARTBEAT_MS,
+  sseReplayBufferSize: parsed.data.SSE_REPLAY_BUFFER,
   dbPoolAlertWaiting: parsed.data.DB_POOL_ALERT_WAITING,
   rpcErrorRateAlertPct: parsed.data.RPC_ERROR_RATE_ALERT_PCT,
 } as const;

--- a/backend/src/graphql/apolloServer.test.ts
+++ b/backend/src/graphql/apolloServer.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../db/index.js", () => ({
+  query: vi.fn().mockResolvedValue([]),
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+vi.mock("pino-http", () => ({ pinoHttp: () => (_req: any, _res: any, next: any) => next() }));
+
+describe("Apollo GraphQL Playground/Sandbox landing page - #765", () => {
+  const originalNodeEnv = process.env["NODE_ENV"];
+
+  afterEach(() => {
+    process.env["NODE_ENV"] = originalNodeEnv;
+  });
+
+  it("serves the interactive landing page for GET /api/graphql in development", async () => {
+    vi.resetModules();
+    process.env["NODE_ENV"] = "development";
+
+    const { default: supertest } = await import("supertest");
+    const { createApp } = await import("../app.js");
+    const app = createApp();
+
+    const res = await supertest(app).get("/api/graphql").set("Accept", "text/html");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/html/);
+  });
+
+  it("does not serve the landing page for GET /api/graphql outside development", async () => {
+    vi.resetModules();
+    process.env["NODE_ENV"] = "production";
+
+    const { default: supertest } = await import("supertest");
+    const { createApp } = await import("../app.js");
+    const app = createApp();
+
+    const res = await supertest(app).get("/api/graphql").set("Accept", "text/html");
+
+    expect(res.headers["content-type"]).not.toMatch(/text\/html/);
+  });
+});

--- a/backend/src/graphql/apolloServer.ts
+++ b/backend/src/graphql/apolloServer.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from "express";
+import { ApolloServer } from "@apollo/server";
+import { ApolloServerPluginLandingPageLocalDefault } from "@apollo/server/plugin/landingPage/default";
+import { ApolloServerPluginLandingPageDisabled } from "@apollo/server/plugin/disabled";
+import { expressMiddleware } from "@as-integrations/express4";
+import { config } from "../config.js";
+import { schema } from "./schema.js";
+import { root } from "./resolvers.js";
+import { createGraphQLContext, type GraphQLContext } from "./context.js";
+
+/**
+ * Apollo Server instance backed by the existing graphql-js schema/rootValue
+ * pair (#765). The landing page (GraphQL Playground/Sandbox) is only enabled
+ * in development so production never serves an interactive query UI.
+ */
+export const apolloServer = new ApolloServer<GraphQLContext>({
+  schema,
+  rootValue: root,
+  introspection: config.nodeEnv !== "production",
+  plugins: [
+    config.nodeEnv === "development"
+      ? ApolloServerPluginLandingPageLocalDefault()
+      : ApolloServerPluginLandingPageDisabled(),
+  ],
+});
+
+const apolloServerStart = apolloServer.start();
+let handler: RequestHandler | null = null;
+
+/**
+ * `expressMiddleware()` requires `server.start()` to have already resolved
+ * *before* it is called (it asserts synchronously), but `createApp()` builds
+ * the Express app synchronously. This lazily builds and caches the real
+ * middleware the first time a request comes in, once startup has finished.
+ */
+export const apolloMiddleware: RequestHandler = async (req, res, next) => {
+  if (!handler) {
+    await apolloServerStart;
+    handler = expressMiddleware(apolloServer, {
+      context: async ({ req: expressReq }) => createGraphQLContext({ raw: expressReq }),
+    });
+  }
+  handler(req, res, next);
+};

--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -25,6 +25,7 @@ function computeYieldPerShare(yieldAmount: string, totalShares: string): string 
 }
 
 export const root = {
+  health: () => "ok",
   user: async ({ address }: { address: string }) => {
     const user = await userService.getUser(address);
     if (!user) return null;

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -23,6 +23,7 @@ export const schema = buildSchema(`
   }
 
   type Query {
+    health: String
     user(address: String!): User
     epochs(contractId: String!): [Epoch!]!
     apiKeys: [ApiKey!]!

--- a/backend/src/services/sseManager.ts
+++ b/backend/src/services/sseManager.ts
@@ -1,10 +1,23 @@
 import type { Request, Response } from "express";
 import { config } from "../config.js";
+import { cacheGet, cacheSet } from "../cache/redis.js";
 
 export interface VaultSseEvent {
   contractId: string;
   type: string;
   payload: Record<string, unknown>;
+}
+
+interface BufferedVaultEvent extends VaultSseEvent {
+  id: number;
+}
+
+// Last event ID is persisted with a long TTL rather than forever, since it's
+// only needed to survive restarts/redeploys, not as permanent storage (#761).
+const LAST_EVENT_ID_TTL_SECONDS = 60 * 60 * 24 * 30;
+
+function lastEventIdKey(contractId: string): string {
+  return `sse:vault:${contractId}:lastEventId`;
 }
 
 export interface IndexerProgressSseEvent {
@@ -31,6 +44,11 @@ export class SseManager {
   private vaultClients = new Map<string, VaultClient>();
   private indexerClients = new Map<string, IndexerClient>();
   private nextClientId = 1;
+
+  // Per-vault monotonically increasing SSE event IDs and their replay buffers (#761).
+  private vaultEventCounters = new Map<string, number>();
+  private vaultEventBuffers = new Map<string, BufferedVaultEvent[]>();
+  private warmedContractIds = new Set<string>();
 
   /**
    * Get the current count of open SSE connections (#760).
@@ -69,6 +87,10 @@ export class SseManager {
 
     this.vaultClients.set(clientId, client);
 
+    // Replay events missed while disconnected, per the Last-Event-ID request
+    // header (#761). No header means the client is new — it only gets future events.
+    this.replayMissedVaultEvents(req, res, client.contractIds);
+
     // Clean up on disconnect (#760)
     const cleanup = () => {
       if (this.vaultClients.has(clientId)) {
@@ -80,6 +102,41 @@ export class SseManager {
 
     req.on?.("close", cleanup);
     res.on?.("close", cleanup);
+  }
+
+  /**
+   * Replay buffered vault events with an id greater than the client's
+   * Last-Event-ID header (#761). The buffer only holds the most recent
+   * `SSE_REPLAY_BUFFER` events per vault, so a gap longer than that is not
+   * fully recoverable.
+   */
+  private replayMissedVaultEvents(req: Request, res: Response, contractIds?: Set<string>): void {
+    const headerValue = req.headers?.["last-event-id"];
+    const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    if (!raw) return;
+
+    const sinceId = parseInt(raw, 10);
+    if (!Number.isFinite(sinceId)) return;
+
+    const relevantIds = contractIds ?? new Set(this.vaultEventBuffers.keys());
+    for (const contractId of relevantIds) {
+      const buffer = this.vaultEventBuffers.get(contractId);
+      if (!buffer) continue;
+      for (const event of buffer) {
+        if (event.id > sinceId) {
+          res.write(this.formatVaultEvent(event));
+        }
+      }
+    }
+  }
+
+  private formatVaultEvent(event: BufferedVaultEvent): string {
+    const dataString = JSON.stringify({
+      contractId: event.contractId,
+      type: event.type,
+      payload: event.payload,
+    });
+    return `id: ${event.id}\ndata: ${dataString}\n\n`;
   }
 
   /**
@@ -125,21 +182,48 @@ export class SseManager {
   }
 
   /**
-   * Broadcast a vault event to matching SSE subscribers (#758).
+   * Broadcast a vault event to matching SSE subscribers, assigning it a
+   * monotonically increasing per-vault `id` and buffering it for replay (#761).
    */
   broadcastVaultEvent(event: VaultSseEvent): void {
-    const dataString = JSON.stringify({
-      contractId: event.contractId,
-      type: event.type,
-      payload: event.payload,
-    });
-    const message = `data: ${dataString}\n\n`;
+    if (!this.warmedContractIds.has(event.contractId)) {
+      this.warmedContractIds.add(event.contractId);
+      void this.warmVaultCounter(event.contractId);
+    }
 
+    const nextId = (this.vaultEventCounters.get(event.contractId) ?? 0) + 1;
+    this.vaultEventCounters.set(event.contractId, nextId);
+
+    const buffered: BufferedVaultEvent = { ...event, id: nextId };
+    const buffer = this.vaultEventBuffers.get(event.contractId) ?? [];
+    buffer.push(buffered);
+    while (buffer.length > config.sseReplayBufferSize) buffer.shift();
+    this.vaultEventBuffers.set(event.contractId, buffer);
+
+    const message = this.formatVaultEvent(buffered);
     for (const client of this.vaultClients.values()) {
       if (client.contractIds && !client.contractIds.has(event.contractId)) {
         continue; // Skip if client filtered by contractIds and event contractId is not in set
       }
       client.res.write(message);
+    }
+
+    // Best-effort durability so the counter survives restarts (#761, #201).
+    void cacheSet(lastEventIdKey(event.contractId), nextId, LAST_EVENT_ID_TTL_SECONDS);
+  }
+
+  /**
+   * Catch the in-memory counter up to the last persisted value for a vault
+   * the first time it's seen in this process. Runs in the background — any
+   * events broadcast before it resolves may reuse IDs from a prior process
+   * life, which is an accepted tradeoff of not blocking event delivery on Redis.
+   */
+  private async warmVaultCounter(contractId: string): Promise<void> {
+    const persisted = await cacheGet<number>(lastEventIdKey(contractId));
+    if (persisted == null) return;
+    const current = this.vaultEventCounters.get(contractId) ?? 0;
+    if (persisted > current) {
+      this.vaultEventCounters.set(contractId, persisted);
     }
   }
 
@@ -172,6 +256,9 @@ export class SseManager {
     this.vaultClients.clear();
     this.indexerClients.clear();
     this.activeConnections = 0;
+    this.vaultEventCounters.clear();
+    this.vaultEventBuffers.clear();
+    this.warmedContractIds.clear();
   }
 }
 

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Apollo Server and our own graphql/schema.ts both import "graphql". Without
+  // this, Vite's SSR module graph can end up loading "graphql" once as an
+  // externalized dependency and once inlined via @apollo/server, producing two
+  // separate GraphQLSchema classes and tripping graphql-js's cross-realm
+  // `instanceof` checks (#765).
+  resolve: {
+    dedupe: ["graphql"],
+  },
   test: {
+    server: {
+      deps: {
+        inline: ["@apollo/server", "graphql"],
+      },
+    },
     include: ["src/**/*.test.ts"],
     env: {
       PORT: "3000",


### PR DESCRIPTION
# Pull Request: Apollo GraphQL server, SSE reconnection, CHANGELOG template, indexer docs

Closes #765
Closes #761
Closes #708
Closes #707

## #765 — Add GraphQL server with Apollo

- Mounts an Apollo Server 5 instance at `POST /api/graphql`, reusing the existing
  `graphql-js` schema and API-key auth context (`graphql/schema.ts`, `graphql/context.ts`).
  Replaces the previous `graphql-http` transport (mounted at `/graphql`), since nothing else
  in the repo referenced that path and Apollo also gives us the dev-only landing page.
- Adds `health: String` to the schema, resolving to `"ok"`.
- The interactive landing page (Playground/Sandbox) is only enabled when `NODE_ENV=development`
  (`ApolloServerPluginLandingPageLocalDefault` in dev, `ApolloServerPluginLandingPageDisabled`
  otherwise) — production never serves an interactive query UI.
- `createApp()` stays synchronous. `expressMiddleware()` requires `server.start()` to have
  already resolved *before* it's called, so the `/api/graphql` mount lazily builds and caches
  the real handler on first request, after awaiting startup (`graphql/apolloServer.ts`).
- Added `@apollo/server` and `@as-integrations/express4` (the current Express 4 integration
  for Apollo Server 5 — Apollo Server 4's built-in `express4` middleware is EOL); removed the
  now-unused `graphql-http`.
- Vitest config now dedupes/inlines `graphql` — without it, Apollo Server's and our own
  `graphql` imports resolved to two separate module instances under Vite's SSR graph, which
  breaks `graphql-js`'s cross-realm `instanceof` checks (`GraphQLSchema` from "another realm").

## #761 — Implement SSE reconnection with Last-Event-ID

- `sseManager.broadcastVaultEvent` now assigns each vault event a monotonically increasing
  per-vault `id`, sent as a proper SSE `id:` field, and keeps an in-memory replay buffer of
  the last `SSE_REPLAY_BUFFER` events per vault (default 100).
- On (re)connect, `addVaultClient` reads the `Last-Event-ID` request header and replays any
  buffered events with a higher id for the client's subscribed vault(s); a client that
  connects without the header only receives future events.
- The last event id per vault is persisted to Redis (best-effort, 30-day TTL, via the
  existing `cache/redis.ts` helpers) and the in-memory counter is warmed from Redis the first
  time a vault is seen in a process, so ids stay monotonic across restarts. The replay buffer
  itself is in-memory only, so a gap wider than the buffer, or spanning a restart, isn't fully
  recoverable — only the id counter survives.
- New `SSE_REPLAY_BUFFER` env var (default 100), documented in `.env.example`.

## #708 — Add CHANGELOG.md template to the backend

- `backend/CHANGELOG.md` in Keep a Changelog format, with a single `[Unreleased]` section
  (Added/Changed/Deprecated/Removed/Fixed/Security) and a 4-line maintainer note at the top
  on how to update it per release.

## #707 — Document the indexer architecture

- `backend/docs/indexer.md` covers the polling loop lifecycle (`start`/`tick`/`tickStateOnly`/
  `sleepWhileRunning`), the backfill mechanism (startup gap detection vs. the admin-triggered
  `pg-boss` job), how `processEvent` dispatches to parsers, the actual dedup guard (a
  `SELECT`-before-insert check — the `ON CONFLICT DO NOTHING` used elsewhere has no matching
  unique index and never actually fires), and a self-contained step-by-step for adding a new
  event type. Linked from `README.md` alongside the existing `events.md`/`webhooks.md`.

## Tests Run

- `npm run lint` — clean.
- `npm run build` — success.
- `npx vitest run --exclude "**/*.e2e.test.ts"` — 408/409 passing. The one failure
  (`indexer.test.ts > passes both RPC events to processEvent`) is pre-existing on `main`
  (confirmed via `git stash`) and unrelated to this change.
- Added tests for the Apollo mount (`POST /api/graphql` health query, dev-only landing page)
  and for SSE id assignment / Last-Event-ID replay / no-header-means-future-only behavior.
