### PR TITLE
feat: compliance endpoints, retention policy, and vault resync (closes #802 #803 #804 #805)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "rotate-api-key": "tsx src/scripts/rotate-api-key.ts",
     "import-from-factory": "tsx src/scripts/import-from-factory.ts",
     "backfill-cooperator": "tsx src/scripts/backfill-cooperator.ts",
+    "resync-vault": "tsx src/scripts/resync-vault.ts",
     "indexer": "node dist/indexer/index.js",
     "operator-expiry-task": "node dist/tasks/operatorExpiry.js"
   },

--- a/backend/src/api/controllers/admin.ts
+++ b/backend/src/api/controllers/admin.ts
@@ -786,6 +786,257 @@ export async function getPositionsSnapshot(req: Request, res: Response, next: Ne
   }
 }
 
+// ── Issue #803: Vault compliance status ──────────────────────────────────────
+export async function getVaultComplianceStatus(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = contractAddressSchema.safeParse(req.params["contractId"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid contractId format" });
+      return;
+    }
+    const contractId = parsed.data;
+
+    // Fetch vault fields needed for compliance flags
+    const vaultRows = await query<{
+      id: number;
+      zkme_verifier_address: string | null;
+      emergency: boolean;
+      paused: boolean;
+    }>(
+      `SELECT id, zkme_verifier_address, COALESCE(emergency, FALSE) AS emergency,
+              COALESCE(paused, FALSE) AS paused
+       FROM vaults
+       WHERE contract_id = $1`,
+      [contractId],
+    );
+
+    if (vaultRows.length === 0) {
+      res.status(404).json({ error: "NotFound", message: "Vault not found" });
+      return;
+    }
+
+    const vault = vaultRows[0];
+
+    // kycEnforced = zkmeVerifier is set and not the zero address
+    const ZERO_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const kycEnforced =
+      vault.zkme_verifier_address !== null &&
+      vault.zkme_verifier_address !== "" &&
+      vault.zkme_verifier_address !== ZERO_ADDRESS;
+
+    // blacklistActive = at least one address is blacklisted for this vault
+    const blacklistRows = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM vault_blacklisted_addresses WHERE vault_id = $1`,
+      [vault.id],
+    );
+    const blacklistActive = parseInt(blacklistRows[0]?.count ?? "0", 10) > 0;
+
+    // lastPauseAt: most recent "paused" event for this contract
+    const pauseRows = await query<{ created_at: Date }>(
+      `SELECT created_at FROM indexed_events
+       WHERE contract_id = $1 AND event_type = 'paused'
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [contractId],
+    );
+    const lastPauseAt = pauseRows.length > 0 ? pauseRows[0].created_at.toISOString() : null;
+
+    res.json({
+      kycEnforced,
+      blacklistActive,
+      emergency: vault.emergency,
+      paused: vault.paused,
+      lastPauseAt,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── Issue #802: User compliance summary ──────────────────────────────────────
+export async function getUserComplianceSummary(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = stellarAddressSchema.safeParse(req.params["address"]);
+    if (!parsed.success) {
+      res.status(400).json({ error: "BadRequest", message: "Invalid address format" });
+      return;
+    }
+    const address = parsed.data;
+
+    // Fetch basic user fields
+    const userRows = await query<{
+      kyc_verified: boolean;
+      aml_flagged: boolean;
+    }>(
+      `SELECT kyc_verified, aml_flagged FROM users WHERE address = $1`,
+      [address],
+    );
+
+    // Defaults for users with no DB record (never interacted via API)
+    const kycVerified = userRows[0]?.kyc_verified ?? false;
+    const amlFlagged = userRows[0]?.aml_flagged ?? false;
+
+    // Aggregate financials from user_vault_positions
+    const financialRows = await query<{
+      total_deposited: string;
+      vault_count: string;
+    }>(
+      `SELECT
+         COALESCE(SUM(uvp.deposited), 0)::text AS total_deposited,
+         COUNT(*)::text AS vault_count
+       FROM user_vault_positions uvp
+       WHERE uvp.user_address = $1`,
+      [address],
+    );
+
+    const totalDeposited = financialRows[0]?.total_deposited ?? "0";
+    const vaultCount = parseInt(financialRows[0]?.vault_count ?? "0", 10);
+
+    // Total withdrawn: sum of amount_returned from withdraw events
+    const withdrawRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM((payload->>'assets')::numeric), 0)::text AS total
+       FROM indexed_events
+       WHERE event_type = 'withdraw'
+         AND payload->>'owner' = $1`,
+      [address],
+    );
+    const totalWithdrawn = withdrawRows[0]?.total ?? "0";
+
+    // Total yield claimed: sum from yield_claim events
+    const yieldRows = await query<{ total: string }>(
+      `SELECT COALESCE(SUM((payload->>'amount')::numeric), 0)::text AS total
+       FROM indexed_events
+       WHERE event_type = 'yield_claimed'
+         AND payload->>'user' = $1`,
+      [address],
+    );
+    const totalYieldClaimed = yieldRows[0]?.total ?? "0";
+
+    // First and last activity timestamps from indexed_events
+    const activityRows = await query<{
+      first_activity: Date | null;
+      last_activity: Date | null;
+    }>(
+      `SELECT
+         MIN(created_at) AS first_activity,
+         MAX(created_at) AS last_activity
+       FROM indexed_events
+       WHERE payload->>'user' = $1
+          OR payload->>'owner' = $1
+          OR payload->>'caller' = $1
+          OR payload->>'receiver' = $1`,
+      [address],
+    );
+
+    const firstActivity = activityRows[0]?.first_activity?.toISOString() ?? null;
+    const lastActivity = activityRows[0]?.last_activity?.toISOString() ?? null;
+
+    res.json({
+      address,
+      kycVerified,
+      amlFlagged,
+      totalDeposited,
+      totalWithdrawn,
+      totalYieldClaimed,
+      vaultCount,
+      firstActivity,
+      lastActivity,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── Issue #804: Data retention policy ────────────────────────────────────────
+const RETENTION_KEYS = ["eventsRetentionDays", "positionRetentionDays", "auditLogRetentionDays"] as const;
+type RetentionKey = (typeof RETENTION_KEYS)[number];
+
+export async function getRetentionPolicy(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const rows = await query<{ key: string; value: string }>(
+      `SELECT key, value FROM app_config WHERE key = ANY($1)`,
+      [RETENTION_KEYS],
+    );
+
+    // Build response, falling back to defaults if a key is missing
+    const defaults: Record<RetentionKey, number> = {
+      eventsRetentionDays: 90,
+      positionRetentionDays: 365,
+      auditLogRetentionDays: 365,
+    };
+
+    const result = { ...defaults };
+    for (const row of rows) {
+      if (RETENTION_KEYS.includes(row.key as RetentionKey)) {
+        result[row.key as RetentionKey] = parseInt(row.value, 10);
+      }
+    }
+
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function patchRetentionPolicy(req: Request, res: Response, next: NextFunction) {
+  try {
+    const patchSchema = z.object({
+      eventsRetentionDays: z.number().int().positive().optional(),
+      positionRetentionDays: z.number().int().positive().optional(),
+      auditLogRetentionDays: z.number().int().positive().optional(),
+    }).strict();
+
+    const parsed = patchSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "BadRequest",
+        message: "Values must be positive integers",
+        details: parsed.error.issues,
+      });
+      return;
+    }
+
+    const updates = parsed.data;
+
+    if (Object.keys(updates).length === 0) {
+      res.status(400).json({ error: "BadRequest", message: "No fields provided to update" });
+      return;
+    }
+
+    // Upsert each supplied key
+    for (const [key, value] of Object.entries(updates)) {
+      await query(
+        `INSERT INTO app_config (key, value, updated_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()`,
+        [key, String(value)],
+      );
+    }
+
+    // Return the full updated policy
+    const rows = await query<{ key: string; value: string }>(
+      `SELECT key, value FROM app_config WHERE key = ANY($1)`,
+      [RETENTION_KEYS],
+    );
+
+    const defaults: Record<RetentionKey, number> = {
+      eventsRetentionDays: 90,
+      positionRetentionDays: 365,
+      auditLogRetentionDays: 365,
+    };
+    const result = { ...defaults };
+    for (const row of rows) {
+      if (RETENTION_KEYS.includes(row.key as RetentionKey)) {
+        result[row.key as RetentionKey] = parseInt(row.value, 10);
+      }
+    }
+
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function getJobStatus(req: Request, res: Response, next: NextFunction) {
   try {
     const jobId = req.params["jobId"] as string;

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -22,6 +22,10 @@ import {
   getFlaggedUsers,
   getPositionsSnapshot,
   streamIndexerProgress,
+  getVaultComplianceStatus,
+  getUserComplianceSummary,
+  getRetentionPolicy,
+  patchRetentionPolicy,
 } from "../controllers/admin.js";
 import { requireApiKey } from "../middleware/auth.js";
 import { ipAllowlist } from "../middleware/ipAllowlist.js";
@@ -52,6 +56,15 @@ adminRouter.post("/users/:address/aml-flag", flagUserAml);
 adminRouter.post("/users/:address/aml-clear", clearUserAml);
 adminRouter.get("/compliance/flagged-users", getFlaggedUsers);
 adminRouter.get("/compliance/positions-snapshot", getPositionsSnapshot);
+
+// Issue #803: Vault compliance status
+adminRouter.get("/compliance/vaults/:contractId/status", getVaultComplianceStatus);
+// Issue #802: User compliance summary
+adminRouter.get("/compliance/users/:address/summary", getUserComplianceSummary);
+
+// Issue #804: Data retention policy
+adminRouter.get("/retention-policy", getRetentionPolicy);
+adminRouter.patch("/retention-policy", patchRetentionPolicy);
 
 adminRouter.get("/jobs/failed", getFailedJobs);
 adminRouter.get("/jobs/:jobId", getJobStatus);

--- a/backend/src/db/migrations/029_compliance_retention.sql
+++ b/backend/src/db/migrations/029_compliance_retention.sql
@@ -1,0 +1,27 @@
+-- Issue #803: Add emergency flag to vaults for compliance tracking
+ALTER TABLE vaults ADD COLUMN IF NOT EXISTS emergency BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Issue #803: Blacklisted addresses per vault
+CREATE TABLE IF NOT EXISTS vault_blacklisted_addresses (
+  id              SERIAL PRIMARY KEY,
+  vault_id        INT NOT NULL REFERENCES vaults(id),
+  address         TEXT NOT NULL,
+  added_by        TEXT,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (vault_id, address)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vault_blacklisted_vault_id ON vault_blacklisted_addresses(vault_id);
+
+-- Issue #804: Key/value config table for runtime-configurable settings
+CREATE TABLE IF NOT EXISTS app_config (
+  key             TEXT PRIMARY KEY,
+  value           TEXT NOT NULL,
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+INSERT INTO app_config (key, value) VALUES
+  ('eventsRetentionDays', '90'),
+  ('positionRetentionDays', '365'),
+  ('auditLogRetentionDays', '365')
+ON CONFLICT (key) DO NOTHING;

--- a/backend/src/scripts/resync-vault.ts
+++ b/backend/src/scripts/resync-vault.ts
@@ -1,0 +1,95 @@
+/**
+ * resync-vault.ts
+ *
+ * Resynchronises a single vault's on-chain fields (total_assets, total_supply)
+ * with the values reported by the Soroban RPC.  Run this after an indexer bug
+ * has left the database out of sync with the chain.
+ *
+ * Usage:
+ *   tsx src/scripts/resync-vault.ts --contractId <C...>
+ *
+ * Exits 0 on success, non-zero on any error (invalid input, RPC failure, etc.)
+ *
+ * Closes #805
+ */
+import "dotenv/config";
+import { pool } from "../db/index.js";
+import { logger } from "../logger.js";
+import { readTotalAssets, readTotalSupply } from "../services/stellar.js";
+import { VaultService } from "../services/vault.js";
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): { contractId: string } {
+  let contractId: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--contractId") {
+      contractId = argv[++i];
+    }
+  }
+
+  if (!contractId) {
+    logger.error("Missing required argument: --contractId <id>");
+    process.exit(1);
+  }
+
+  // Basic Stellar contract address validation (56 chars, starts with 'C')
+  if (!/^C[A-Z2-7]{55}$/.test(contractId)) {
+    logger.error({ contractId }, "Invalid contract ID format — must be a 56-character Stellar contract address starting with 'C'");
+    process.exit(1);
+  }
+
+  return { contractId };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function resyncVault(contractId: string): Promise<void> {
+  logger.info({ contractId }, "Starting vault resync");
+
+  // Fetch on-chain values — exit non-zero if RPC fails
+  let totalAssets: bigint;
+  let totalSupply: bigint;
+
+  try {
+    [totalAssets, totalSupply] = await Promise.all([
+      readTotalAssets(contractId),
+      readTotalSupply(contractId),
+    ]);
+  } catch (err) {
+    logger.error({ err, contractId }, "RPC call failed — is the contract ID correct and the RPC endpoint reachable?");
+    process.exit(2);
+  }
+
+  logger.info(
+    { contractId, totalAssets: totalAssets.toString(), totalSupply: totalSupply.toString() },
+    "Fetched on-chain values",
+  );
+
+  // Persist to database
+  const vaultService = new VaultService();
+
+  try {
+    await vaultService.upsertVault({
+      contractId,
+      totalAssets: totalAssets.toString(),
+      totalSupply: totalSupply.toString(),
+    });
+  } catch (err) {
+    logger.error({ err, contractId }, "Database upsert failed");
+    process.exit(3);
+  }
+
+  logger.info({ contractId }, "Vault resync complete");
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+const { contractId } = parseArgs(process.argv.slice(2));
+
+await resyncVault(contractId);
+
+// Close the connection pool so the process can exit cleanly
+await pool.end();
+process.exit(0);


### PR DESCRIPTION
## Summary

Adds compliance review endpoints, data retention policy configuration, and a vault resync script as requested in issues #802–#805.

### Changes

**Issue #802 — User activity summary for compliance review**
- `GET /api/v1/admin/compliance/users/:address/summary`
- Returns: `address`, `kycVerified`, `amlFlagged`, `totalDeposited`, `totalWithdrawn`, `totalYieldClaimed`, `vaultCount`, `firstActivity`, `lastActivity`
- Derives timestamps from `indexed_events`; all fields present even for users with no on-chain activity.

**Issue #803 — Vault compliance status endpoint**
- `GET /api/v1/admin/compliance/vaults/:contractId/status`
- Returns: `kycEnforced` (zkmeVerifier set & not zero address), `blacklistActive` (≥1 blacklisted address), `emergency`, `paused`, `lastPauseAt`

**Issue #804 — Data retention policy configuration**
- `GET /api/v1/admin/retention-policy` — returns current policy (defaults: 90/365/365 days)
- `PATCH /api/v1/admin/retention-policy` — partial update, positive integers only, returns 400 on invalid input
- Persisted to `app_config` key/value table; takes effect on next scheduled pruning run

**Issue #805 — Vault resync script**
- `backend/src/scripts/resync-vault.ts` — accepts `--contractId <id>`, calls `readTotalAssets`/`readTotalSupply`, upserts via `VaultService`
- `npm run resync-vault` added to package.json
- Exits non-zero on invalid input or RPC failure

### Migration

- `029_compliance_retention.sql` — adds `emergency` column to vaults, `vault_blacklisted_addresses` table, and `app_config` table with default retention values.

Closes #802
Closes #803
Closes #804
Closes #805
